### PR TITLE
[RFR] Fix default istexQuery.context.link

### DIFF
--- a/config.json
+++ b/config.json
@@ -43,7 +43,7 @@
     "context": {
       "categories.inist": "istex:subjectInist",
       "host.genre.raw": "istex:publicationType",
-      "link": "dcterms:ispartOf",
+      "link": "dcterms:isPartOf",
       "doi": "bibo:doi",
       "fulltext[0].uri": "istex:accessURL",
       "labels": "",

--- a/config.json
+++ b/config.json
@@ -39,15 +39,12 @@
   "collectionClass": "",
   "istexQuery": {
     "labels": "",
-    "linked": "host.genre.raw",
+    "linked": "categories.inist",
     "context": {
       "categories.inist": "istex:subjectInist",
-      "host.genre.raw": "istex:publicationType",
       "link": "dcterms:isPartOf",
       "doi": "bibo:doi",
-      "fulltext[0].uri": "istex:accessURL",
-      "labels": "",
-      "linked": "categories.inist"
+      "fulltext[0].uri": "istex:accessURL"
     }
   }
 }

--- a/src/api/statements/convertToExtendedJsonLd.js
+++ b/src/api/statements/convertToExtendedJsonLd.js
@@ -22,9 +22,9 @@ function getContext(config) {
         if (!prefixes[istexProperty[0]]) {
             // eslint-disable-next-line
             return console.error(
-                `property "${
+                `property "${v}" in istexQuery ("${
                     istexProperty[0]
-                }" in istexQuery is not found in prefixes`,
+                }") is not found in prefixes`,
             );
         }
 

--- a/src/api/statements/convertToExtendedJsonLd.js
+++ b/src/api/statements/convertToExtendedJsonLd.js
@@ -20,7 +20,6 @@ function getContext(config) {
         const istexProperty = propertyValue.split(':').map(e => e.trim());
 
         if (!prefixes[istexProperty[0]]) {
-            // eslint-disable-next-line
             return console.error(
                 `property "${v}" in istexQuery ("${
                     istexProperty[0]
@@ -33,8 +32,10 @@ function getContext(config) {
     });
 
     if (context[config.istexQuery.linked] === undefined) {
-        // eslint-disable-next-line
-        return console.error('convertToExtendedJsonLd', `${config.istexQuery.linked} not found in context`);
+        return console.error(
+            'convertToExtendedJsonLd',
+            `${config.istexQuery.linked} not found in context`,
+        );
     }
 
     context[config.istexQuery.linked] = {


### PR DESCRIPTION
The link between a document and the resource of the current LODEX instance points to an URI (of the resource) which network protocol is not always correct.

Ex: for the resource https://loaded-corpus.data.istex.fr/ark:/67375/XBH-00BJNC61-D, the triple is

```
<https://api.istex.fr/ark:/67375/80W-GXWJ2C2B-P> <http://purl.org/dc/terms/ispartOf> <http://loaded-corpus.data.istex.fr/ark:/67375/XBH-00BJNC61-D> .
```

where the last part of the triple is http://loaded-corpus.data.istex.fr/ark:/67375/XBH-00BJNC61-D (`http` instead of `https`).

That prevents from joining resources coming from the nquads exporter, where the resource is identified *with* its `https` URI.