### PR TITLE
Fix triple exports (rdf:type)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5855,9 +5855,9 @@
             }
         },
         "ezs-istex": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/ezs-istex/-/ezs-istex-5.0.3.tgz",
-            "integrity": "sha512-GeZw9lXt//OYqzTiTBEJiozqRBZ73KsKVywt6zvx3tEDsXfMcAF2iTTR50iGyY57UdJ6mgAdp+QxZ61lAfbOeg==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/ezs-istex/-/ezs-istex-5.0.5.tgz",
+            "integrity": "sha512-Zov9JiipOPYv6D6ikf3Rghiphzz/SUhJn3EskbI28V7IzcVj2MRnyPYZbSD4fhgurve+1bjBtkM52ak1rI13LA==",
             "requires": {
                 "async.queue": "0.5.2",
                 "babel-runtime": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "ezs": "6.3.0",
         "ezs-analytics": "1.8.1",
         "ezs-basics": "3.6.7",
-        "ezs-istex": "5.0.3",
+        "ezs-istex": "5.0.5",
         "ezs-lodex": "1.1.2",
         "feed": "1.1.0",
         "fetch-with-proxy": "1.1.0",


### PR DESCRIPTION
To fix triples exports (rdf:type was using https instead of http).