### PR TITLE
Run tests in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,23 +30,23 @@ install:
 
 stages:
     - name: test
+      branches:
+          only:
+              - master
 
 jobs:
     include:
         - stage: test
           name: 'Unit Tests'
           env: NODE_ENV=test
-          script:
-              - make test-unit
+          script: make test-unit
 
         - stage: test
           name: 'API E2E Tests'
           env: NODE_ENV=test
-          script:
-              - make test-api-e2e
+          script: make test-api-e2e
 
         - stage: test
           name: 'E2E Tests'
           env: NODE_ENV=test
-          script:
-              - make test-e2e
+          script: make test-e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,15 @@ cache:
         - ~/node_modules/.cache/
         - ~/node_modules/.cache/@babel/register/
 
+branches:
+    only:
+        - master
+
 install:
     - make install
 
 stages:
     - name: test
-      branches:
-          only:
-              - master
 
 jobs:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
     - docker
 
 node_js:
-    - "10"
+    - '10'
 
 env:
     global:
@@ -25,9 +25,28 @@ cache:
         - ~/node_modules/.cache/
         - ~/node_modules/.cache/@babel/register/
 
-
 install:
-    - "make install"
+    - make install
 
-script:
-    - make test
+stages:
+    - name: test
+
+jobs:
+    include:
+        - stage: test
+          name: 'Unit Tests'
+          env: NODE_ENV=test
+          script:
+              - make test-unit
+
+        - stage: test
+          name: 'API E2E Tests'
+          env: NODE_ENV=test
+          script:
+              - make test-api-e2e
+
+        - stage: test
+          name: 'E2E Tests'
+          env: NODE_ENV=test
+          script:
+              - make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -97,15 +97,15 @@ test-e2e-stop-dockers:
 	docker-compose -f docker-compose.spec.yml down
 
 test-e2e-open-cypress:
-	NODE_ENV=e2e ./node_modules/.bin/cypress open
+	NODE_ENV=e2e npx cypress open
 
 test-e2e:
 ifeq "$(DISABLE_E2E_TESTS)" "true"
 	echo "E2E tests were disable because of the flag 'DISABLE_E2E_TESTS=true'"
 else
 	$(MAKE) test-e2e-start-dockers
-	./node_modules/.bin/cypress install
-	./bin/wait-for -t 30 localhost:3000 -- ./node_modules/.bin/cypress run --browser chrome || \
+	npx cypress install
+	./bin/wait-for -t 30 localhost:3000 -- npx cypress run --browser chrome || \
 		echo "ERROR: The API didn't start! Here are the logs:" && \
 		$(MAKE) test-e2e-logs && \
 		$(MAKE) test-e2e-stop-dockers && \


### PR DESCRIPTION
Travis tests take more than 20 minutes. That means we often wait more than 10 minutes to detect a bug. The solution is to run tests in parallel thanks to travis jobs.

## Todo

- [x] Create 3 travis jobs: unit, e2e and e2e api tests
