### PR TITLE
Resource - Fix the view of resources which contain an empty list

### DIFF
--- a/src/app/js/formats/list/ListView.js
+++ b/src/app/js/formats/list/ListView.js
@@ -59,7 +59,11 @@ const ListView = ({
     subFormat,
     subFormatOptions,
 }) => {
-    let values = resource[field.name];
+    const values = resource[field.name];
+    if (values == null || values === '' || !Array.isArray(values)) {
+        return null;
+    }
+
     const { ViewComponent, args } = getViewComponent(subFormat);
 
     const List = type === 'ordered' ? OL : UL;

--- a/src/app/js/formats/list/ListView.js
+++ b/src/app/js/formats/list/ListView.js
@@ -67,10 +67,7 @@ const ListView = ({
     return (
         <List className={classnames(styles[type], className)}>
             {values.map((value, index) => (
-                <li
-                    key={value}
-                    className={classnames(styles[`${type}_li`])}
-                >
+                <li key={value} className={classnames(styles[`${type}_li`])}>
                     {subFormat ? (
                         <ViewComponent
                             resource={values}

--- a/src/app/js/formats/list/ListView.spec.js
+++ b/src/app/js/formats/list/ListView.spec.js
@@ -31,6 +31,17 @@ describe('list format view <ListView />', () => {
 
     beforeEach(() => StyleSheetTestUtils.suppressStyleInjection());
 
+    it('should render nothing if the list of value is not an array', () => {
+        const wrongValues = [undefined, null, '', 'covfefe', 0, 42, {}];
+
+        wrongValues.forEach(value => {
+            const component = shallow(
+                <ListView {...defaultProps} resource={{ name: value }} />,
+            );
+            expect(component.length).toBe(0);
+        });
+    });
+
     it('should render list of value', () => {
         const component = shallow(<ListView {...defaultProps} />);
         const subFormat = component.find('Translated(CheckedComponent)');

--- a/src/app/js/formats/list/ListView.spec.js
+++ b/src/app/js/formats/list/ListView.spec.js
@@ -38,12 +38,17 @@ describe('list format view <ListView />', () => {
             const component = shallow(
                 <ListView {...defaultProps} resource={{ name: value }} />,
             );
-            expect(component.length).toBe(0);
+            const listComponent = component.find(UL);
+            expect(listComponent.length).toBe(0);
         });
     });
 
     it('should render list of value', () => {
         const component = shallow(<ListView {...defaultProps} />);
+
+        const listComponent = component.find(UL);
+        expect(listComponent.length).toBe(1);
+
         const subFormat = component.find('Translated(CheckedComponent)');
         expect(subFormat.length).toBe(3);
         subFormat.forEach((t, index) => {


### PR DESCRIPTION
[Trello Card #9](https://trello.com/c/3jD8fLTh/9-impossible-de-modifier-un-champ)

Refs. https://github.com/Inist-CNRS/lodex/pull/968

It's now possible to add resources with an empty list. But their views are broken because of the following javascript error.

``` log
Cannot read property 'map' of undefined
```

## Todo

- [x] Render nothing if the field value is not an array in the list format
- [x] Add tests