### PR TITLE
[RFR] Fix preview column size in edition dialog

### DIFF
--- a/src/app/js/admin/publicationPreview/PublicationEditionModal.js
+++ b/src/app/js/admin/publicationPreview/PublicationEditionModal.js
@@ -25,7 +25,9 @@ const styles = {
     modal: {
         maxWidth: '100%',
     },
-    overlay: {
+    column: {
+        minWidth: '10rem',
+        maxWidth: '10rem',
     },
 };
 
@@ -55,7 +57,7 @@ const PublicationEditionComponent = ({ editedColumn, lines, onExitEdition, p: po
                     className="publication-excerpt-for-edition"
                     columns={[editedColumn]}
                     lines={lines}
-                    style={styles.column}
+                    colStyle={styles.column}
                     onHeaderClick={null}
                 />
             </div>

--- a/src/app/js/admin/publicationPreview/PublicationExcerpt.js
+++ b/src/app/js/admin/publicationPreview/PublicationExcerpt.js
@@ -4,6 +4,7 @@ import pure from 'recompose/pure';
 import withProps from 'recompose/withProps';
 import withHandlers from 'recompose/withHandlers';
 import translate from 'redux-polyglot/translate';
+import memoize from 'lodash.memoize';
 import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow } from 'material-ui/Table';
 
 import { polyglot as polyglotPropTypes, field as fieldPropTypes } from '../../propTypes';
@@ -26,7 +27,10 @@ const styles = {
     },
 };
 
+const getColStyle = memoize(style => Object.assign(styles.header, style));
+
 export const PublicationExcerptComponent = ({
+    colStyle,
     areHeadersClickable,
     className,
     columns,
@@ -53,7 +57,7 @@ export const PublicationExcerptComponent = ({
                                 field.label.toLowerCase().replace(/\s/g, '_')
                             }`
                         }
-                        style={styles.header}
+                        style={getColStyle(colStyle)}
                         tooltip={areHeadersClickable ? polyglot.t('click_to_edit_publication_field') : ''}
                     >
                         <PublicationExcerptHeader field={field} />
@@ -79,6 +83,7 @@ PublicationExcerptComponent.propTypes = {
     areHeadersClickable: PropTypes.bool.isRequired,
     className: PropTypes.string,
     columns: PropTypes.arrayOf(fieldPropTypes).isRequired,
+    colStyle: PropTypes.object, // eslint-disable-line
     lines: PropTypes.arrayOf(PropTypes.object).isRequired,
     onCellClick: PropTypes.func.isRequired,
     onHeaderClick: PropTypes.func.isRequired,
@@ -87,6 +92,7 @@ PublicationExcerptComponent.propTypes = {
 
 PublicationExcerptComponent.defaultProps = {
     className: 'publication-excerpt',
+    colStyle: null,
 };
 
 export default compose(

--- a/src/app/js/lib/longTexts.js
+++ b/src/app/js/lib/longTexts.js
@@ -1,3 +1,3 @@
-export const isLongText = (text = '') => text && text.length > 50;
+export const isLongText = (text = '') => text && text.length > 30;
 
-export const getShortText = (text = '') => `${text.substr(0, 47)}...`;
+export const getShortText = (text = '') => `${text.substr(0, 26)}...`;


### PR DESCRIPTION
Tested on 1280x1024
Had to reduce long texts to 30 characters instead of 50.

Small column
![screen](http://i.imgur.com/0QJW698.png)

Large column
![screen](http://i.imgur.com/QERzAVZ.png)