### PR TITLE
[RFR] use no-important version of aphrodite remove !important from generate…

### DIFF
--- a/src/api/controller/front.js
+++ b/src/api/controller/front.js
@@ -13,7 +13,7 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import { END } from 'redux-saga';
 import koaWebpack from 'koa-webpack';
 import fs from 'fs';
-import { StyleSheetServer } from 'aphrodite';
+import { StyleSheetServer } from 'aphrodite/no-important';
 import jwt from 'koa-jwt';
 import jsonwebtoken from 'jsonwebtoken';
 import { auth } from 'config';

--- a/src/app/js/formats/emphased-number/Bigbold.js
+++ b/src/app/js/formats/emphased-number/Bigbold.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { StyleSheet, css } from 'aphrodite';
+import { StyleSheet, css } from 'aphrodite/no-important';
 
 const sizes = ['8rem', '6rem', '3rem'];
 

--- a/src/app/js/formats/heatmap/HeatMapView.js
+++ b/src/app/js/formats/heatmap/HeatMapView.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { StyleSheet, css } from 'aphrodite';
+import { StyleSheet, css } from 'aphrodite/no-important';
 import PropTypes from 'prop-types';
 import compose from 'recompose/compose';
 import { connect } from 'react-redux';

--- a/src/app/js/formats/identifier-badge/IdentifierBadgeView.js
+++ b/src/app/js/formats/identifier-badge/IdentifierBadgeView.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { StyleSheet, css } from 'aphrodite';
+import { StyleSheet, css } from 'aphrodite/no-important';
 import { field as fieldPropTypes } from '../../propTypes';
 
 const IdentifierBadgeView = ({ resource, field, typid, colors }) => {

--- a/src/app/js/formats/lodex-resource/LodexResourceView.js
+++ b/src/app/js/formats/lodex-resource/LodexResourceView.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import translate from 'redux-polyglot/translate';
-import { StyleSheet, css } from 'aphrodite';
+import { StyleSheet, css } from 'aphrodite/no-important';
 import compose from 'recompose/compose';
 import { connect } from 'react-redux';
 import get from 'lodash.get';

--- a/src/app/js/formats/resources-grid/ResourcesGridView.js
+++ b/src/app/js/formats/resources-grid/ResourcesGridView.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import RaisedButton from 'material-ui/RaisedButton';
 import CircularProgress from 'material-ui/CircularProgress';
 import translate from 'redux-polyglot/translate';
-import { StyleSheet, css } from 'aphrodite';
+import { StyleSheet, css } from 'aphrodite/no-important';
 import compose from 'recompose/compose';
 
 import LodexResource from '../shared/LodexResource';

--- a/src/app/js/formats/shared/LodexResource.js
+++ b/src/app/js/formats/shared/LodexResource.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { StyleSheet, css } from 'aphrodite';
+import { StyleSheet, css } from 'aphrodite/no-important';
 import { Link } from 'react-router';
 import { getFullResourceUri } from '../../../../common/uris';
 


### PR DESCRIPTION
By default aphrodite use `!important` in the generated style, deactivate it to allow for theme to override style.