### PR TITLE
[RFR] Export model ready

### DIFF
--- a/src/api/controller/api/field.js
+++ b/src/api/controller/api/field.js
@@ -76,6 +76,35 @@ export const exportFields = async ctx => {
     ctx.body = JSON.stringify(fields.map(f => omit(f, ['_id'])), null, 4);
 };
 
+const simplifyTransformers = field => {
+    field.transformers = [
+        {
+            operation: 'COLUMN',
+            args: [
+                {
+                    name: 'column',
+                    type: 'column',
+                    value: field.label,
+                },
+            ],
+        },
+    ];
+    return field;
+};
+
+export const exportFieldsReady = async ctx => {
+    const fields = await ctx.field.findAll();
+
+    ctx.attachment('lodex_model.json');
+    ctx.type = 'application/json';
+
+    ctx.body = JSON.stringify(
+        fields.map(f => omit(f, ['_id'])).map(simplifyTransformers),
+        null,
+        4,
+    );
+};
+
 export const getUploadedFields = (
     asyncBusboyImpl,
     streamToStringImpl,
@@ -102,6 +131,7 @@ app.use(setup);
 
 app.use(route.get('/', getAllField));
 app.use(route.get('/export', exportFields));
+app.use(route.get('/export/ready', exportFieldsReady));
 app.use(
     route.post(
         '/import',

--- a/src/api/controller/api/field.spec.js
+++ b/src/api/controller/api/field.spec.js
@@ -4,6 +4,7 @@ import {
     setup,
     getAllField,
     exportFields,
+    exportFieldsReady,
     importFields,
     postField,
     putField,
@@ -56,6 +57,67 @@ describe('field routes', () => {
             await getAllField(ctx);
             expect(ctx.field.findAll).toHaveBeenCalled();
             expect(ctx.body).toBe('all fields');
+        });
+    });
+
+    describe('exportFieldsReady', () => {
+        it('should call ctx.field.findAll and pass the result with correct transformers', async () => {
+            const ctx = {
+                field: {
+                    findAll: createSpy().andReturn(
+                        Promise.resolve([
+                            { name: 'field1', label: 'column1', _id: 'id1' },
+                            { name: 'field2', label: 'column2', _id: 'id2' },
+                        ]),
+                    ),
+                },
+                attachment: createSpy(),
+            };
+
+            await exportFieldsReady(ctx);
+            expect(ctx.field.findAll).toHaveBeenCalled();
+            expect(ctx.body).toEqual(
+                JSON.stringify(
+                    [
+                        {
+                            name: 'field1',
+                            label: 'column1',
+                            transformers: [
+                                {
+                                    operation: 'COLUMN',
+                                    args: [
+                                        {
+                                            name: 'column',
+                                            type: 'column',
+                                            value: 'column1',
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        {
+                            name: 'field2',
+                            label: 'column2',
+                            transformers: [
+                                {
+                                    operation: 'COLUMN',
+                                    args: [
+                                        {
+                                            name: 'column',
+                                            type: 'column',
+                                            value: 'column2',
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                    null,
+                    4,
+                ),
+            );
+            expect(ctx.attachment).toHaveBeenCalledWith('lodex_model.json');
+            expect(ctx.type).toBe('application/json');
         });
     });
 

--- a/src/app/js/admin/Appbar/ModelMenu.js
+++ b/src/app/js/admin/Appbar/ModelMenu.js
@@ -9,6 +9,7 @@ import { withRouter, Link } from 'react-router';
 import ImportFieldsDialog from './ImportFieldsDialog';
 import { polyglot as polyglotPropTypes } from '../../propTypes';
 import { exportFields as exportFieldsAction } from '../../exportFields';
+import { exportFieldsReady as exportFieldsReadyAction } from '../../exportFieldsReady';
 
 const styles = {
     container: {
@@ -25,6 +26,7 @@ export class ModelMenuComponent extends Component {
     static propTypes = {
         hasPublishedDataset: PropTypes.bool.isRequired,
         exportFields: PropTypes.func.isRequired,
+        exportFieldsReady: PropTypes.func.isRequired,
         location: PropTypes.shape({ pathname: PropTypes.string }),
         p: polyglotPropTypes.isRequired,
     };
@@ -75,6 +77,14 @@ export class ModelMenuComponent extends Component {
         this.props.exportFields();
     };
 
+    handleExportFieldsReady = () => {
+        this.setState({
+            open: false,
+        });
+
+        this.props.exportFieldsReady();
+    };
+
     render() {
         const { hasPublishedDataset, location, p: polyglot } = this.props;
         const { showImportFieldsConfirmation } = this.state;
@@ -109,6 +119,7 @@ export class ModelMenuComponent extends Component {
 
 const mapDispatchToProps = {
     exportFields: exportFieldsAction,
+    exportFieldsReady: exportFieldsReadyAction,
 };
 
 export default compose(

--- a/src/app/js/admin/sagas.js
+++ b/src/app/js/admin/sagas.js
@@ -1,6 +1,7 @@
 import { fork } from 'redux-saga/effects';
 
 import exportSaga from '../exportFields/sagas';
+import exportReadySaga from '../exportFieldsReady/sagas';
 import importSaga from './import/sagas';
 import fieldsSaga from '../fields/sagas';
 import parsingSaga from './parsing/sagas';
@@ -17,6 +18,7 @@ import clearSaga from './clear/sagas';
 
 export default function*() {
     yield fork(exportSaga);
+    yield fork(exportReadySaga);
     yield fork(fetchSaga);
     yield fork(fieldsSaga);
     yield fork(importSaga);

--- a/src/app/js/exportFieldsReady/index.js
+++ b/src/app/js/exportFieldsReady/index.js
@@ -1,0 +1,9 @@
+import { createAction } from 'redux-actions';
+
+export const EXPORT_FIELDS_READY = 'EXPORT_FIELDS_READY';
+export const EXPORT_FIELDS_ERROR = 'EXPORT_FIELDS_ERROR';
+export const EXPORT_FIELDS_SUCCESS = 'EXPORT_FIELDS_SUCCESS';
+
+export const exportFieldsReady = createAction(EXPORT_FIELDS_READY);
+export const exportFieldsError = createAction(EXPORT_FIELDS_ERROR);
+export const exportFieldsSuccess = createAction(EXPORT_FIELDS_SUCCESS);

--- a/src/app/js/exportFieldsReady/sagas.js
+++ b/src/app/js/exportFieldsReady/sagas.js
@@ -1,0 +1,22 @@
+import { call, select, put, takeEvery } from 'redux-saga/effects';
+import fetchSaga from '../lib/sagas/fetchSaga';
+import { fromUser } from '../sharedSelectors';
+
+import { EXPORT_FIELDS_READY, exportFieldsError } from './';
+import downloadFile from '../lib/downloadFile';
+
+export function* handleExportPublishedDatasetSuccess() {
+    const request = yield select(fromUser.getExportFieldsReadyRequest);
+    const { error, response } = yield call(fetchSaga, request, [], 'blob');
+
+    if (error) {
+        yield put(exportFieldsError(error));
+        return;
+    }
+
+    yield call(downloadFile, response, 'lodex_model.json');
+}
+
+export default function*() {
+    yield takeEvery(EXPORT_FIELDS_READY, handleExportPublishedDatasetSuccess);
+}

--- a/src/app/js/fields/ontology/Ontology.js
+++ b/src/app/js/fields/ontology/Ontology.js
@@ -14,6 +14,7 @@ import AddCharacteristic from '../addCharacteristic/AddCharacteristic';
 import OntologyTable from './OntologyTable';
 import { COVER_DATASET } from '../../../../common/cover';
 import ExportFieldsButton from '../../public/export/ExportFieldsButton';
+import ExportFieldsReadyButton from '../../public/export/ExportFieldsReadyButton';
 
 const ALL = 'all';
 
@@ -43,7 +44,10 @@ export class OntologyComponent extends Component {
                         value={filter}
                         onChange={this.handleFilterChange}
                     >
-                        <MenuItem value={ALL} primaryText={polyglot.t('model_filter_all')} />
+                        <MenuItem
+                            value={ALL}
+                            primaryText={polyglot.t('model_filter_all')}
+                        />
                         <MenuItem
                             value={'document'}
                             primaryText={polyglot.t('model_filter_document')}
@@ -62,6 +66,7 @@ export class OntologyComponent extends Component {
                 </CardText>
                 <CardActions>
                     <ExportFieldsButton />
+                    <ExportFieldsReadyButton />
                     <AddCharacteristic />
                 </CardActions>
             </Card>

--- a/src/app/js/public/export/ExportFieldsReadyButton.js
+++ b/src/app/js/public/export/ExportFieldsReadyButton.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import compose from 'recompose/compose';
+import withHandlers from 'recompose/withHandlers';
+
+import translate from 'redux-polyglot/translate';
+import FlatButton from 'material-ui/FlatButton';
+
+import { polyglot as polyglotPropTypes } from '../../propTypes';
+import { exportFieldsReady as exportFieldsAction } from '../../exportFieldsReady';
+
+const styles = {
+    button: {
+        marginLeft: 4,
+        marginRight: 4,
+        marginTop: 4,
+    },
+};
+
+export const ExportFieldsReadyButtonComponent = ({
+    handleClick,
+    p: polyglot,
+}) => (
+    <FlatButton
+        primary
+        onClick={handleClick}
+        label={polyglot.t('export_fields_ready')}
+        style={styles.button}
+    />
+);
+
+ExportFieldsReadyButtonComponent.propTypes = {
+    handleClick: PropTypes.func.isRequired,
+    p: polyglotPropTypes.isRequired,
+};
+
+ExportFieldsReadyButtonComponent.defaultProps = {
+    iconStyle: null,
+};
+
+const mapDispatchToProps = {
+    exportFields: exportFieldsAction,
+};
+
+export default compose(
+    connect(undefined, mapDispatchToProps),
+    withHandlers({
+        handleClick: ({ exportFields }) => () => {
+            exportFields();
+        },
+    }),
+    translate,
+)(ExportFieldsReadyButtonComponent);

--- a/src/app/js/user/index.js
+++ b/src/app/js/user/index.js
@@ -222,6 +222,11 @@ export const getExportFieldsRequest = state =>
         url: '/api/field/export',
     });
 
+export const getExportFieldsReadyRequest = state =>
+    getRequest(state, {
+        url: '/api/field/export/ready',
+    });
+
 export const getLoadFacetValuesRequest = (
     state,
     { field, filter, currentPage = 0, perPage = 10, sort = {} },
@@ -307,6 +312,7 @@ export const selectors = {
     getLoadContributedResourcePageRequest,
     getLoadFacetValuesRequest,
     getExportFieldsRequest,
+    getExportFieldsReadyRequest,
     getCreateResourceRequest,
     getAddFieldToResourceRequest,
     getHideResourceRequest,

--- a/src/app/translations.tsv
+++ b/src/app/translations.tsv
@@ -126,6 +126,7 @@
 "close"	"close"	"fermer"
 "export_data"	"Export"	"Exporter"
 "export_fields"	"Export model"	"Exporter le modèle"
+"export_fields_ready"	"Export ready model"	"Exporter le modèle prêt"
 "import_fields"	"Import model"	"Importer le modèle"
 "view_fields"	"View model"	"Voir le modèle"
 "confirm_import_fields"	"Importing a saved model will override your current work. Are you sure ?"	"Importer un modèle existant remplacera le modèle actuel. Êtes-vous sûr de vouloir continuer ?"


### PR DESCRIPTION
Add an export of the model, which can be directly used with exported data.

(the first time, you have to adapt the model, because all transformers are useless, only use the one which pick the value from a column)

I call it "model ready" because the model is ready to be applied to the exported data. Maybe I should call it "ready model".