### PR TITLE
[RFR] Améliorer SPARQL Texte

### DIFF
--- a/config.json
+++ b/config.json
@@ -46,5 +46,11 @@
       "doi": "bibo:doi",
       "fulltext[0].uri": "istex:accessURL"
     }
-  }
+  },
+  "sparqlEndpoints": [
+    "https://lod.abes.fr/sparql",
+    "http://data.persee.fr/sparql/",
+    "https://data.istex.fr/sparql/",
+    "http://data.bnf.fr/sparql"
+  ]
 }

--- a/src/app/js/formats/sparql/SparqlRequest.js
+++ b/src/app/js/formats/sparql/SparqlRequest.js
@@ -100,7 +100,7 @@ export default url => FormatView => {
             });
         };
 
-        redirectIfUrl = () => {
+        windowOpenIfUrl = () => {
             const { resource, field } = this.props;
             const requestText = resource[field.name];
 

--- a/src/app/js/formats/sparql/SparqlRequest.js
+++ b/src/app/js/formats/sparql/SparqlRequest.js
@@ -13,6 +13,7 @@ import { loadFormatData } from '../../formats/reducer';
 import Loading from '../../lib/components/Loading';
 import ActionSearch from 'material-ui/svg-icons/action/search';
 import TextField from 'material-ui/TextField';
+import { isURL } from '../../../../common/uris.js';
 
 const styles = {
     message: {
@@ -20,6 +21,11 @@ const styles = {
     },
     icon: {
         cursor: 'default',
+        verticalAlign: 'middle',
+        width: '5%',
+    },
+    pointer: {
+        cursor: 'pointer',
         verticalAlign: 'middle',
         width: '5%',
     },
@@ -94,6 +100,15 @@ export default url => FormatView => {
             });
         };
 
+        redirectIfUrl = () => {
+            const { resource, field } = this.props;
+            const requestText = resource[field.name];
+
+            if (isURL(requestText)) {
+                window.open(requestText);
+            }
+        };
+
         getHeaderFormat = () => {
             const { resource, field, sparql } = this.props;
             const requestText = resource[field.name];
@@ -103,7 +118,15 @@ export default url => FormatView => {
             if (!sparql.hiddenInfo) {
                 return (
                     <div>
-                        <ActionSearch style={styles.icon} color="lightGrey" />
+                        <ActionSearch
+                            style={
+                                isURL(requestText)
+                                    ? styles.pointer
+                                    : styles.icon
+                            }
+                            color="lightGrey"
+                            onClick={this.redirectIfUrl}
+                        />
                         <TextField
                             style={styles.input1}
                             name="sparqlRequest"

--- a/src/app/js/formats/sparql/SparqlRequest.js
+++ b/src/app/js/formats/sparql/SparqlRequest.js
@@ -11,10 +11,32 @@ import {
 import { fromFormat } from '../../public/selectors';
 import { loadFormatData } from '../../formats/reducer';
 import Loading from '../../lib/components/Loading';
+import ActionSearch from 'material-ui/svg-icons/action/search';
+import TextField from 'material-ui/TextField';
 
 const styles = {
     message: {
         margin: 20,
+    },
+    icon: {
+        cursor: 'default',
+        verticalAlign: 'middle',
+        width: '5%',
+    },
+    container: {
+        display: 'block',
+        width: '100%',
+    },
+    input1: {
+        fontSize: '1em',
+        width: '80%',
+        borderImage: 'none',
+    },
+    input2: {
+        marginLeft: '2.5%',
+        fontSize: '1em',
+        width: '12.5%',
+        borderImage: 'none',
     },
 };
 
@@ -41,6 +63,7 @@ export default url => FormatView => {
             isLoaded: PropTypes.bool.isRequired,
             error: PropTypes.object,
             p: polyglotPropTypes.isRequired,
+            sparql: PropTypes.object,
         };
 
         loadFormatData = () => {
@@ -71,6 +94,31 @@ export default url => FormatView => {
             });
         };
 
+        getHeaderFormat = () => {
+            const { resource, field, sparql } = this.props;
+            // let requestText = 'titi';
+            // let endpoint = 'toto';
+            const requestText = resource[field.name];
+            let endpoint = sparql.endpoint.substring(
+                sparql.endpoint.search('//') + 2,
+            );
+            return (
+                <div>
+                    <ActionSearch style={styles.icon} color="lightGrey" />
+                    <TextField
+                        style={styles.input1}
+                        name="sparqlRequest"
+                        value={requestText}
+                    />
+                    <TextField
+                        style={styles.input2}
+                        name="sparqlEnpoint"
+                        value={endpoint}
+                    />
+                </div>
+            );
+        };
+
         render() {
             const {
                 loadFormatData,
@@ -84,18 +132,29 @@ export default url => FormatView => {
 
             if (error) {
                 return (
-                    <p style={styles.message}>{polyglot.t('sparql_error')}</p>
+                    <div style={styles.container}>
+                        {this.getHeaderFormat()}
+                        <p style={styles.message}>
+                            {polyglot.t('sparql_error')}
+                        </p>
+                    </div>
                 );
             }
 
-            if (formatData === 'no result') {
+            if (formatData == 0) {
                 return (
-                    <p style={styles.message}>{polyglot.t('sparql_data')}</p>
+                    <div style={styles.container}>
+                        {this.getHeaderFormat()}
+                        <p style={styles.message}>
+                            {polyglot.t('sparql_data')}
+                        </p>
+                    </div>
                 );
             }
 
             return (
                 <div>
+                    {this.getHeaderFormat()}
                     {!isLoaded && <Loading>{polyglot.t('loading')}</Loading>}
                     <FormatView
                         {...props}

--- a/src/app/js/formats/sparql/SparqlRequest.js
+++ b/src/app/js/formats/sparql/SparqlRequest.js
@@ -141,15 +141,17 @@ export default url => FormatView => {
                 );
             }
 
-            if (formatData == 0) {
-                return (
-                    <div style={styles.container}>
-                        {this.getHeaderFormat()}
-                        <p style={styles.message}>
-                            {polyglot.t('sparql_data')}
-                        </p>
-                    </div>
-                );
+            if (formatData != undefined) {
+                if (formatData.results.bindings.length == 0) {
+                    return (
+                        <div style={styles.container}>
+                            {this.getHeaderFormat()}
+                            <p style={styles.message}>
+                                {polyglot.t('sparql_data')}
+                            </p>
+                        </div>
+                    );
+                }
             }
 
             return (

--- a/src/app/js/formats/sparql/SparqlRequest.js
+++ b/src/app/js/formats/sparql/SparqlRequest.js
@@ -125,7 +125,7 @@ export default url => FormatView => {
                                     : styles.icon
                             }
                             color="lightGrey"
-                            onClick={this.redirectIfUrl}
+                            onClick={this.windowOpenIfUrl}
                         />
                         <TextField
                             style={styles.input1}

--- a/src/app/js/formats/sparql/SparqlRequest.js
+++ b/src/app/js/formats/sparql/SparqlRequest.js
@@ -96,27 +96,29 @@ export default url => FormatView => {
 
         getHeaderFormat = () => {
             const { resource, field, sparql } = this.props;
-            // let requestText = 'titi';
-            // let endpoint = 'toto';
             const requestText = resource[field.name];
             let endpoint = sparql.endpoint.substring(
                 sparql.endpoint.search('//') + 2,
             );
-            return (
-                <div>
-                    <ActionSearch style={styles.icon} color="lightGrey" />
-                    <TextField
-                        style={styles.input1}
-                        name="sparqlRequest"
-                        value={requestText}
-                    />
-                    <TextField
-                        style={styles.input2}
-                        name="sparqlEnpoint"
-                        value={endpoint}
-                    />
-                </div>
-            );
+            if (!sparql.hiddenInfo) {
+                return (
+                    <div>
+                        <ActionSearch style={styles.icon} color="lightGrey" />
+                        <TextField
+                            style={styles.input1}
+                            name="sparqlRequest"
+                            value={requestText}
+                        />
+                        <TextField
+                            style={styles.input2}
+                            name="sparqlEnpoint"
+                            value={endpoint}
+                        />
+                    </div>
+                );
+            }
+
+            return null;
         };
 
         render() {

--- a/src/app/js/formats/sparql/SparqlTextField/SparqlAdmin.js
+++ b/src/app/js/formats/sparql/SparqlTextField/SparqlAdmin.js
@@ -17,6 +17,8 @@ const styles = {
     },
     checkbox: {
         marginTop: 12,
+        marginRight: 5,
+        verticalAlign: 'sub',
     },
     previewDefaultColor: color => ({
         display: 'inline-block',
@@ -117,11 +119,12 @@ class SparqlTextFieldAdmin extends Component {
                     style={styles.input}
                     value={maxValue}
                 />
-                <label style={styles.checkbox}>
+                <label>
                     <input
                         type="checkbox"
                         checked={hiddenInfo}
                         onChange={this.setHiddenInfo}
+                        style={styles.checkbox}
                     />
                     {polyglot.t('hidden_info')}
                 </label>

--- a/src/app/js/formats/sparql/SparqlTextField/SparqlAdmin.js
+++ b/src/app/js/formats/sparql/SparqlTextField/SparqlAdmin.js
@@ -2,8 +2,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import translate from 'redux-polyglot/translate';
 import TextField from 'material-ui/TextField';
+import config from '../../../../../../config.json';
 
 import { polyglot as polyglotPropTypes } from '../../../propTypes';
+
+const endpoints = config.sparqlEndpoints;
 
 const styles = {
     container: {
@@ -101,10 +104,21 @@ class SparqlTextFieldAdmin extends Component {
             <div style={styles.container}>
                 <TextField
                     floatingLabelText={polyglot.t('sparql_endpoint')}
-                    onChange={this.setEndpoint}
                     style={styles.input}
                     value={endpoint}
+                    onChange={this.setEndpoint}
+                    native="true"
+                    type="text"
+                    name="valueEnpoint"
+                    list="listEnpoint"
+                    required="true"
                 />
+                <datalist id="listEnpoint">
+                    {endpoints.map(source => (
+                        <option key={source} value={source} />
+                    ))}
+                </datalist>
+
                 <TextField
                     floatingLabelText={polyglot.t('sparql_request')}
                     multiLine={true}

--- a/src/app/js/formats/sparql/SparqlTextField/SparqlAdmin.js
+++ b/src/app/js/formats/sparql/SparqlTextField/SparqlAdmin.js
@@ -15,6 +15,9 @@ const styles = {
     input: {
         width: '100%',
     },
+    checkbox: {
+        marginTop: 12,
+    },
     previewDefaultColor: color => ({
         display: 'inline-block',
         backgroundColor: color,
@@ -38,6 +41,7 @@ WHERE
   ?uri skos:prefLabel ?LibelleNomBnf.
   ?uri rdfs:seeAlso ?LienCatalogueBnf.
 }`,
+        hiddenInfo: false,
     },
 };
 
@@ -48,6 +52,7 @@ class SparqlTextFieldAdmin extends Component {
                 endpoint: PropTypes.string,
                 maxValue: PropTypes.number,
                 request: PropTypes.string,
+                hiddenInfo: PropTypes.object,
             }),
         }),
         onChange: PropTypes.func.isRequired,
@@ -78,10 +83,17 @@ class SparqlTextFieldAdmin extends Component {
         const newState = { ...state, sparql: { ...sparql, maxValue } };
         this.props.onChange(newState);
     };
+    setHiddenInfo = event => {
+        let hiddenInfo = event.target.checked;
+        const { sparql, ...state } = this.props.args;
+        const newState = { ...state, sparql: { ...sparql, hiddenInfo } };
+        this.props.onChange(newState);
+    };
 
     render() {
         const { p: polyglot, args: { sparql } } = this.props;
-        const { endpoint, request, maxValue } = sparql || defaultArgs.sparql;
+        const { endpoint, request, maxValue, hiddenInfo } =
+            sparql || defaultArgs.sparql;
 
         return (
             <div style={styles.container}>
@@ -105,6 +117,14 @@ class SparqlTextFieldAdmin extends Component {
                     style={styles.input}
                     value={maxValue}
                 />
+                <label style={styles.checkbox}>
+                    <input
+                        type="checkbox"
+                        checked={hiddenInfo}
+                        onChange={this.setHiddenInfo}
+                    />
+                    {polyglot.t('hidden_info')}
+                </label>
             </div>
         );
     }

--- a/src/app/js/formats/sparql/SparqlTextField/SparqlView.js
+++ b/src/app/js/formats/sparql/SparqlTextField/SparqlView.js
@@ -6,34 +6,10 @@ import SparqlRequest from '../SparqlRequest';
 import { isURL } from '../../../../../common/uris.js';
 import { field as fieldPropTypes } from '../../../propTypes';
 import URL from 'url';
-import IconButton from 'material-ui/IconButton';
-import ActionSearch from 'material-ui/svg-icons/action/search';
-import TextField from 'material-ui/TextField';
 import topairs from 'lodash.topairs';
 import toSentenceCase from 'js-sentencecase';
 
 const styles = {
-    icon: {
-        cursor: 'default',
-        verticalAlign: 'bottom',
-        width: '5%',
-    },
-    container: {
-        display: 'block',
-        width: '100%',
-        color: 'lightGrey',
-    },
-    input1: {
-        fontSize: '0.7em',
-        width: '80%',
-        borderImage: 'none',
-    },
-    input2: {
-        marginLeft: '2.5%',
-        fontSize: '0.7em',
-        width: '12.5%',
-        borderImage: 'none',
-    },
     container2: {
         paddingLeft: '2rem',
         marginBottom: '10px',
@@ -97,29 +73,10 @@ export class SparqlTextField extends Component {
     };
 
     render() {
-        const { className, formatData, resource, field, sparql } = this.props;
+        const { className, formatData } = this.props;
         if (formatData != undefined) {
-            const requestText = resource[field.name];
-            let endpoint = sparql.endpoint.substring(
-                sparql.endpoint.search('//') + 2,
-            );
             return (
                 <div className={className}>
-                    <div style={styles.container}>
-                        <IconButton style={styles.icon}>
-                            <ActionSearch color="lightGrey" />
-                        </IconButton>
-                        <TextField
-                            style={styles.input1}
-                            name="sparqlRequest"
-                            value={requestText}
-                        />
-                        <TextField
-                            style={styles.input2}
-                            name="sparqlEnpoint"
-                            value={endpoint}
-                        />
-                    </div>
                     {formatData.results.bindings.map((result, key) => {
                         return (
                             <div key={key} style={styles.container2}>

--- a/src/app/translations.tsv
+++ b/src/app/translations.tsv
@@ -188,6 +188,7 @@
 "sparql_data"	"No data"	"Absence de donnée"
 "sparql_endpoint"	"SPARQL endpoint"	"Endpoint SPARQL"
 "sparql_request"	"SPARQL request"	"Requête SPARQL"
+"hidden_info"	"Hide the resource field"	"Cacher le champ de la ressource"
 "a_column"	"A value from an existing column"	"Une valeur en provenance d'une colonne existante"
 "select_a_column"	"Select a column"	"Sélectionner une colonne"
 "a_composition"	"A value from multiple columns"	"Une valeur en provenance de colonnes multiples"


### PR DESCRIPTION
Ajout de petite fonctionnalité pour SPARQL Texte :
- possibilité de cacher les informations
- affiche les informations même en cas d'erreur ou d'absence de données et durant le chargement
- affiche une liste de sparql endpoints enregistrés