### PR TITLE
Fix compressed extended NQuads export

### DIFF
--- a/config.json
+++ b/config.json
@@ -72,9 +72,7 @@
     "linked": "categories.inist",
     "context": {
       "categories.inist": "istex:subjectInist",
-      "link": "dcterms:isPartOf",
-      "doi": "bibo:doi",
-      "fulltext[0].uri": "istex:accessURL"
+      "link": "dcterms:isPartOf"
     }
   },
   "sparqlEndpoints": [

--- a/src/api/exporters/exportExtendedNquadsCompressed.js
+++ b/src/api/exporters/exportExtendedNquadsCompressed.js
@@ -33,33 +33,30 @@ function ezsExport(data, feed) {
             }),
         )
         .pipe(ezs('ISTEXResult'))
+        .pipe(
+            ezs(function(d, f) {
+                if (this.isLast()) {
+                    return f.close();
+                }
+                const o = {
+                    lodex: {
+                        uri: data.uri,
+                    },
+                    content: d,
+                };
+                f.write(o);
+                f.send();
+            }),
+        )
+        .pipe(ezs('convertToExtendedJsonLd', { config }))
+        .pipe(ezs('convertJsonLdToNQuads'))
         .on('data', d => {
-            const o = {
-                lodex: {
-                    uri: data.uri,
-                },
-                content: d,
-            };
-            const subInput = ezs.createStream(ezs.objectMode());
-            subInput
-                .pipe(ezs('convertToExtendedJsonLd', { config }))
-                .pipe(ezs('convertJsonLdToNQuads'))
-                .on('data', d => {
-                    feed.write(d);
-                })
-                .on('end', () => feed.end())
-                .on('error', err => {
-                    console.error(err);
-                    feed.stop(err);
-                });
-
-            subInput.write(o);
-            subInput.end();
-            subInput.destroy();
+            feed.write(d);
         })
-        .on('close', () => feed.end())
+        .on('end', () => feed.end())
         .on('error', err => {
             console.error(err);
+            feed.stop(err);
         });
 }
 


### PR DESCRIPTION
The non-compressed and compressed code are too dissimilar to be honest.

The compressed export gives multiple:

```
Error while exporting published dataset into extendednquadscompressed Error [ERR_MULTIPLE_CALLBACK]: Callback called multiple times
    at Engine.afterTransform (_stream_transform.js:85:31)
    at Feed.end (/app/node_modules/ezs/lib/feed.js:32:18)
    at Engine.end (/app/src/api/exporters/exportExtendedNquadsCompressed.js:50:39)
    at Engine.emit (events.js:182:13)
    at endReadableNT (_stream_readable.js:1094:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)

  Error [ERR_MULTIPLE_CALLBACK]: Callback called multiple times
      at Engine.afterTransform (_stream_transform.js:85:31)
      at Feed.end (/app/node_modules/ezs/lib/feed.js:32:18)
      at Engine.end (/app/src/api/exporters/exportExtendedNquadsCompressed.js:50:39)
      at Engine.emit (events.js:182:13)
      at endReadableNT (_stream_readable.js:1094:12)
      at process._tickCallback (internal/process/next_tick.js:63:19)
```
