### PR TITLE
Hide empty  loaded format

### DIFF
--- a/src/app/js/formats/bubbleChart/index.js
+++ b/src/app/js/formats/bubbleChart/index.js
@@ -9,4 +9,15 @@ export default {
     AdminComponent,
     defaultArgs,
     Icon,
+    predicate: (value, formatData) => {
+        if (!DefaultFormat.predicate(value)) {
+            return false;
+        }
+
+        if (formatData === 'loading' || typeof formatData === 'undefined') {
+            return true;
+        }
+
+        return Array.isArray(formatData) && formatData.length;
+    },
 };

--- a/src/app/js/formats/cartography/index.js
+++ b/src/app/js/formats/cartography/index.js
@@ -9,4 +9,15 @@ export default {
     AdminComponent,
     defaultArgs,
     Icon,
+    predicate: (value, formatData) => {
+        if (!DefaultFormat.predicate(value)) {
+            return false;
+        }
+
+        if (formatData === 'loading' || typeof formatData === 'undefined') {
+            return true;
+        }
+
+        return Array.isArray(formatData) && formatData.length;
+    },
 };

--- a/src/app/js/formats/distributionChart/global-bar-chart/index.js
+++ b/src/app/js/formats/distributionChart/global-bar-chart/index.js
@@ -9,4 +9,15 @@ export default {
     AdminComponent,
     defaultArgs,
     Icon,
+    predicate: (value, formatData) => {
+        if (!DefaultFormat.predicate(value)) {
+            return false;
+        }
+
+        if (formatData === 'loading' || typeof formatData === 'undefined') {
+            return true;
+        }
+
+        return Array.isArray(formatData) && formatData.length;
+    },
 };

--- a/src/app/js/formats/distributionChart/global-pie-chart/index.js
+++ b/src/app/js/formats/distributionChart/global-pie-chart/index.js
@@ -9,4 +9,15 @@ export default {
     AdminComponent,
     defaultArgs,
     Icon,
+    predicate: (value, formatData) => {
+        if (!DefaultFormat.predicate(value)) {
+            return false;
+        }
+
+        if (formatData === 'loading' || typeof formatData === 'undefined') {
+            return true;
+        }
+
+        return Array.isArray(formatData) && formatData.length;
+    },
 };

--- a/src/app/js/formats/distributionChart/global-radar-chart/index.js
+++ b/src/app/js/formats/distributionChart/global-radar-chart/index.js
@@ -9,4 +9,15 @@ export default {
     AdminComponent,
     defaultArgs,
     Icon,
+    predicate: (value, formatData) => {
+        if (!DefaultFormat.predicate(value)) {
+            return false;
+        }
+
+        if (formatData === 'loading' || typeof formatData === 'undefined') {
+            return true;
+        }
+
+        return Array.isArray(formatData) && formatData.length;
+    },
 };

--- a/src/app/js/formats/emphased-number/index.js
+++ b/src/app/js/formats/emphased-number/index.js
@@ -7,4 +7,15 @@ export default {
     Component,
     AdminComponent,
     defaultArgs,
+    predicate: (value, formatData) => {
+        if (!DefaultFormat.predicate(value)) {
+            return false;
+        }
+
+        if (formatData === 'loading' || typeof formatData === 'undefined') {
+            return true;
+        }
+
+        return !!formatData;
+    },
 };

--- a/src/app/js/formats/heatmap/index.js
+++ b/src/app/js/formats/heatmap/index.js
@@ -9,4 +9,15 @@ export default {
     AdminComponent,
     defaultArgs,
     Icon,
+    predicate: (value, formatData) => {
+        if (!DefaultFormat.predicate(value)) {
+            return false;
+        }
+
+        if (formatData === 'loading' || typeof formatData === 'undefined') {
+            return true;
+        }
+
+        return Array.isArray(formatData) && formatData.length;
+    },
 };

--- a/src/app/js/formats/istexSummary/index.js
+++ b/src/app/js/formats/istexSummary/index.js
@@ -1,3 +1,4 @@
+import get from 'lodash.get';
 import translate from 'redux-polyglot/translate';
 
 import Component from './IstexSummaryView';
@@ -11,4 +12,19 @@ export default {
     ListComponent,
     AdminComponent,
     defaultArgs,
+    predicate: (value, formatData) => {
+        if (!DefaultFormat.predicate(value)) {
+            return false;
+        }
+
+        if (formatData === 'loading' || typeof formatData === 'undefined') {
+            return true;
+        }
+
+        return get(
+            formatData,
+            'aggregations.publicationDate.buckets.length',
+            false,
+        );
+    },
 };

