### PR TITLE
to avoid field names contains '+' and '/' characters

### DIFF
--- a/src/api/services/generateUid.js
+++ b/src/api/services/generateUid.js
@@ -6,6 +6,6 @@ export default () => new Promise((resolve, reject) =>
             reject(error);
             return;
         }
-        resolve(result.toString('base64'));
+        resolve(result.toString('base64').replace(/[+/]/g, 'z'));
     }),
 );

--- a/src/api/services/generateUid.js
+++ b/src/api/services/generateUid.js
@@ -6,6 +6,6 @@ export default () => new Promise((resolve, reject) =>
             reject(error);
             return;
         }
-        resolve(result.toString('base64').replace(/[+/]/g, 'z'));
+        resolve(result.toString('base64').replace(/[+\/]/g, 'z'));
     }),
 );


### PR DESCRIPTION
because base64 contains this characters https://en.wikipedia.org/wiki/Base64 and we cannot use them in web semantic export formats.