### PR TITLE
only update facet on field update when data are published

### DIFF
--- a/src/api/controller/api/field.js
+++ b/src/api/controller/api/field.js
@@ -58,7 +58,9 @@ export const putField = async (ctx, id) => {
         return;
     }
 
-    await ctx.publishFacets(ctx, [ctx.body], false);
+    if ((await ctx.publishedDataset.countAll()) > 0) {
+        await ctx.publishFacets(ctx, [ctx.body], false);
+    }
 };
 
 export const removeField = async (ctx, id) => {

--- a/src/api/controller/api/field.spec.js
+++ b/src/api/controller/api/field.spec.js
@@ -328,6 +328,9 @@ describe('field routes', () => {
                 findOneAndUpdate: jest.fn(),
             },
             publishFacets: jest.fn(),
+            publishedDataset: {
+                countAll: jest.fn(() => Promise.resolve(1000)),
+            },
         };
 
         beforeEach(() => {
@@ -373,6 +376,13 @@ describe('field routes', () => {
                 ['update result'],
                 false,
             );
+        });
+
+        it('should not update the published facets if dataset is not published (publishedDataset = 0)', async () => {
+            ctx.publishedDataset.countAll.mockImplementation(() =>
+                Promise.resolve(0),
+            );
+            expect(ctx.publishFacets).toHaveBeenCalledTimes(0);
         });
     });
 


### PR DESCRIPTION
fix: Impossibilité de sauvegarder les modifications de configuration d'une colonne "Ressources" avant publication des données - versions 8.22.4 et 8.22.5

https://trello.com/c/oLfyujHh/47-impossibilit%C3%A9-de-sauvegarder-les-modifications-de-configuration-dune-colonne-ressources-avant-publication-des-donn%C3%A9es-versions-8