### PR TITLE
Resource Navigation - Search Results take the whole space available when there is no facets 

### DIFF
--- a/src/app/js/public/search/Search.js
+++ b/src/app/js/public/search/Search.js
@@ -315,11 +315,17 @@ class Search extends Component {
                         styles.searchContent,
                     )}
                 >
-                    <Facets
-                        className={classnames('search-facets', styles.facets, {
-                            [styles.facetsOpening]: showFacets,
-                        })}
-                    />
+                    {withFacets && (
+                        <Facets
+                            className={classnames(
+                                'search-facets',
+                                styles.facets,
+                                {
+                                    [styles.facetsOpening]: showFacets,
+                                },
+                            )}
+                        />
+                    )}
 
                     <div
                         className={classnames(

--- a/src/app/js/public/search/SearchResult.js
+++ b/src/app/js/public/search/SearchResult.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -72,100 +72,91 @@ const styles = stylesToClassname(
     'search-result',
 );
 
-class SearchResult extends Component {
-    shouldComponentUpdate(nextProps) {
-        return nextProps.result.uri !== this.props.result.uri;
-    }
-    render() {
-        const { fields, fieldNames, result, closeDrawer } = this.props;
-        const titleField = fields.find(
-            field => field.name === fieldNames.title,
-        );
-        const descriptionField = fields.find(
-            field => field.name === fieldNames.description,
-        );
-        const firstDetailField = fields.find(
-            field => field.name === fieldNames.detail1,
-        );
-        const secondDetailField = fields.find(
-            field => field.name === fieldNames.detail2,
-        );
+const SearchResult = ({ fields, fieldNames, result, closeDrawer }) => {
+    const titleField = fields.find(field => field.name === fieldNames.title);
+    const descriptionField = fields.find(
+        field => field.name === fieldNames.description,
+    );
+    const firstDetailField = fields.find(
+        field => field.name === fieldNames.detail1,
+    );
+    const secondDetailField = fields.find(
+        field => field.name === fieldNames.detail2,
+    );
 
-        const shouldDisplayDetails =
-            (firstDetailField && result[firstDetailField.name]) ||
-            (secondDetailField && result[secondDetailField.name]);
+    const shouldDisplayDetails =
+        (firstDetailField && result[firstDetailField.name]) ||
+        (secondDetailField && result[secondDetailField.name]);
 
-        return (
-            <Link
-                routeAware
-                to={getResourceUri(result)}
-                className={classnames('search-result-link', styles.link)}
-                onClick={closeDrawer}
-                activeClassName={styles.activeLink}
+    return (
+        <Link
+            to={getResourceUri(result)}
+            routeAware
+            className={classnames('search-result-link', styles.link)}
+            onClick={closeDrawer}
+            activeClassName={styles.activeLink}
+        >
+            <div
+                id={`search-result-${result.uri}`}
+                className={classnames('search-result', styles.container)}
             >
-                <div
-                    id={`search-result-${result.uri}`}
-                    className={classnames('search-result', styles.container)}
-                >
-                    {titleField && result[titleField.name] && (
-                        <div
-                            className={classnames(
-                                'search-result-title',
-                                styles.title,
-                            )}
-                            title={result[titleField.name]}
-                        >
-                            {result[titleField.name]}
-                        </div>
-                    )}
-                    {descriptionField && result[descriptionField.name] && (
-                        <div
-                            className={classnames(
-                                'search-result-description',
-                                styles.description,
-                            )}
-                            title={result[descriptionField.name]}
-                        >
-                            {result[descriptionField.name]}
-                        </div>
-                    )}
-                    {shouldDisplayDetails && (
-                        <div
-                            className={classnames(
-                                'search-result-details',
-                                styles.details,
-                            )}
-                        >
-                            {firstDetailField && result[firstDetailField.name] && (
-                                <div
-                                    className={classnames(
-                                        'search-result-detail1',
-                                        styles.detailsColumn,
-                                    )}
-                                    title={result[firstDetailField.name]}
-                                >
-                                    {result[firstDetailField.name]}
-                                </div>
-                            )}
-                            {secondDetailField &&
-                                result[secondDetailField.name] && (
-                                    <div
-                                        className={classnames(
-                                            'search-result-detail2',
-                                            styles.detailsColumn,
-                                        )}
-                                        title={result[secondDetailField.name]}
-                                    >
-                                        {result[secondDetailField.name]}
-                                    </div>
+                {titleField && result[titleField.name] && (
+                    <div
+                        className={classnames(
+                            'search-result-title',
+                            styles.title,
+                        )}
+                        title={result[titleField.name]}
+                    >
+                        {result[titleField.name]}
+                    </div>
+                )}
+                {descriptionField && result[descriptionField.name] && (
+                    <div
+                        className={classnames(
+                            'search-result-description',
+                            styles.description,
+                        )}
+                        title={result[descriptionField.name]}
+                    >
+                        {result[descriptionField.name]}
+                    </div>
+                )}
+                {shouldDisplayDetails && (
+                    <div
+                        className={classnames(
+                            'search-result-details',
+                            styles.details,
+                        )}
+                    >
+                        {firstDetailField && result[firstDetailField.name] && (
+                            <div
+                                className={classnames(
+                                    'search-result-detail1',
+                                    styles.detailsColumn,
                                 )}
-                        </div>
-                    )}
-                </div>
-            </Link>
-        );
-    }
-}
+                                title={result[firstDetailField.name]}
+                            >
+                                {result[firstDetailField.name]}
+                            </div>
+                        )}
+                        {secondDetailField && result[secondDetailField.name] && (
+                            <div
+                                className={classnames(
+                                    'search-result-detail2',
+                                    styles.detailsColumn,
+                                )}
+                                title={result[secondDetailField.name]}
+                            >
+                                {result[secondDetailField.name]}
+                            </div>
+                        )}
+                    </div>
+                )}
+            </div>
+        </Link>
+    );
+};
 
 SearchResult.propTypes = {
     fields: PropTypes.arrayOf(fieldProptypes).isRequired,
@@ -180,4 +171,7 @@ SearchResult.propTypes = {
     closeDrawer: PropTypes.func.isRequired,
 };
 
-export default SearchResult;
+export default memo(
+    SearchResult,
+    (prevProps, nextProps) => prevProps.result.uri === nextProps.result.uri,
+);


### PR DESCRIPTION
[Trello Card #87](https://trello.com/c/LJpKsKOF/87-un-espace-blanc-est-r%C3%A9serv%C3%A9-pour-les-facettes-dans-le-panneau-de-recherche-m%C3%AAme-sil-ny-en-a-pas-%C3%A0-afficher)

Sometimes there is no facets to display in the search, but some space is still reserved for facets.

## Todo

- [x] Don't display the facets block when there is nothing to display in

## Screenshots

**Before- Desktop without facets**

![Sélection_008](https://user-images.githubusercontent.com/5584839/67272687-49765980-f4bd-11e9-8e3b-abc6280cfb3e.png)

**After - Desktop without facets**

![Sélection_005](https://user-images.githubusercontent.com/5584839/67271929-d02a3700-f4bb-11e9-94c4-604acf0bd7ed.png)

**After - Desktop with facets (no changes)**

![Sélection_006](https://user-images.githubusercontent.com/5584839/67271934-d28c9100-f4bb-11e9-9153-de57d9b7cbfd.png)

**After - Mobile with facets (no changes)**

![Sélection_007](https://user-images.githubusercontent.com/5584839/67271937-d5878180-f4bb-11e9-944a-1a48328f6c3e.png)
