### PR TITLE
Fix the modal actions which are hidden by the menu

### DIFF
--- a/src/app/js/admin/Appbar/ModelMenu.js
+++ b/src/app/js/admin/Appbar/ModelMenu.js
@@ -107,12 +107,11 @@ export class ModelMenuComponent extends Component {
                         style={styles.button}
                     />
                 )}
-                {!hasPublishedDataset &&
-                    showImportFieldsConfirmation && (
-                        <ImportFieldsDialog
-                            onClose={this.handleImportFieldsClose}
-                        />
-                    )}
+                {!hasPublishedDataset && showImportFieldsConfirmation && (
+                    <ImportFieldsDialog
+                        onClose={this.handleImportFieldsClose}
+                    />
+                )}
             </div>
         );
     }
@@ -125,6 +124,9 @@ const mapDispatchToProps = {
 
 export default compose(
     withRouter,
-    connect(null, mapDispatchToProps),
+    connect(
+        null,
+        mapDispatchToProps,
+    ),
     translate,
 )(ModelMenuComponent);

--- a/src/app/js/fields/addField/AddField.js
+++ b/src/app/js/fields/addField/AddField.js
@@ -26,6 +26,10 @@ const mapDispatchToProps = {
     handleClose: () => addFieldToResourceCancel(),
 };
 
-export default compose(translate, connect(mapStateToProps, mapDispatchToProps))(
-    ButtonWithDialogForm,
-);
+export default compose(
+    translate,
+    connect(
+        mapStateToProps,
+        mapDispatchToProps,
+    ),
+)(ButtonWithDialogForm);

--- a/src/app/js/fields/wizard/index.js
+++ b/src/app/js/fields/wizard/index.js
@@ -36,6 +36,7 @@ const styles = {
     },
     modal: {
         maxWidth: '100%',
+        transform: 'translate(0px, 8px)',
     },
     column: {
         minWidth: '10rem',

--- a/src/app/js/lib/components/ButtonWithDialog.js
+++ b/src/app/js/lib/components/ButtonWithDialog.js
@@ -6,6 +6,12 @@ import Dialog from 'material-ui/Dialog';
 
 import { polyglot as polyglotPropTypes } from '../../propTypes';
 
+const styles = {
+    modal: {
+        transform: 'translate(0px, 8px)',
+    },
+};
+
 export const PureButtonWithDialog = ({
     handleClose,
     handleOpen,
@@ -48,6 +54,7 @@ export const PureButtonWithDialog = ({
                 open={open}
                 onRequestClose={handleClose}
                 autoScrollBodyContent
+                contentStyle={styles.modal}
             >
                 {dialog}
             </Dialog>

--- a/src/app/js/public/resource/HideResource.js
+++ b/src/app/js/public/resource/HideResource.js
@@ -28,6 +28,10 @@ const mapDispatchToProps = {
     handleClose: () => hideResourceCancel(),
 };
 
-export default compose(translate, connect(mapStateToProps, mapDispatchToProps))(
-    ButtonWithDialogForm,
-);
+export default compose(
+    translate,
+    connect(
+        mapStateToProps,
+        mapDispatchToProps,
+    ),
+)(ButtonWithDialogForm);


### PR DESCRIPTION
[Trello Card #62](https://trello.com/c/CtnQBHBD/62-bug-acc%C3%A8s-difficile-au-bouton-sauvegarder-de-la-modale-de-param%C3%A9trage-dun-champ)

Since the introduction of the new menu, it's impossible to click on the save buttons when opening a modal.

## Todo

- [x] Use the `contentStyle` prop to fix the issue in app modal

## Screenshots

**Before**

![Sélection_023](https://user-images.githubusercontent.com/5584839/66830493-e6814180-ef55-11e9-9074-a278b6105c82.png)

**After**

![Sélection_022](https://user-images.githubusercontent.com/5584839/66830363-9a360180-ef55-11e9-9acb-a68bdee5670e.png)