### PR TITLE
[RFR] DRY: Don't repeat istexApiUrl definition

### DIFF
--- a/src/api/statements/scroll.js
+++ b/src/api/statements/scroll.js
@@ -1,8 +1,7 @@
 import request from 'request';
 import url from 'url';
 import logger from '../services/logger';
-
-const istexApiUrl = 'https://api.istex.fr/document';
+import { ISTEX_API_URL as istexApiUrl } from '../../common/externals';
 
 /**
  * Recursive scroll

--- a/src/app/js/formats/istex/ListComponent.js
+++ b/src/app/js/formats/istex/ListComponent.js
@@ -4,8 +4,7 @@ import memoize from 'lodash.memoize';
 
 import { REJECTED } from '../../../../common/propositionStatus';
 import { field as fieldPropTypes } from '../../propTypes';
-
-const istexApiUrl = 'https://api.istex.fr/document';
+import { ISTEX_API_URL as istexApiUrl } from '../../../../common/externals';
 
 const styles = {
     text: memoize(status =>

--- a/src/app/js/formats/istex/fetchIstexData.js
+++ b/src/app/js/formats/istex/fetchIstexData.js
@@ -1,8 +1,7 @@
 import fetch from '../../lib/fetch';
 import composeAsync from '../../../../common/lib/composeAsync';
 import URL from 'url';
-
-const istexApiUrl = 'https://api.istex.fr/document';
+import { ISTEX_API_URL as istexApiUrl } from '../../../../common/externals';
 
 export const getUrl = ({ props: { resource, field }, page, perPage }) => {
     const value = resource[field.name];

--- a/src/common/externals.js
+++ b/src/common/externals.js
@@ -1,0 +1,1 @@
+export const ISTEX_API_URL = 'https://api.istex.fr/document';


### PR DESCRIPTION
Create a src/common/externals to define external URLs, like istexApiUrl, but we will put there external routine repository URL, for example.