### PR TITLE
[RFR] diplay field name in edition modals

### DIFF
--- a/src/app/js/fields/editFieldValue/EditButton.js
+++ b/src/app/js/fields/editFieldValue/EditButton.js
@@ -19,6 +19,15 @@ import { openEditFieldValue, closeEditFieldValue } from '../';
 import { COVER_DATASET } from '../../../../common/cover';
 import { saveResource } from '../../public/resource';
 import { updateCharacteristics } from '../../characteristic';
+import { grey400 } from 'material-ui/styles/colors';
+
+const styles = {
+    label: {
+        float: 'right',
+        color: grey400,
+        fontSize: '1.5rem',
+    },
+};
 
 const mapStateToProps = (state, { field, resource, onSaveProperty, p }) => ({
     open: fromFields.isFieldEdited(state, field.name),
@@ -39,7 +48,12 @@ const mapStateToProps = (state, { field, resource, onSaveProperty, p }) => ({
     ),
     formName: FORM_NAME,
     className: classnames('edit-field', getFieldClassName(field)),
-    label: p.t('edit_field', { field: field.label }),
+    label: (
+        <p>
+            {p.t('edit_field', { field: field.label })}{' '}
+            <span style={styles.label}>{field.name}</span>
+        </p>
+    ),
     icon: <EditIcon viewBox="-10 0 32 32" />,
     buttonStyle: { padding: 0, height: 'auto', width: 'auto' },
 });

--- a/src/app/js/fields/ontology/EditOntologyFieldButton.js
+++ b/src/app/js/fields/ontology/EditOntologyFieldButton.js
@@ -10,13 +10,27 @@ import EditOntologyFieldForm, { FORM_NAME } from './EditOntologyFieldForm';
 import { fromUser, fromFields } from '../../sharedSelectors';
 import ButtonWithDialogForm from '../../lib/components/ButtonWithDialogForm';
 import { configureFieldOpen, configureFieldCancel } from '../';
+import { grey400 } from 'material-ui/styles/colors';
+
+const styles = {
+    label: {
+        float: 'right',
+        color: grey400,
+        fontSize: '1.5rem',
+    },
+};
 
 const mapStateToProps = (state, { field, p }) => ({
     open: fromFields.isFieldConfigured(state, field.name),
     show: fromUser.isAdmin(state),
     saving: fromFields.isSaving(state),
     className: classnames('configure-field', getFieldClassName(field)),
-    label: p.t('configure_field', { field: field.label }),
+    label: (
+        <p>
+            {p.t('configure_field', { field: field.label })}{' '}
+            <span style={styles.label}>{field.name}</span>
+        </p>
+    ),
     form: <EditOntologyFieldForm field={field} />,
     formName: FORM_NAME,
     icon: <SettingsIcon />,


### PR DESCRIPTION
show the technical name of the field in the edition modals title to the right.
![capture du 2018-02-01 09-45-53](https://user-images.githubusercontent.com/4034399/35669312-f75ec7f8-0734-11e8-8f5c-d634577da86d.png)
