### PR TITLE
Home Page - Hide graphs that are not supposed to appear

### DIFF
--- a/src/app/js/characteristic/index.js
+++ b/src/app/js/characteristic/index.js
@@ -104,11 +104,7 @@ const getRootCharacteristics = createSelector(
                 ...field,
                 value: characteristics[field.name],
             }))
-            .filter(
-                field =>
-                    !field.completes &&
-                    (field.display_in_home || field.display_in_graph),
-            ),
+            .filter(field => !field.completes && !!field.display_in_home),
 );
 
 const getCharacteristicByName = createSelector(

--- a/src/app/js/characteristic/index.spec.js
+++ b/src/app/js/characteristic/index.spec.js
@@ -4,92 +4,149 @@ import reducer, {
     updateCharacteristics,
     updateCharacteristicsError,
     updateCharacteristicsSuccess,
+    selectors,
 } from './';
 
 import { loadPublicationSuccess } from '../fields';
 
-describe('characteristic reducer', () => {
-    it('should initialize with correct state', () => {
-        const state = reducer(undefined, { type: '@@INIT' });
-        expect(state).toEqual(defaultState);
+describe('characteristic', () => {
+    describe('reducer', () => {
+        it('should initialize with correct state', () => {
+            const state = reducer(undefined, { type: '@@INIT' });
+            expect(state).toEqual(defaultState);
+        });
+
+        it('should handle the LOAD_PUBLICATION_SUCCESS action', () => {
+            const action = loadPublicationSuccess({
+                characteristics: ['foo'],
+                fields: ['bar'],
+                published: true,
+            });
+
+            const state = reducer({ data: 'value' }, action);
+
+            expect(state).toEqual({
+                data: 'value',
+                characteristics: ['foo'],
+                newCharacteristics: 'foo',
+            });
+        });
+
+        it('should handle the SET_CHARACTERISTIC_VALUE action', () => {
+            const action = setCharacteristicValue({
+                name: 'name',
+                value: 'value',
+            });
+            const state = {
+                data: 'value',
+                newCharacteristics: {
+                    charac: 'data',
+                },
+            };
+
+            expect(reducer(state, action)).toEqual({
+                data: 'value',
+                newCharacteristics: {
+                    charac: 'data',
+                    name: 'value',
+                },
+            });
+        });
+
+        it('should handle the UPDATE_CHARACTERISTICS action', () => {
+            const action = updateCharacteristics();
+            const state = {
+                data: 'value',
+            };
+
+            expect(reducer(state, action)).toEqual({
+                data: 'value',
+                error: null,
+                isSaving: true,
+            });
+        });
+
+        it('should handle updateCharacteristicsError', () => {
+            const action = updateCharacteristicsError('error');
+            const state = {
+                data: 'value',
+            };
+
+            expect(reducer(state, action)).toEqual({
+                data: 'value',
+                error: 'error',
+                isSaving: false,
+            });
+        });
+
+        it('should handle updateCharacteristicsSuccess', () => {
+            const action = updateCharacteristicsSuccess({
+                characteristics: 'new',
+            });
+            const state = {
+                data: 'value',
+                characteristics: ['charac'],
+            };
+
+            expect(reducer(state, action)).toEqual({
+                data: 'value',
+                characteristics: ['new', 'charac'],
+                newCharacteristics: 'new',
+                error: null,
+                isSaving: false,
+            });
+        });
     });
 
-    it('should handle the LOAD_PUBLICATION_SUCCESS action', () => {
-        const action = loadPublicationSuccess({
-            characteristics: ['foo'],
-            fields: ['bar'],
-            published: true,
-        });
+    describe('selectors', () => {
+        describe('getRootCharacteristics', () => {
+            it('should return only characteristics that should be displayed in home', () => {
+                const state = {
+                    characteristics: [
+                        {
+                            lothal: 'ezra',
+                            mandalore: 'sabine',
+                            malachor: 'ahsoka',
+                        },
+                    ],
+                };
+                const fields = [
+                    {
+                        name: 'lothal',
+                        completes: false,
+                        display_in_home: true,
+                    },
+                    {
+                        name: 'mandalore',
+                        completes: false,
+                        display_in_home: false,
+                    },
+                    {
+                        name: 'malachor',
+                        completes: false,
+                        display_in_home: true,
+                    },
+                ];
 
-        const state = reducer({ data: 'value' }, action);
+                const characteristics = selectors.getRootCharacteristics(
+                    state,
+                    fields,
+                );
 
-        expect(state).toEqual({
-            data: 'value',
-            characteristics: ['foo'],
-            newCharacteristics: 'foo',
-        });
-    });
+                expect(characteristics.length).toEqual(2);
 
-    it('should handle the SET_CHARACTERISTIC_VALUE action', () => {
-        const action = setCharacteristicValue({
-            name: 'name',
-            value: 'value',
-        });
-        const state = {
-            data: 'value',
-            newCharacteristics: {
-                charac: 'data',
-            },
-        };
+                const c1 = characteristics[0];
+                expect(c1.name).toEqual('lothal');
+                expect(c1.completes).toEqual(false);
+                expect(c1.display_in_home).toEqual(true);
+                expect(c1.value).toEqual('ezra');
 
-        expect(reducer(state, action)).toEqual({
-            data: 'value',
-            newCharacteristics: {
-                charac: 'data',
-                name: 'value',
-            },
-        });
-    });
-
-    it('should handle the UPDATE_CHARACTERISTICS action', () => {
-        const action = updateCharacteristics();
-        const state = {
-            data: 'value',
-        };
-
-        expect(reducer(state, action)).toEqual({
-            data: 'value',
-            error: null,
-            isSaving: true,
-        });
-    });
-
-    it('should handle updateCharacteristicsError', () => {
-        const action = updateCharacteristicsError('error');
-        const state = {
-            data: 'value',
-        };
-
-        expect(reducer(state, action)).toEqual({
-            data: 'value',
-            error: 'error',
-            isSaving: false,
-        });
-    });
-
-    it('should handle updateCharacteristicsSuccess', () => {
-        const action = updateCharacteristicsSuccess({ characteristics: 'new' });
-        const state = {
-            data: 'value',
-            characteristics: ['charac'],
-        };
-
-        expect(reducer(state, action)).toEqual({
-            data: 'value',
-            characteristics: ['new', 'charac'],
-            newCharacteristics: 'new',
-            error: null,
-            isSaving: false,
+                const c2 = characteristics[1];
+                expect(c2.name).toEqual('malachor');
+                expect(c2.completes).toEqual(false);
+                expect(c2.display_in_home).toEqual(true);
+                expect(c2.value).toEqual('ahsoka');
+            });
         });
     });
 });


### PR DESCRIPTION
[Trello Card #4](https://trello.com/c/ptJ48Rqt/4-impossible-de-choisir-de-nafficher-aucun-graphique-dans-la-page-daccueil)

Refs. https://github.com/Inist-CNRS/lodex/pull/571

## Todo

- [x] Remove the condition `field.display_in_home || field.display_in_graph`

## Screenshots

**Before**

![Sélection_011](https://user-images.githubusercontent.com/5584839/66659626-27bade00-ec44-11e9-84da-11c4a30593d7.png)

**After**

![Sélection_010](https://user-images.githubusercontent.com/5584839/66659284-7d42bb00-ec43-11e9-9541-f9df52ed9d85.png)
