### PR TITLE
[RFR] Fix IdentifierBadge format's CSS

### DIFF
--- a/src/app/js/formats/identifier-badge/IdentifierBadgeView.js
+++ b/src/app/js/formats/identifier-badge/IdentifierBadgeView.js
@@ -47,7 +47,7 @@ const IdentifierBadgeView = ({ resource, field, typid, colors }) => {
     });
 
     return (
-        <a href={target} className={css(styles.label)}>
+        <a href={target}>
             <span className={css(styles.key)}>{typid}</span>
             <span className={css(styles.value)}>{identifier}</span>
         </a>


### PR DESCRIPTION
When overloaded with an external CSS, `<a>` tag had the same class as `LodexResource`'s `div`.

[![image](https://user-images.githubusercontent.com/595509/40659309-31e1d8dc-634e-11e8-8fea-f3fbb97d6e33.png)](http://niveau3orthob-test-2.lodex-dev.inist.fr/ark:/67375/1BB-Z9XR1RHS-K)
