### PR TITLE
Load loaders dynamically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,10 @@ else
 		exit 1)
 endif
 
-test: test-unit test-api-e2e test-e2e
+test: ## Run all tests
+	$(MAKE) test-unit
+	$(MAKE) test-api-e2e
+	CI=true $(MAKE) test-e2e
 
 ## Data ========================================================================
 

--- a/cypress/integration/publication.spec.js
+++ b/cypress/integration/publication.spec.js
@@ -1,5 +1,6 @@
 import { teardown } from '../support/authentication';
 import * as homePage from '../support/homePage';
+import * as adminPage from '../support/adminPage';
 import * as datasetImportPage from '../support/datasetImportPage';
 import { fillInputWithFixture } from '../support/forms';
 import * as searchDrawer from '../support/searchDrawer';
@@ -8,6 +9,17 @@ describe('Dataset Publication', () => {
     beforeEach(teardown);
 
     describe('Dataset Import', () => {
+        it('should get the list of possible loaders', () => {
+            homePage.openAdvancedDrawer();
+            homePage.goToAdminDashboard();
+            adminPage.checkListOfSupportedFileFormats();
+
+            datasetImportPage.openImportDialog();
+            cy.wait(300);
+
+            datasetImportPage.checkListOfSupportedFileFormats();
+        });
+
         it('should receive a csv file and preview its data in a table', () => {
             homePage.openAdvancedDrawer();
             homePage.goToAdminDashboard();

--- a/cypress/support/adminPage.js
+++ b/cypress/support/adminPage.js
@@ -1,0 +1,7 @@
+export const checkListOfSupportedFileFormats = () => {
+    cy.get('.upload')
+        .contains(
+            'List of supported file formats: csv, csv-semicolon, csv-comma, tsv, tsv-double-quotes, rdf, skos, json, json-istex, json-lodex, ini, atom, mods, tei, xml, corpus, zip',
+        )
+        .should('be.visible');
+};

--- a/cypress/support/datasetImportPage.js
+++ b/cypress/support/datasetImportPage.js
@@ -109,3 +109,23 @@ export const importModel = (filename, mimeType = 'application/json') => {
     cy.get('button.btn-import-fields').click();
     fillInputWithFixture('input[name="file_model"]', filename, mimeType);
 };
+
+export const checkListOfSupportedFileFormats = () => {
+    cy.get('div')
+        .contains('AUTO')
+        .click({ force: true });
+    cy.wait(300);
+    cy.get('span[role=menuitem]').should('have.length', 18);
+    checkParserItemm('CSV - with semicolon');
+    checkParserItemm('XML - TEI document');
+    checkParserItemm('ZIP file from dl.istex.fr');
+    checkParserItemm('JSON - from Lodex API');
+    checkParserItemm('XML - ATOM feed');
+};
+
+const checkParserItemm = label => {
+    cy.get('span[role=menuitem]')
+        .contains(label)
+        .scrollIntoView()
+        .should('be.visible');
+};

--- a/cypress/support/datasetImportPage.js
+++ b/cypress/support/datasetImportPage.js
@@ -110,22 +110,22 @@ export const importModel = (filename, mimeType = 'application/json') => {
     fillInputWithFixture('input[name="file_model"]', filename, mimeType);
 };
 
+const checkParserItem = label => {
+    cy.get('span[role=menuitem]')
+        .contains(label)
+        .scrollIntoView()
+        .should('be.visible');
+};
+
 export const checkListOfSupportedFileFormats = () => {
     cy.get('div')
         .contains('AUTO')
         .click({ force: true });
     cy.wait(300);
     cy.get('span[role=menuitem]').should('have.length', 18);
-    checkParserItemm('CSV - with semicolon');
-    checkParserItemm('XML - TEI document');
-    checkParserItemm('ZIP file from dl.istex.fr');
-    checkParserItemm('JSON - from Lodex API');
-    checkParserItemm('XML - ATOM feed');
-};
-
-const checkParserItemm = label => {
-    cy.get('span[role=menuitem]')
-        .contains(label)
-        .scrollIntoView()
-        .should('be.visible');
+    checkParserItem('CSV - with semicolon');
+    checkParserItem('XML - TEI document');
+    checkParserItem('ZIP file from dl.istex.fr');
+    checkParserItem('JSON - from Lodex API');
+    checkParserItem('XML - ATOM feed');
 };

--- a/src/api/controller/api/export.js
+++ b/src/api/controller/api/export.js
@@ -120,9 +120,7 @@ export async function exportFileMiddleware(
 export async function exportWidgetMiddleware(ctx, type) {
     const fields = encodeURIComponent(JSON.stringify(ctx.query.fields));
     const uri = encodeURIComponent(ctx.query.uri);
-    const widgetUrl = `${
-        config.host
-    }/api/widget?type=${type}&fields=${fields}&uri=${uri}`;
+    const widgetUrl = `${config.host}/api/widget?type=${type}&fields=${fields}&uri=${uri}`;
 
     ctx.body = widgetUrl;
 }

--- a/src/api/controller/api/index.js
+++ b/src/api/controller/api/index.js
@@ -22,6 +22,7 @@ import run from './run';
 import progress from './progress';
 import breadcrumbs from './breadcrumb';
 import menu from './menu';
+import loader from './loader';
 
 const app = new Koa();
 
@@ -103,6 +104,7 @@ app.use(mount('/publish', publish));
 app.use(mount('/upload', upload));
 app.use(mount('/dataset', dataset));
 app.use(route.get('/progress', progress));
+app.use(mount('/loader', loader));
 
 app.use(async ctx => {
     ctx.status = 404;

--- a/src/api/controller/api/loader.js
+++ b/src/api/controller/api/loader.js
@@ -1,0 +1,88 @@
+import Koa from 'koa';
+import route from 'koa-route';
+import ezs from '@ezs/core';
+import ezsLodex from '@ezs/lodex';
+import { getHost, getCleanHost } from '../../../common/uris';
+import config from '../../../../config.json';
+
+import Script from '../../services/script';
+
+const loaders = new Script('loaders');
+
+ezs.use(ezsLodex);
+
+export const getLoader = async type => {
+    const loader = await loaders.get(type);
+    if (!loader) {
+        throw new Error(`Unsupported document type: ${type}`);
+    }
+
+    const [, metaData, , script] = loader;
+
+    const loaderStreamFactory = (config, fields, characteristics, stream) =>
+        stream
+            .pipe(ezs('filterVersions'))
+            .pipe(ezs('filterContributions', { fields }))
+            .pipe(
+                ezs(
+                    'delegate',
+                    { script },
+                    {
+                        cleanHost: config.cleanHost,
+                        collectionClass: config.collectionClass,
+                        datasetClass: config.datasetClass,
+                        exportDataset: config.exportDataset,
+                        schemeForDatasetLink: config.schemeForDatasetLink,
+                        labels: config.istexQuery.labels,
+                        linked: config.istexQuery.linked,
+                        context: config.istexQuery.context,
+                        fields,
+                        characteristics,
+                    },
+                ),
+            );
+
+    loaderStreamFactory.extension = metaData.extension;
+    loaderStreamFactory.mimeType = metaData.mimeType;
+    loaderStreamFactory.type = metaData.type;
+    loaderStreamFactory.label = metaData.label;
+
+    return loaderStreamFactory;
+};
+
+export const getLoadersConfig = () => ({
+    ...config,
+    host: getCleanHost(),
+    rawHost: getHost(),
+    cleanHost: getCleanHost(),
+});
+
+export async function setup(ctx, next) {
+    ctx.getLoader = getLoader;
+    ctx.getLoadersConfig = getLoadersConfig;
+    await next();
+}
+
+export async function getLoaders(ctx) {
+    const configuredLoaders = config.loaders || [];
+
+    const availableLoaderStreamFactoryPromises = configuredLoaders.map(loader =>
+        ctx.getLoader(loader),
+    );
+    const availableLoaders = await Promise.all(
+        availableLoaderStreamFactoryPromises,
+    );
+
+    ctx.body = availableLoaders
+        .filter(loader => loader.label !== undefined)
+        .map(loader => ({
+            name: loader.label,
+        }));
+}
+
+const app = new Koa();
+
+app.use(setup);
+app.use(route.get('/', getLoaders));
+
+export default app;

--- a/src/api/controller/api/run.js
+++ b/src/api/controller/api/run.js
@@ -65,9 +65,7 @@ export const runRoutine = async (ctx, routineCalled, field1, field2) => {
     if (filter.$and && !filter.$and.length) {
         delete filter.$and;
     }
-    const connectionStringURI = `mongodb://${config.mongo.host}/${
-        config.mongo.dbName
-    }`;
+    const connectionStringURI = `mongodb://${config.mongo.host}/${config.mongo.dbName}`;
     // context is the intput for LodexReduceQuery & LodexRunQuery & LodexDocuments
     const context = {
         // /*

--- a/src/api/controller/api/upload.js
+++ b/src/api/controller/api/upload.js
@@ -196,9 +196,7 @@ export const checkChunkMiddleware = async ctx => {
         resumableIdentifier,
         resumableCurrentChunkSize,
     } = ctx.request.query;
-    const chunkname = `${
-        config.uploadDir
-    }/${resumableIdentifier}.${resumableChunkNumber}`;
+    const chunkname = `${config.uploadDir}/${resumableIdentifier}.${resumableChunkNumber}`;
     const exists = await checkFileExists(chunkname, resumableCurrentChunkSize);
     ctx.status = exists ? 200 : 204;
 };

--- a/src/app/js/admin/Admin.js
+++ b/src/app/js/admin/Admin.js
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import compose from 'recompose/compose';
+import { compose, lifecycle } from 'recompose';
 import { connect } from 'react-redux';
 import translate from 'redux-polyglot/translate';
 
@@ -30,11 +30,10 @@ export const AdminComponent = ({
     hasPublishedDataset,
     canUploadFile,
     p: polyglot,
-    preLoadLoaders,
 }) => {
-    useEffect(() => {
+    /* useEffect(() => {
         preLoadLoaders();
-    }, []);
+    }, []);*/
 
     if (loadingParsingResult) {
         return (
@@ -95,5 +94,10 @@ export default compose(
         mapStateToProps,
         mapDispatchToProps,
     ),
+    lifecycle({
+        componentWillMount() {
+            this.props.preLoadLoaders();
+        },
+    }),
     translate,
 )(AdminComponent);

--- a/src/app/js/admin/Admin.js
+++ b/src/app/js/admin/Admin.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import compose from 'recompose/compose';
 import { connect } from 'react-redux';
@@ -15,6 +15,7 @@ import Loading from '../lib/components/Loading';
 import Card from '../lib/components/Card';
 import Statistics from './Statistics';
 import theme from '../theme';
+import { preLoadLoaders } from './loader/';
 
 const styles = {
     punchLine: {
@@ -29,7 +30,12 @@ export const AdminComponent = ({
     hasPublishedDataset,
     canUploadFile,
     p: polyglot,
+    preLoadLoaders,
 }) => {
+    useEffect(() => {
+        preLoadLoaders();
+    }, []);
+
     if (loadingParsingResult) {
         return (
             <Loading className="admin">
@@ -79,8 +85,15 @@ const mapStateToProps = state => ({
     hasPublishedDataset: fromPublication.hasPublishedDataset(state),
 });
 
+const mapDispatchToProps = {
+    preLoadLoaders,
+};
+
 export default compose(
     withInitialData,
-    connect(mapStateToProps),
+    connect(
+        mapStateToProps,
+        mapDispatchToProps,
+    ),
     translate,
 )(AdminComponent);

--- a/src/app/js/admin/Admin.js
+++ b/src/app/js/admin/Admin.js
@@ -31,10 +31,6 @@ export const AdminComponent = ({
     canUploadFile,
     p: polyglot,
 }) => {
-    /* useEffect(() => {
-        preLoadLoaders();
-    }, []);*/
-
     if (loadingParsingResult) {
         return (
             <Loading className="admin">

--- a/src/app/js/admin/Appbar/index.js
+++ b/src/app/js/admin/Appbar/index.js
@@ -72,22 +72,20 @@ const AppbarComponent = ({
                     )}
                 />
             )}
-            {isAdmin &&
-                hasPublishedDataset && (
-                    <FlatButton
-                        label={polyglot.t('moderation')}
-                        containerElement={<Link to="/contributions" />}
-                        style={styles.button}
-                    />
-                )}
-            {isAdmin &&
-                hasPublishedDataset && (
-                    <FlatButton
-                        label={polyglot.t('removed_resources')}
-                        containerElement={<Link to="/removed" />}
-                        style={styles.button}
-                    />
-                )}
+            {isAdmin && hasPublishedDataset && (
+                <FlatButton
+                    label={polyglot.t('moderation')}
+                    containerElement={<Link to="/contributions" />}
+                    style={styles.button}
+                />
+            )}
+            {isAdmin && hasPublishedDataset && (
+                <FlatButton
+                    label={polyglot.t('removed_resources')}
+                    containerElement={<Link to="/removed" />}
+                    style={styles.button}
+                />
+            )}
             {isAdmin ? (
                 <ModelMenu hasPublishedDataset={hasPublishedDataset} />
             ) : (

--- a/src/app/js/admin/loader/index.js
+++ b/src/app/js/admin/loader/index.js
@@ -1,0 +1,48 @@
+import { createAction, handleActions } from 'redux-actions';
+
+export const PRE_LOAD_LOADERS = 'PRE_LOAD_LOADERS';
+export const LOAD_LOADERS = 'LOAD_LOADERS';
+export const LOAD_LOADERS_ERROR = 'LOAD_LOADERS_ERROR';
+export const LOAD_LOADERS_SUCCESS = 'LOAD_LOADERS_SUCCESS';
+
+export const preLoadLoaders = createAction(PRE_LOAD_LOADERS);
+export const loadLoaders = createAction(LOAD_LOADERS);
+export const loadLoadersError = createAction(LOAD_LOADERS_ERROR);
+export const loadLoadersSuccess = createAction(LOAD_LOADERS_SUCCESS);
+
+const initialState = {
+    error: false,
+    loading: false,
+    loaders: [],
+};
+
+export default handleActions(
+    {
+        [LOAD_LOADERS]: state => ({
+            ...state,
+            error: false,
+            loading: true,
+        }),
+        [LOAD_LOADERS_ERROR]: (state, { payload: error }) => ({
+            ...state,
+            error,
+            loading: false,
+        }),
+        [LOAD_LOADERS_SUCCESS]: (state, { payload: loaders }) => ({
+            ...state,
+            error: false,
+            loaders,
+            loading: false,
+        }),
+    },
+    initialState,
+);
+
+export const getLoaders = state => state.loaders;
+export const areLoadersLoaded = state => getLoaders(state).length > 0;
+
+export const selectors = {
+    preLoadLoaders,
+    areLoadersLoaded,
+    getLoaders,
+};

--- a/src/app/js/admin/loader/sagas/index.js
+++ b/src/app/js/admin/loader/sagas/index.js
@@ -1,0 +1,6 @@
+import { fork } from 'redux-saga/effects';
+import loadLoaders from './loadLoaders';
+
+export default function*() {
+    yield fork(loadLoaders);
+}

--- a/src/app/js/admin/loader/sagas/loadLoaders.js
+++ b/src/app/js/admin/loader/sagas/loadLoaders.js
@@ -1,0 +1,31 @@
+import { call, takeEvery, select, put } from 'redux-saga/effects';
+
+import {
+    PRE_LOAD_LOADERS,
+    loadLoaders,
+    loadLoadersError,
+    loadLoadersSuccess,
+} from '..';
+import { fromUser } from '../../../sharedSelectors';
+import { fromLoaders } from '../../selectors';
+import fetchSaga from '../../../lib/sagas/fetchSaga';
+
+export function* handleLoadLoaders() {
+    if (yield select(fromLoaders.areLoadersLoaded)) {
+        return;
+    }
+    yield put(loadLoaders());
+    const request = yield select(fromUser.getLoadLoadersRequest);
+    const { response, error } = yield call(fetchSaga, request);
+
+    if (error) {
+        yield put(loadLoadersError(error));
+        return;
+    }
+
+    yield put(loadLoadersSuccess(response));
+}
+
+export default function*() {
+    yield takeEvery(PRE_LOAD_LOADERS, handleLoadLoaders);
+}

--- a/src/app/js/admin/loader/sagas/loadLoaders.js
+++ b/src/app/js/admin/loader/sagas/loadLoaders.js
@@ -11,9 +11,11 @@ import { fromLoaders } from '../../selectors';
 import fetchSaga from '../../../lib/sagas/fetchSaga';
 
 export function* handleLoadLoaders() {
-    if (yield select(fromLoaders.areLoadersLoaded)) {
+    const loadersAlreadyLoaded = yield select(fromLoaders.areLoadersLoaded);
+    if (loadersAlreadyLoaded) {
         return;
     }
+
     yield put(loadLoaders());
     const request = yield select(fromUser.getLoadLoadersRequest);
     const { response, error } = yield call(fetchSaga, request);

--- a/src/app/js/admin/reducers.js
+++ b/src/app/js/admin/reducers.js
@@ -17,6 +17,7 @@ import contributedResources from './contributedResources';
 import clear from './clear';
 import characteristic from '../characteristic';
 import progress from './progress/reducer';
+import loaders from './loader';
 
 const reducer = combineReducers({
     fetch: fetchReducer,
@@ -36,6 +37,7 @@ const reducer = combineReducers({
     contributedResources,
     characteristic,
     progress,
+    loaders,
 });
 
 export default reducer;

--- a/src/app/js/admin/sagas.js
+++ b/src/app/js/admin/sagas.js
@@ -17,6 +17,7 @@ import i18nSagas from '../i18n/sagas';
 import clearSaga from './clear/sagas';
 import progressSaga from './progress/sagas';
 import characteristicSaga from '../characteristic/sagas';
+import loaderSaga from './loader/sagas';
 
 export default function*() {
     yield fork(exportSaga);
@@ -36,4 +37,5 @@ export default function*() {
     yield fork(clearSaga);
     yield fork(progressSaga);
     yield fork(characteristicSaga);
+    yield fork(loaderSaga);
 }

--- a/src/app/js/admin/selectors.js
+++ b/src/app/js/admin/selectors.js
@@ -11,6 +11,7 @@ import { selectors as uploadSelectors } from './upload';
 import { selectors as contributedResourcesSelectors } from './contributedResources';
 import { selectors as clearSelectors } from './clear';
 import { selectors as progressSelectors } from './progress/reducer';
+import { selectors as loaderSelectors } from './loader';
 
 export const fromParsing = createGlobalSelectors(
     s => s.parsing,
@@ -46,4 +47,8 @@ export const fromContributedResources = createGlobalSelectors(
 export const fromProgress = createGlobalSelectors(
     s => s.progress,
     progressSelectors,
+);
+export const fromLoaders = createGlobalSelectors(
+    s => s.loaders,
+    loaderSelectors,
 );

--- a/src/app/js/admin/upload/Upload.js
+++ b/src/app/js/admin/upload/Upload.js
@@ -68,7 +68,8 @@ export const UploadComponent = ({
                 label={polyglot.t('first-upload')}
             />
             <p>
-                {polyglot.t('supported_format_list') loaders.map(loader => loader.name).join(', ')}
+                {polyglot.t('supported_format_list')}{' '}
+                {loaders.map(loader => loader.name).join(', ')}
             </p>
         </div>
     </div>
@@ -97,7 +98,7 @@ const mapDispatchToProps = {
 export default compose(
     connect(
         mapsStateToProps,
-        mapDispatchToProps,
+        mapDispatchToProps
     ),
-    translate,
+    translate
 )(UploadComponent);

--- a/src/app/js/admin/upload/Upload.js
+++ b/src/app/js/admin/upload/Upload.js
@@ -9,7 +9,7 @@ import { lightBlue500 } from 'material-ui/styles/colors';
 
 import Alert from '../../lib/components/Alert';
 import { uploadFile } from './';
-import { fromUpload } from '../selectors';
+import { fromUpload, fromLoaders } from '../selectors';
 import { polyglot as polyglotPropTypes } from '../../propTypes';
 import UploadButton from './UploadButton';
 
@@ -46,6 +46,7 @@ export const UploadComponent = ({
     onFileLoad,
     error,
     p: polyglot,
+    loaders,
     ...props
 }) => (
     <div className={classnames('upload', props.className)} style={styles.div}>
@@ -67,7 +68,7 @@ export const UploadComponent = ({
                 label={polyglot.t('first-upload')}
             />
             <p>
-                {polyglot.t('supported_format_list')} {LOADERS.join(', ')}
+                {polyglot.t('supported_format_list') loaders.map(loader => loader.name).join(', ')}
             </p>
         </div>
     </div>
@@ -86,6 +87,7 @@ UploadComponent.defaultProps = {
 
 const mapsStateToProps = state => ({
     ...fromUpload.getUpload(state),
+    loaders: fromLoaders.getLoaders(state),
 });
 
 const mapDispatchToProps = {
@@ -93,6 +95,9 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(mapsStateToProps, mapDispatchToProps),
+    connect(
+        mapsStateToProps,
+        mapDispatchToProps,
+    ),
     translate,
 )(UploadComponent);

--- a/src/app/js/admin/upload/Upload.spec.js
+++ b/src/app/js/admin/upload/Upload.spec.js
@@ -6,15 +6,12 @@ import Alert from '../../lib/components/Alert';
 import { UploadComponent as Upload } from './Upload';
 
 describe('<Upload />', () => {
-    beforeAll(() => {
-        global.LOADERS = [];
-    });
-
     it('should render the Upload button with no error', () => {
         const props = {
             p: { t: key => key },
             error: false,
             onFileLoad() {},
+            loaders: [],
         };
         const wrapper = shallow(<Upload {...props} />);
 
@@ -36,6 +33,7 @@ describe('<Upload />', () => {
             p: { t: key => key },
             error: 'Boom',
             onFileLoad() {},
+            loaders: [],
         };
         const wrapper = shallow(<Upload {...props} />);
 
@@ -47,9 +45,5 @@ describe('<Upload />', () => {
                 </Alert>,
             ),
         ).toBe(true);
-    });
-
-    afterAll(() => {
-        delete global.LOADERS;
     });
 });

--- a/src/app/js/admin/upload/UploadDialog.js
+++ b/src/app/js/admin/upload/UploadDialog.js
@@ -11,7 +11,7 @@ import MenuItem from 'material-ui/MenuItem';
 
 import { polyglot as polyglotPropTypes } from '../../propTypes';
 import { uploadFile, changeUploadUrl, changeParserName, uploadUrl } from './';
-import { fromUpload } from '../selectors';
+import { fromUpload, fromLoaders } from '../selectors';
 
 const styles = {
     button: {
@@ -53,10 +53,14 @@ export const UploadDialogComponent = ({
     onFileLoad,
     onUrlUpload,
     p: polyglot,
+    loaders,
 }) => {
-    const parserNames = LOADERS.sort((x, y) =>
-        polyglot.t(x).localeCompare(polyglot.t(y)),
-    ).map(pn => <MenuItem key={pn} value={pn} primaryText={polyglot.t(pn)} />);
+    const parserNames = loaders
+        .map(loader => loader.name)
+        .sort((x, y) => polyglot.t(x).localeCompare(polyglot.t(y)))
+        .map(pn => (
+            <MenuItem key={pn} value={pn} primaryText={polyglot.t(pn)} />
+        ));
 
     return (
         <div>
@@ -153,6 +157,7 @@ const mapStateToProps = state => ({
     url: fromUpload.getUrl(state),
     isUrlValid: fromUpload.isUrlValid(state),
     parserName: fromUpload.getParserName(state),
+    loaders: fromLoaders.getLoaders(state),
 });
 
 const mapDispatchToProps = {

--- a/src/app/js/configureStore.js
+++ b/src/app/js/configureStore.js
@@ -24,9 +24,10 @@ export default function configureStore(
           }
         : pureReducer;
 
-    const reducer = compose(mergePersistedState(), connectRouter(history))(
-        rootReducer,
-    );
+    const reducer = compose(
+        mergePersistedState(),
+        connectRouter(history),
+    )(rootReducer);
 
     const storage = compose(filter('user'))(adapter(window.sessionStorage));
 
@@ -45,7 +46,11 @@ export default function configureStore(
     const store = createStore(
         reducer,
         initialState,
-        compose(middlewares, persistStateEnhancer, devtools),
+        compose(
+            middlewares,
+            persistStateEnhancer,
+            devtools,
+        ),
     );
 
     sagaMiddleware.run(sagas);

--- a/src/app/js/configureStoreServer.js
+++ b/src/app/js/configureStoreServer.js
@@ -23,7 +23,10 @@ export default function configureStoreServer(
     const store = createStore(
         connectRouter(history)(reducer),
         initialState,
-        compose(middlewares, devtools),
+        compose(
+            middlewares,
+            devtools,
+        ),
     );
 
     sagaMiddleware.run(sagas);

--- a/src/app/js/user/index.js
+++ b/src/app/js/user/index.js
@@ -377,6 +377,11 @@ export const getMenuRequest = state =>
         url: '/api/menu',
     });
 
+export const getLoadLoadersRequest = state =>
+    getRequest(state, {
+        url: '/api/loader',
+    });
+
 export const selectors = {
     isAdmin,
     getRole,
@@ -422,4 +427,5 @@ export const selectors = {
     getIstexRequest,
     getMenuRequest,
     getBreadcrumbRequest,
+    getLoadLoadersRequest,
 };


### PR DESCRIPTION
[Trello Card #5](https://trello.com/c/1XCtwe9p/5-impossible-dajouter-dynamiquement-un-nouveau-loader-alors-que-lon-peut-ajouter-une-routine)

It's possible to add a routine dynamically, but not a loader. The objective is to inject new loaders without creating a new version of loadex.

## Todo

- [x] Add loader dynamically
- [x] Add tests