### PR TITLE
Breadcrumb - Improve its visibility

### DIFF
--- a/src/app/js/public/breadcrumb/Breadcrumb.js
+++ b/src/app/js/public/breadcrumb/Breadcrumb.js
@@ -2,13 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faAngleLeft } from '@fortawesome/free-solid-svg-icons';
 
+import theme from '../../theme';
 import { fromBreadcrumb } from '../selectors';
 import BreadcrumbItem from './BreadcrumbItem';
 import stylesToClassname from '../../lib/stylesToClassName';
 
 const styles = stylesToClassname(
     {
+        root: {
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'flex-start',
+        },
+        icon: {
+            color: theme.green.primary,
+            margin: '5px 0px',
+        },
         trail: {
             margin: '5px 0px',
         },
@@ -31,7 +43,12 @@ export const Breadcrumb = ({ breadcrumb, location }) => {
         : breadcrumb;
 
     return (
-        <div>
+        <div className={styles.root}>
+            <FontAwesomeIcon
+                className={styles.icon}
+                icon={faAngleLeft}
+                height={20}
+            />
             <div className={styles.trail}>
                 {items.map((item, index) => (
                     <>


### PR DESCRIPTION
[Trello Card #73](https://trello.com/c/HhA8RxLS/73-fil-dariane-ssr)

Breadcrumb is not clear enough. The solution is to display an icon before.

## Todo

- [x] Display an icon before the breadcrumb

## Screenshots

![Sélection_003](https://user-images.githubusercontent.com/5584839/67098777-12eac700-f1bd-11e9-98c5-d01458f0cfd0.png)
