### PR TITLE
Remove bibo:Document from extended export

### DIFF
--- a/src/api/statements/convertToExtendedJsonLd.js
+++ b/src/api/statements/convertToExtendedJsonLd.js
@@ -79,7 +79,6 @@ module.exports = function convertToExtendedJsonLd(data, feed) {
         ...data.content,
     };
     newHit['@id'] = `https://api.istex.fr/${data.content.arkIstex}`;
-    newHit['@type'] = 'http://purl.org/ontology/bibo/Document';
     newHit[config.istexQuery.linked] = data.lodex.uri;
 
     this.searchKeys.forEach(key => {

--- a/src/api/statements/convertToExtendedJsonLd.spec.js
+++ b/src/api/statements/convertToExtendedJsonLd.spec.js
@@ -57,7 +57,6 @@ const expectedJsonLd = {
                 },
             ],
             '@id': 'https://api.istex.fr/ark:/67375/6H6-N49F7FRR-Q',
-            '@type': 'http://purl.org/ontology/bibo/Document',
             'categories.inist':
                 'http://localhost:3000/ark:/67375/RZL-F4841DSB-1',
             'fulltext[0].uri': {


### PR DESCRIPTION
Because it may be redundant, in some cases.

See [Trello](https://trello.com/c/kJ4H96NG/116-enlever-la-propri%C3%A9t%C3%A9-a-bibodocument-de-lexport-%C3%A9tendu): because base bibliographic information, already loaded into the triple store will already contain the type (bibo:Document) of every document.

And because if several lodex instances point to the same documents, the bibo:Document triple will occur as many times as instances number.