### PR TITLE
Fix NQuads export with composed field (number in sub-domain)

### DIFF
--- a/src/api/exporters/exportNQuads.js
+++ b/src/api/exporters/exportNQuads.js
@@ -9,7 +9,6 @@ const exporter = (config, fields, characteristics, stream) =>
     stream
         .pipe(ezs('filterVersions'))
         .pipe(ezs('filterContributions', { fields }))
-        // .pipe(ezs('debug'))
         .pipe(
             ezs('JSONLDObject', {
                 fields,

--- a/src/api/exporters/exportNQuads.js
+++ b/src/api/exporters/exportNQuads.js
@@ -9,6 +9,7 @@ const exporter = (config, fields, characteristics, stream) =>
     stream
         .pipe(ezs('filterVersions'))
         .pipe(ezs('filterContributions', { fields }))
+        // .pipe(ezs('debug'))
         .pipe(
             ezs('JSONLDObject', {
                 fields,
@@ -17,6 +18,7 @@ const exporter = (config, fields, characteristics, stream) =>
                 exportDataset: config.exportDataset,
             }),
         )
+        .pipe(ezs.catch(console.error))
         .pipe(
             ezs('linkDataset', {
                 uri: config.cleanHost,

--- a/src/api/exporters/exportNQuads.spec.js
+++ b/src/api/exporters/exportNQuads.spec.js
@@ -291,10 +291,10 @@ describe('export Nquads', () => {
                         expect(outputString).toEqual(
                             [
                                 /*eslint-disable prettier/prettier */
-                                `<http://a-b.c.d.e/1#complete/${completing}> <http://purl.org/dc/terms/source> <https://fr.wikipedia.org/wiki/Chimie_inorganique> .`,
-                                `<http://a-b.c.d.e/1#complete/${completing}> <http://www.w3.org/2000/01/rdf-schema#label> "La chimie minérale (= inorganique) étudie ..." .`,
-                                `<http://a-b.c.d.e/1> <http://purl.org/dc/terms/description> <http://a-b.c.d.e/1#complete/${completing}> .`,
-                                '',
+`<http://a-b.c.d.e/1#complete/${completing}> <http://purl.org/dc/terms/source> <https://fr.wikipedia.org/wiki/Chimie_inorganique> .`,
+`<http://a-b.c.d.e/1#complete/${completing}> <http://www.w3.org/2000/01/rdf-schema#label> "La chimie minérale (= inorganique) étudie ..." .`,
+`<http://a-b.c.d.e/1> <http://purl.org/dc/terms/description> <http://a-b.c.d.e/1#complete/${completing}> .`,
+'',
                                 /*eslint-enable prettier/prettier */
                             ].join('\n'),
                         );

--- a/src/api/exporters/exportNQuads.spec.js
+++ b/src/api/exporters/exportNQuads.spec.js
@@ -217,7 +217,7 @@ describe('export Nquads', () => {
             null,
             from([
                 {
-                    uri: 'http://a-b-1.uri/1',
+                    uri: 'http://a-b-1.c.d.e/1',
                     propcomposed: 'label a',
                     propb: 'value 1',
                     propc: 'value 2',
@@ -231,10 +231,10 @@ describe('export Nquads', () => {
                     try {
                         expect(outputString).toEqual(
                             [
-                                '<http://a-b.uri/1#compose/propcomposed> <http://property/b> "value 1" .',
-                                '<http://a-b.uri/1#compose/propcomposed> <http://property/c> "value 2" .',
-                                '<http://a-b.uri/1#compose/propcomposed> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://class/composed> .',
-                                '<http://a-b.uri/1> <http://property/composed> <http://a-b.uri/1#compose/propcomposed> .',
+                                '<http://a-b.c.d.e/1#compose/propcomposed> <http://property/b> "value 1" .',
+                                '<http://a-b.c.d.e/1#compose/propcomposed> <http://property/c> "value 2" .',
+                                '<http://a-b.c.d.e/1#compose/propcomposed> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://class/composed> .',
+                                '<http://a-b.c.d.e/1> <http://property/composed> <http://a-b.c.d.e/1#compose/propcomposed> .',
                                 '',
                             ].join('\n'),
                         );

--- a/src/api/exporters/exportNQuads.spec.js
+++ b/src/api/exporters/exportNQuads.spec.js
@@ -284,12 +284,18 @@ describe('export Nquads', () => {
                     outputString += data;
                 } else {
                     try {
+                        expect(outputString).toContain('#complete/');
+                        const completing = RegExp('#complete/([^>]*)').exec(
+                            outputString,
+                        )[1];
                         expect(outputString).toEqual(
                             [
-                                '<http://a-b.c.d.e/1#complete/completing> <http://purl.org/dc/terms/source> <https://fr.wikipedia.org/wiki/Chimie_inorganique> .',
-                                '<http://a-b.c.d.e/1#complete/completing> <http://www.w3.org/2000/01/rdf-schema#label> "La chimie minérale (= inorganique) étudie ..." .',
-                                '<http://a-b.c.d.e/1> <http://purl.org/dc/terms/description> <http://a-b.c.d.e/1#complete/completing> .',
+                                /*eslint-disable prettier/prettier */
+                                `<http://a-b.c.d.e/1#complete/${completing}> <http://purl.org/dc/terms/source> <https://fr.wikipedia.org/wiki/Chimie_inorganique> .`,
+                                `<http://a-b.c.d.e/1#complete/${completing}> <http://www.w3.org/2000/01/rdf-schema#label> "La chimie minérale (= inorganique) étudie ..." .`,
+                                `<http://a-b.c.d.e/1> <http://purl.org/dc/terms/description> <http://a-b.c.d.e/1#complete/${completing}> .`,
                                 '',
+                                /*eslint-enable prettier/prettier */
                             ].join('\n'),
                         );
                     } catch (e) {

--- a/src/api/exporters/exportNQuads.spec.js
+++ b/src/api/exporters/exportNQuads.spec.js
@@ -247,4 +247,58 @@ describe('export Nquads', () => {
             }),
         );
     });
+
+    it.only('should export a annotating property without number in sub-domain', done => {
+        let outputString = '';
+        exportNQuads(
+            {
+                cleanHost: '',
+                schemeForDatasetLink: '',
+            },
+            [
+                {
+                    cover: 'collection',
+                    scheme: 'http://purl.org/dc/terms/description',
+                    name: 'completed',
+                },
+                {
+                    cover: 'collection',
+                    scheme: 'http://purl.org/dc/terms/source',
+                    completes: 'completed',
+                    name: 'completing',
+                },
+            ],
+            null,
+            from([
+                {
+                    uri: 'http://a-b-1.c.d.e/1',
+                    completed: 'La chimie minérale (= inorganique) étudie ...',
+                    completing: [
+                        'https://fr.wikipedia.org/wiki/Chimie_inorganique',
+                    ],
+                },
+            ]),
+        ).pipe(
+            ezs((data, feed) => {
+                if (data !== null) {
+                    outputString += data;
+                } else {
+                    try {
+                        expect(outputString).toEqual(
+                            [
+                                '<http://a-b.c.d.e/1#complete/completing> <http://purl.org/dc/terms/source> <https://fr.wikipedia.org/wiki/Chimie_inorganique> .',
+                                '<http://a-b.c.d.e/1#complete/completing> <http://www.w3.org/2000/01/rdf-schema#label> "La chimie minérale (= inorganique) étudie ..." .',
+                                '<http://a-b.c.d.e/1> <http://purl.org/dc/terms/description> <http://a-b.c.d.e/1#complete/completing> .',
+                                '',
+                            ].join('\n'),
+                        );
+                    } catch (e) {
+                        return done(e);
+                    }
+                    return done();
+                }
+                return feed.end();
+            }),
+        );
+    });
 });

--- a/src/api/exporters/exportNQuads.spec.js
+++ b/src/api/exporters/exportNQuads.spec.js
@@ -185,4 +185,66 @@ describe('export Nquads', () => {
             }),
         );
     });
+
+    it.only('should export a composed object property (with a class) without number in sub-domain', done => {
+        let outputString = '';
+        exportNQuads(
+            {
+                cleanHost: '',
+                schemeForDatasetLink: '',
+            },
+            [
+                {
+                    cover: 'collection',
+                    scheme: 'http://property/composed',
+                    name: 'propcomposed',
+                    classes: ['http://class/composed'],
+                    composedOf: {
+                        fields: ['propb', 'propc'],
+                    },
+                },
+                {
+                    cover: 'collection',
+                    scheme: 'http://property/b',
+                    name: 'propb',
+                },
+                {
+                    cover: 'collection',
+                    scheme: 'http://property/c',
+                    name: 'propc',
+                },
+            ],
+            null,
+            from([
+                {
+                    uri: 'http://a-b-1.uri/1',
+                    propcomposed: 'label a',
+                    propb: 'value 1',
+                    propc: 'value 2',
+                },
+            ]),
+        ).pipe(
+            ezs((data, feed) => {
+                if (data !== null) {
+                    outputString += data;
+                } else {
+                    try {
+                        expect(outputString).toEqual(
+                            [
+                                '<http://a-b.uri/1#compose/propcomposed> <http://property/b> "value 1" .',
+                                '<http://a-b.uri/1#compose/propcomposed> <http://property/c> "value 2" .',
+                                '<http://a-b.uri/1#compose/propcomposed> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://class/composed> .',
+                                '<http://a-b.uri/1> <http://property/composed> <http://a-b.uri/1#compose/propcomposed> .',
+                                '',
+                            ].join('\n'),
+                        );
+                    } catch (e) {
+                        return done(e);
+                    }
+                    return done();
+                }
+                return feed.end();
+            }),
+        );
+    });
 });

--- a/src/api/exporters/exportNQuads.spec.js
+++ b/src/api/exporters/exportNQuads.spec.js
@@ -186,7 +186,7 @@ describe('export Nquads', () => {
         );
     });
 
-    it.only('should export a composed object property (with a class) without number in sub-domain', done => {
+    it('should export a composed object property (with a class) without number in sub-domain', done => {
         let outputString = '';
         exportNQuads(
             {

--- a/src/api/exporters/exportNQuads.spec.js
+++ b/src/api/exporters/exportNQuads.spec.js
@@ -248,7 +248,7 @@ describe('export Nquads', () => {
         );
     });
 
-    it.only('should export a annotating property without number in sub-domain', done => {
+    it('should export an annotating property without number in sub-domain', done => {
         let outputString = '';
         exportNQuads(
             {

--- a/src/api/exporters/exportNQuads.spec.js
+++ b/src/api/exporters/exportNQuads.spec.js
@@ -186,7 +186,7 @@ describe('export Nquads', () => {
         );
     });
 
-    it('should export a composed object property (with a class) without number in sub-domain', done => {
+    it.only('should export a composed object property (with a class) without number in sub-domain', done => {
         let outputString = '';
         exportNQuads(
             {
@@ -217,7 +217,7 @@ describe('export Nquads', () => {
             null,
             from([
                 {
-                    uri: 'http://a-b-1.c.d.e/1',
+                    uri: 'http://a-b-1.uri/1',
                     propcomposed: 'label a',
                     propb: 'value 1',
                     propc: 'value 2',
@@ -231,64 +231,10 @@ describe('export Nquads', () => {
                     try {
                         expect(outputString).toEqual(
                             [
-                                '<http://a-b.c.d.e/1#compose/propcomposed> <http://property/b> "value 1" .',
-                                '<http://a-b.c.d.e/1#compose/propcomposed> <http://property/c> "value 2" .',
-                                '<http://a-b.c.d.e/1#compose/propcomposed> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://class/composed> .',
-                                '<http://a-b.c.d.e/1> <http://property/composed> <http://a-b.c.d.e/1#compose/propcomposed> .',
-                                '',
-                            ].join('\n'),
-                        );
-                    } catch (e) {
-                        return done(e);
-                    }
-                    return done();
-                }
-                return feed.end();
-            }),
-        );
-    });
-
-    it.only('should export a annotating property without number in sub-domain', done => {
-        let outputString = '';
-        exportNQuads(
-            {
-                cleanHost: '',
-                schemeForDatasetLink: '',
-            },
-            [
-                {
-                    cover: 'collection',
-                    scheme: 'http://purl.org/dc/terms/description',
-                    name: 'completed',
-                },
-                {
-                    cover: 'collection',
-                    scheme: 'http://purl.org/dc/terms/source',
-                    completes: 'completed',
-                    name: 'completing',
-                },
-            ],
-            null,
-            from([
-                {
-                    uri: 'http://a-b-1.c.d.e/1',
-                    completed: 'La chimie minérale (= inorganique) étudie ...',
-                    completing: [
-                        'https://fr.wikipedia.org/wiki/Chimie_inorganique',
-                    ],
-                },
-            ]),
-        ).pipe(
-            ezs((data, feed) => {
-                if (data !== null) {
-                    outputString += data;
-                } else {
-                    try {
-                        expect(outputString).toEqual(
-                            [
-                                '<http://a-b.c.d.e/1#complete/completing> <http://purl.org/dc/terms/source> <https://fr.wikipedia.org/wiki/Chimie_inorganique> .',
-                                '<http://a-b.c.d.e/1#complete/completing> <http://www.w3.org/2000/01/rdf-schema#label> "La chimie minérale (= inorganique) étudie ..." .',
-                                '<http://a-b.c.d.e/1> <http://purl.org/dc/terms/description> <http://a-b.c.d.e/1#complete/completing> .',
+                                '<http://a-b.uri/1#compose/propcomposed> <http://property/b> "value 1" .',
+                                '<http://a-b.uri/1#compose/propcomposed> <http://property/c> "value 2" .',
+                                '<http://a-b.uri/1#compose/propcomposed> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://class/composed> .',
+                                '<http://a-b.uri/1> <http://property/composed> <http://a-b.uri/1#compose/propcomposed> .',
                                 '',
                             ].join('\n'),
                         );

--- a/src/api/statements/JSONLDObject/index.js
+++ b/src/api/statements/JSONLDObject/index.js
@@ -25,7 +25,7 @@ const merge = async (field, fields, currentOutput, data) => {
     }
 
     if (completesAnotherField) {
-        return mergeCompleteField(currentOutput, field, fields, data); // FIXME: mergeCompleteField is async!!! JSONLDObject can also be async
+        return await mergeCompleteField(currentOutput, field, fields, data);
     }
 
     if (

--- a/src/api/statements/JSONLDObject/mergeCompleteField.js
+++ b/src/api/statements/JSONLDObject/mergeCompleteField.js
@@ -1,6 +1,7 @@
 import getFieldContext from './getFieldContext';
 import transformCompleteFields from './transformCompleteFields';
 import formatData from './formatData';
+import getUri from './getUri';
 
 export default async function mergeCompleteField(output, field, fields, data) {
     const { name, complete, completed } = await transformCompleteFields(field);
@@ -17,7 +18,7 @@ export default async function mergeCompleteField(output, field, fields, data) {
     return {
         ...output,
         [name]: {
-            '@id': `${data.uri}#complete/${name}`,
+            '@id': `${getUri(data.uri)}#complete/${name}`,
             [complete]: formatData(data, complete),
             [completed]: formatData(data, completed),
         },


### PR DESCRIPTION
See [Trello](https://trello.com/c/rNPgI7mS/131-lexport-nquads-laisse-le-num%C3%A9ro-de-linstance-dans-les-champs-compos%C3%A9s).

NQuads export keeps number of instance in composed fields' URI.

![image](https://user-images.githubusercontent.com/595509/46143225-a15e7480-c259-11e8-9a70-1231327ea084.png)
