### PR TITLE
[RFR] allow complex path in istexQuery context

### DIFF
--- a/config.json
+++ b/config.json
@@ -63,7 +63,8 @@
        "context": {
           "link": "dcterms:ispartOf",
           "language": "dcterms:language",
-          "doi": "bibo:doi"
+          "doi": "bibo:doi",
+          "fulltext[0].uri": "dcterms:hasFormat"
        }
     }
 }

--- a/src/api/exporters/exportExtendedNquads.js
+++ b/src/api/exporters/exportExtendedNquads.js
@@ -11,8 +11,7 @@ const exporter = (config, fields, characteristics, stream) =>
     .pipe(ezs('filterContributions', { fields }))
     .pipe(ezs('extractIstexQuery', { fields, config }))
     .pipe(ezs('scroll', { output: Object.keys(config.istexQuery.context)
-                                        .filter(e => e !== config.istexQuery.linked)
-                                        .join() }))
+                                        .filter(e => e !== config.istexQuery.linked) }))
     .pipe(ezs('convertToExtendedNquads', { config }));
 
 exporter.extension = 'nq';

--- a/src/api/statements/scroll.js
+++ b/src/api/statements/scroll.js
@@ -85,10 +85,11 @@ module.exports = function scroll(data, feed) {
     /**
      * Parameters of the API query
      */
-    const output = this.getParam('output', 'doi');
+    const output = this.getParam('output', ['doi']);
     const sid = this.getParam('sid', 'lodex');
     const size = this.getParam('size', 5000);
     const query = url.parse(data.content);
+    const cleanOutput = output.map(e => /\w+/.exec(e)[0]).join();
 
     const urlObj = {
         protocol: 'https',
@@ -96,7 +97,7 @@ module.exports = function scroll(data, feed) {
         pathname: 'document',
         // Change '&' to validate the query as an URI component (and not the '?'
         // at the beginning)
-        search: `${query.search.replace(/&/g, '%26')}&scroll=30s&output=${output}&size=${size}&sid=${sid}`,
+        search: `${query.search.replace(/&/g, '%26')}&scroll=30s&output=${cleanOutput}&size=${size}&sid=${sid}`,
     };
     const uri = url.format(urlObj);
 


### PR DESCRIPTION
example:
```"fulltext[0].uri": "dcterms:hasFormat"```

result: 
```<https://api.istex.fr/document/0024BF0E7ECF9F7666415908976375994EB6ADC3> <http://purl.org/dc/terms/hasFormat> <https://api.istex.fr/document/0024BF0E7ECF9F7666415908976375994EB6ADC3/fulltext/pdf> .```