### PR TITLE
Display better errors while failing E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,10 @@ ifeq "$(DISABLE_E2E_TESTS)" "true"
 else
 	$(MAKE) test-e2e-start-dockers
 	./node_modules/.bin/cypress install
-	./bin/wait-for -t 60 localhost:3000 -- ./node_modules/.bin/cypress run --browser chrome
+	./bin/wait-for -t 30 localhost:3000 -- ./node_modules/.bin/cypress run --browser chrome || \
+		echo "ERROR: The API didn't start! Here are the logs:" && \
+		$(MAKE) test-e2e-logs && \
+		$(MAKE) test-e2e-stop-dockers
 	$(MAKE) test-e2e-stop-dockers
 endif
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/jSEHn9Oc)

Before launching E2E tests, the makefile first check that the API is running and waiting for a response from it.
If the API fail to respond (because it has crashed or something), the error log wasn't explicit enough to understand what happened.

The goal of this PR is to help developers understand why the tests failed.

## Before

```txt
./bin/wait-for -t 60 localhost:3000 -- ./node_modules/.bin/cypress run --browser chrome
Operation timed out
make: *** [test-e2e] Error 1
The command "make test" exited with 2.
```

## After
```txt
./bin/wait-for -t 30 localhost:3000 -- ./node_modules/.bin/cypress run --browser chrome
Operation timed out
The API didn't start! Here are the logs:
WARNING: The UID variable is not set. Defaulting to a blank string.
WARNING: The GID variable is not set. Defaulting to a blank string.
Attaching to lodex_api_1, lodex_mongo_1, lodex_istex-api_1
api_1        | 
api_1        | > lodex@9.3.11 start /app
api_1        | > node --require @babel/register src/api
api_1        | 
api_1        | /app/src/api/index.js:28
api_1        | throw new Error('yolo');
api_1        | ^
api_1        | 
api_1        | Error: yolo
api_1        |     at Object.<anonymous> (/app/src/api/index.js:11:7)
api_1        |     at Module._compile (internal/modules/cjs/loader.js:688:30)
api_1        |     at Module._compile (/app/node_modules/pirates/lib/index.js:83:24)
api_1        |     at Module._extensions..js (internal/modules/cjs/loader.js:699:10)
api_1        |     at Object.newLoader [as .js] (/app/node_modules/pirates/lib/index.js:88:7)
api_1        |     at Module.load (internal/modules/cjs/loader.js:598:32)
api_1        |     at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
api_1        |     at Function.Module._load (internal/modules/cjs/loader.js:529:3)
api_1        |     at Function.Module.runMain (internal/modules/cjs/loader.js:741:12)
api_1        |     at startup (internal/bootstrap/node.js:285:19)
api_1        | npm ERR! code ELIFECYCLE
api_1        | npm ERR! errno 1
api_1        | npm ERR! lodex@9.3.11 start: `node --require @babel/register src/api`
api_1        | npm ERR! Exit status 1
api_1        | npm ERR! 
api_1        | npm ERR! Failed at the lodex@9.3.11 start script.
api_1        | npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
api_1        | 
api_1        | npm ERR! A complete log of this run can be found in:
[...]
make: *** [test-e2e] Error 1
The command "make test" exited with 2.
```