### PR TITLE
Resources Navigation - Temporary remove swipe left and right on mobile

### DIFF
--- a/src/app/js/public/resource/ResourceNavigation.js
+++ b/src/app/js/public/resource/ResourceNavigation.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect } from 'react';
+import React, { Fragment } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import compose from 'recompose/compose';
@@ -6,7 +6,6 @@ import { withRouter } from 'react-router-dom';
 
 import stylesToClassname from '../../lib/stylesToClassName';
 import NavButton, { NEXT, PREV } from '../../lib/components/NavButton';
-import useSwiper, { SWIPE_LEFT, SWIPE_RIGHT } from '../../lib/hooks/useSwiper';
 
 const styles = stylesToClassname(
     {
@@ -43,16 +42,6 @@ const ResourceNavigation = ({ history, prevResource, nextResource }) => {
     const nextLocation = buildLocationFromResource(nextResource);
 
     const navigate = location => history.push(location);
-
-    const direction = useSwiper();
-
-    useEffect(() => {
-        if (direction === SWIPE_LEFT && prevLocation) {
-            navigate(prevLocation);
-        } else if (direction === SWIPE_RIGHT && nextLocation) {
-            navigate(nextLocation);
-        }
-    }, [direction]);
 
     return (
         <Fragment>

--- a/src/app/js/public/search/sagas.js
+++ b/src/app/js/public/search/sagas.js
@@ -100,12 +100,11 @@ const handleLoadNextResource = function*() {
     }
 
     const currentResource = yield select(fromResource.getResourceLastVersion);
-    const nextResource = yield select(
-        fromSearch.getNextResource,
-        currentResource,
+    const indexCurrentResource = results.findIndex(
+        resource => resource.uri === currentResource.uri,
     );
 
-    if (nextResource != null) {
+    if (indexCurrentResource < results.length - 1) {
         return;
     }
 


### PR DESCRIPTION
[Trello Card #59](https://trello.com/c/2v3TolPe/59-navigation-pr%C3%A9c%C3%A9dent-suivant-sur-les-fiches-ressources)

Related to PR #952

Activate swiper leads to a bug in load more mechanism. So this feature is disabled at the moment and will be enabled later.

## Todo

- [x] Improve LoadMore method
- [x] Remove useSwiper hook