### PR TITLE
[RFR] Restore schemeForDatasetLink in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -42,6 +42,7 @@
     "widget"
   ],
   "datasetClass": "http://test.fr/datasetClass",
+  "schemeForDatasetLink": "http://www.w3.org/2004/02/skos/core#inScheme",
   "exportDataset": "true",
   "collectionClass": "",
   "istexQuery": {


### PR DESCRIPTION
As it is still useful to nquads exporters (jsonld, jsonldcompacted, nquads, turtle)