### PR TITLE
use-clean-host-everywhere

### DIFF
--- a/src/common/uris.js
+++ b/src/common/uris.js
@@ -59,7 +59,7 @@ export const getHost = () => {
 };
 
 export const getFullResourceUri = (resource, defaultBaseUri) => {
-    const baseUri = getHost() || defaultBaseUri;
+    const baseUri = getCleanHost() || defaultBaseUri;
     const uri = getResourceUri(resource);
 
     return `${baseUri}${uri}`;


### PR DESCRIPTION
to avoid to export uri with ezmaster version number