--- a/src/app/js/formats/lodex-field/index.js
+++ b/src/app/js/formats/lodex-field/index.js
@@ -9,4 +9,15 @@ export default {
     AdminComponent,
     ListComponent: Component,
     defaultArgs,
+    predicate: (value, formatData) => {
+        if (!DefaultFormat.predicate(value)) {
+            return false;
+        }
+
+        if (formatData === 'loading' || typeof formatData === 'undefined') {
+            return true;
+        }
+
+        return Array.isArray(formatData) && formatData.length;
+    },
 };

--- a/src/app/js/formats/lodex-resource/index.js
+++ b/src/app/js/formats/lodex-resource/index.js
@@ -5,4 +5,15 @@ import DefaultFormat from '../DefaultFormat';
 export default {
     ...DefaultFormat,
     Component,
+    predicate: (value, formatData) => {
+        if (!DefaultFormat.predicate(value)) {
+            return false;
+        }
+
+        if (formatData === 'loading' || typeof formatData === 'undefined') {
+            return true;
+        }
+
+        return !!formatData;
+    },
 };

--- a/src/app/js/formats/network/index.js
+++ b/src/app/js/formats/network/index.js
@@ -9,4 +9,15 @@ export default {
     AdminComponent,
     defaultArgs,
     Icon,
+    predicate: (value, formatData) => {
+        if (!DefaultFormat.predicate(value)) {
+            return false;
+        }
+
+        if (formatData === 'loading' || typeof formatData === 'undefined') {
+            return true;
+        }
+
+        return Array.isArray(formatData) && formatData.length;
+    },
 };

--- a/src/app/js/formats/reducer.js
+++ b/src/app/js/formats/reducer.js
@@ -44,7 +44,7 @@ export default handleActions(
 
 const isFormatDataLoaded = (state, name) => state[name] !== 'loading';
 
-const getFormatData = (state, name) => get(state, [name, 'data']);
+const getFormatData = (state, name) => console.log({ name }) || get(state, [name, 'data']);
 const getFormatError = (state, name) => get(state, [name, 'error']);
 
 export const getCurrentFieldNames = state =>

--- a/src/app/js/formats/resources-grid/index.js
+++ b/src/app/js/formats/resources-grid/index.js
@@ -7,4 +7,19 @@ export default {
     Component,
     AdminComponent,
     defaultArgs,
+    predicate: (value, formatData) => {
+        if (!DefaultFormat.predicate(value)) {
+            return false;
+        }
+
+        if (formatData === 'loading' || typeof formatData === 'undefined') {
+            return true;
+        }
+
+        return (
+            formatData &&
+            Array.isArray(formatData.items) &&
+            formatData.items.length
+        );
+    },
 };

--- a/src/app/js/formats/streamgraph/index.js
+++ b/src/app/js/formats/streamgraph/index.js
@@ -6,4 +6,15 @@ export default {
     ...DefaultFormat,
     Component,
     Icon,
+    predicate: (value, formatData) => {
+        if (!DefaultFormat.predicate(value)) {
+            return false;
+        }
+
+        if (formatData === 'loading' || typeof formatData === 'undefined') {
+            return true;
+        }
+
+        return Array.isArray(formatData) && formatData.length;
+    },
 };

--- a/src/app/js/public/Property/index.js
+++ b/src/app/js/public/Property/index.js
@@ -85,6 +85,12 @@ const styles = {
     },
 };
 
