### PR TITLE
[RFR] Update moment to 2.9.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5585,7 +5585,7 @@
       "requires": {
         "latinize": "0.4.0",
         "markdown-it": "8.4.0",
-        "moment": "2.18.1",
+        "moment": "2.19.4",
         "trello-promise": "1.0.7"
       }
     },
@@ -6113,7 +6113,7 @@
       "requires": {
         "hoek": "2.16.3",
         "isemail": "1.2.0",
-        "moment": "2.18.1",
+        "moment": "2.19.4",
         "topo": "1.1.0"
       }
     },
@@ -7233,9 +7233,9 @@
       }
     },
     "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+      "version": "2.19.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.4.tgz",
+      "integrity": "sha512-1xFTAknSLfc47DIxHDUbnJWC+UwgWxATmymaxIPQpmMh7LBm7ZbwVEsuushqwL2GYZU0jie4xO+TK44hJPjNSQ=="
     },
     "mongodb": {
       "version": "2.2.33",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "markdown-it": "8.4.0",
     "material-ui": "0.19.4",
     "material-ui-superselectfield": "1.7.2",
-    "moment": "2.18.1",
+    "moment": "2.19.4",
     "mongodb": "2.2.33",
     "mongodb-querystring": "1.0.3",
     "multistream": "2.1.0",


### PR DESCRIPTION
This fixes a moment < 2.9.13 vulnerability.

I did not try more recent moment versions (the last one is 2.21.0).