+const isEmpty = value =>
+    value === null ||
+    typeof value === 'undefined' ||
+    value === '' ||
+    (Array.isArray(value) && value.length === 0);
+
 const PropertyComponent = ({
     className,
     field,
@@ -97,14 +103,14 @@ const PropertyComponent = ({
     parents,
 }) => {
     if (!isAdmin) {
-        const predicate = getPredicate(field);
-        if (!predicate(resource[field.name])) {
+        if (fieldStatus === REJECTED) {
             return null;
         }
-    }
-
-    if (!isAdmin && fieldStatus === REJECTED) {
-        return null;
+        const value = resource[field.name];
+        const predicate = getPredicate(field);
+        if (!predicate(value) || isEmpty(value)) {
+            return null;
+        }
     }
     const fieldClassName = getFieldClassName(field);
 

--- a/src/app/js/public/Property/index.js
+++ b/src/app/js/public/Property/index.js
@@ -91,7 +91,7 @@ const isEmpty = value =>
     value === '' ||
     (Array.isArray(value) && value.length === 0);
 
-const PropertyComponent = ({
+export const PropertyComponent = ({
     className,
     field,
     isSub,

--- a/src/app/js/public/Property/index.js
+++ b/src/app/js/public/Property/index.js
@@ -9,7 +9,7 @@ import { grey500 } from 'material-ui/styles/colors';
 import memoize from 'lodash.memoize';
 import get from 'lodash.get';
 
-import { fromResource } from '../selectors';
+import { fromResource, fromFormat } from '../selectors';
 import { field as fieldPropTypes } from '../../propTypes';
 import CompositeProperty from './CompositeProperty';
 import propositionStatus, {
@@ -101,6 +101,7 @@ export const PropertyComponent = ({
     changeStatus,
     style,
     parents,
+    formatData,
 }) => {
     if (!isAdmin) {
         if (fieldStatus === REJECTED) {
@@ -108,7 +109,7 @@ export const PropertyComponent = ({
         }
         const value = resource[field.name];
         const predicate = getPredicate(field);
-        if (!predicate(value) || isEmpty(value)) {
+        if (!predicate(value, formatData) || isEmpty(value)) {
             return null;
         }
     }
@@ -213,6 +214,7 @@ PropertyComponent.propTypes = {
     resource: PropTypes.shape({}).isRequired,
     parents: PropTypes.arrayOf(PropTypes.string).isRequired,
     style: PropTypes.object,
+    formatData: PropTypes.any,
 };
 
 PropertyComponent.defaultProps = {
@@ -224,6 +226,7 @@ PropertyComponent.defaultProps = {
 const mapStateToProps = (state, { field }) => ({
     isAdmin: fromUser.isAdmin(state),
     fieldStatus: fromResource.getFieldStatus(state, field),
+    formatData: fromFormat.getFormatData(state, field.name),
 });
 
 const mapDispatchToProps = (dispatch, { field, resource: { uri } }) =>

--- a/src/app/js/public/Property/index.spec.js
+++ b/src/app/js/public/Property/index.spec.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { PropertyComponent } from './index';
+import { REJECTED, VALIDATED } from '../../../../common/propositionStatus';
+
+describe('Property', () => {
+    const defaultProps = {
+        className: 'class',
+        field: { name: 'field' },
+        resource: {
+            field: 'value',
+        },
+        fieldStatus: VALIDATED,
+        isAdmin: true,
+        changeStatus: () => null,
+        parents: [],
+    };
+
+    describe('is not admin', () => {
+        it('should render nothing if resource[field.name] is null', () => {
+            const wrapper = shallow(
+                <PropertyComponent
+                    {...defaultProps}
+                    isAdmin={false}
+                    resource={{ field: null }}
+                />,
+            );
+
+            expect(wrapper.getElement()).toBe(null);
+        });
+        it('should render nothing if resource[field.name] is undefined', () => {
+            const wrapper = shallow(
+                <PropertyComponent
+                    {...defaultProps}
+                    isAdmin={false}
+                    resource={{}}
+                />,
+            );
+
+            expect(wrapper.getElement()).toBe(null);
+        });
+        it('should render nothing if resource[field.name] is an empty string', () => {
+            const wrapper = shallow(
+                <PropertyComponent
+                    {...defaultProps}
+                    isAdmin={false}
+                    resource={{ field: '' }}
+                />,
+            );
+
+            expect(wrapper.getElement()).toBe(null);
+        });
+        it('should render nothing if resource[field.name] is an empty array', () => {
+            const wrapper = shallow(
+                <PropertyComponent
+                    {...defaultProps}
+                    isAdmin={false}
+                    resource={{ field: [] }}
+                />,
+            );
+
+            expect(wrapper.getElement()).toBe(null);
+        });
+        it('should render something if resource[field.name] is a value', () => {
+            const wrapper = shallow(
+                <PropertyComponent
+                    {...defaultProps}
+                    isAdmin={false}
+                    resource={{ field: 'value' }}
+                />,
+            );
+
+            expect(wrapper.getElement()).not.toBe(null);
+        });
+        it('should render something if resource[field.name] and field format is list is a list of value', () => {
+            const wrapper = shallow(
+                <PropertyComponent
+                    {...defaultProps}
+                    isAdmin={false}
+                    field={{
+                        name: 'field',
+                        format: {
+                            name: 'list',
+                        },
+                    }}
+                    resource={{ field: ['value1', 'value2'] }}
+                />,
+            );
+
+            expect(wrapper.getElement()).not.toBe(null);
+        });
+    });
+
+    describe('is admin', () => {
+        it('should always render something', () => {
+            [null, undefined, '', [], 'value', ['value1', 'value2']].forEach(
+                value => {
+                    const wrapper = shallow(
+                        <PropertyComponent
+                            {...defaultProps}
+                            isAdmin={true}
+                            resource={{ field: value }}
+                        />,
+                    );
+
+                    expect(wrapper.getElement()).not.toBe(null);
+                },
+            );
+        });
+    });
+});


### PR DESCRIPTION
follow #840 
This PR change the working of format so that the predicate function receive the formatData as well as the value.
The predicate function is a function that check the value of a format and return true if the value is correct.
This means that if a field has loaded empty data, then it will disappear for the user, and appear as incorrect to the administrator.
This has not been thoroughly tested and could introduce new bug.