### PR TITLE
Resources Navigation - Reset the current page counter after performing a new search

### DIFF
--- a/cypress/integration/publication.spec.js
+++ b/cypress/integration/publication.spec.js
@@ -99,7 +99,7 @@ describe('Dataset Publication', () => {
             datasetImportPage.goToPublishedResources();
 
             searchDrawer.openSearchDrawer();
-            searchDrawer.checkMoreCount(10, 14);
+            searchDrawer.checkMoreResultsCount(10, 14);
         });
     });
 

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -21,13 +21,13 @@ describe('Search', () => {
     describe('Basics', () => {
         beforeEach(initSearchDataset());
 
-        it.skip('should have the right informations in the search results', () => {
+        it('should have the right informations in the search results', () => {
             searchDrawer.openSearchDrawer();
             cy.get('.search-result').should('have.length', 10);
             cy.get('.drawer .load-more button').should('contain', '(10 / 12)');
         });
 
-        it.skip('should export the dataset', () => {
+        it('should export the dataset', () => {
             searchDrawer.openSearchDrawer();
             cy.get('.search-result').should('have.length', 10);
             cy.get('.export').click();
@@ -38,7 +38,7 @@ describe('Search', () => {
                 .should('be.visible');
         });
 
-        it.skip('should do a search, and its result redirect to a resource', () => {
+        it('should do a search, and its result redirect to a resource', () => {
             searchDrawer.openSearchDrawer();
             searchDrawer.search('Annals of the rheumatic');
 
@@ -65,7 +65,6 @@ describe('Search', () => {
             searchDrawer.checkMoreResultsNotExist();
 
             searchDrawer.search('bezoar');
-            searchDrawer.search('dragoncelle');
             searchDrawer.clearSearch();
 
             searchDrawer.checkResultsCount(10);
@@ -77,7 +76,7 @@ describe('Search', () => {
             searchDrawer.checkMoreResultsNotExist();
         });
 
-        it.skip('should mark active resource on the result list', () => {
+        it('should mark active resource on the result list', () => {
             searchDrawer.openSearchDrawer();
             searchDrawer.search('Annals of the rheumatic');
 
@@ -92,7 +91,7 @@ describe('Search', () => {
             cy.get('.search-result-link[class*=activeLink_]').should('exist');
         });
 
-        it.skip('should keep track of the current search after changing page', () => {
+        it('should keep track of the current search after changing page', () => {
             const query = 'Annals of the rheumatic';
             searchDrawer.openSearchDrawer();
             searchDrawer.search(query);
@@ -110,7 +109,7 @@ describe('Search', () => {
             searchDrawer.searchInput().should('have.value', query);
         });
 
-        it.skip('should sort result by pertinence', () => {
+        it('should sort result by pertinence', () => {
             searchDrawer.openSearchDrawer();
             searchDrawer.search('medicine');
             cy.get('.search-result').should('have.length', 2);
@@ -132,7 +131,7 @@ describe('Search', () => {
         });
     });
 
-    describe.skip('Advanced Search', () => {
+    describe('Advanced Search', () => {
         beforeEach(initSearchDataset());
 
         it('should filter search results by facets', () => {
@@ -222,7 +221,7 @@ describe('Search', () => {
         });
     });
 
-    describe.skip('Edge Cases', () => {
+    describe('Edge Cases', () => {
         beforeEach(
             initSearchDataset(
                 'dataset/exotic-search-dataset.csv',

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -53,12 +53,24 @@ describe('Search', () => {
                 .should('be.visible');
         });
 
-        it('should be able to load more search results', () => {
+        it('should be able to load more search results several times', () => {
             searchDrawer.openSearchDrawer();
             cy.get('.search-result').should('have.length', 10);
-            cy.get('.drawer .load-more button').should('contain', '(10 / 12)');
+            cy.get('.drawer- .load-more button').should('be.visible');
 
-            searchDrawer.loadMore();
+            searchDrawer.loadMore(); // Call load more for the first time
+
+            cy.get('.search-result').should('have.length', 12);
+            cy.get('.drawer- .load-more button').should('not.be.visible');
+
+            searchDrawer.search('bezoar');
+            searchDrawer.search('dragoncelle');
+            searchDrawer.clearSearch();
+
+            cy.get('.search-result').should('have.length', 10);
+            cy.get('.drawer- .load-more button').should('be.visible');
+
+            searchDrawer.loadMore(); // Call load more for the second time
 
             cy.get('.search-result').should('have.length', 12);
             cy.get('.drawer- .load-more button').should('not.be.visible');

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -5,7 +5,7 @@ import * as searchDrawer from '../support/searchDrawer';
 
 const initSearchDataset = (
     dataset = 'dataset/book_summary.csv',
-    model = 'model/book_summary.json'
+    model = 'model/book_summary.json',
 ) => () => {
     teardown();
     homePage.openAdvancedDrawer();
@@ -213,8 +213,8 @@ describe('Search', () => {
         beforeEach(
             initSearchDataset(
                 'dataset/exotic-search-dataset.csv',
-                'model/exotic-search-model.json'
-            )
+                'model/exotic-search-model.json',
+            ),
         );
 
         it('should have a diacritic insensible text-based search', () => {

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -21,13 +21,13 @@ describe('Search', () => {
     describe('Basics', () => {
         beforeEach(initSearchDataset());
 
-        it('should have the right informations in the search results', () => {
+        it.skip('should have the right informations in the search results', () => {
             searchDrawer.openSearchDrawer();
             cy.get('.search-result').should('have.length', 10);
             cy.get('.drawer .load-more button').should('contain', '(10 / 12)');
         });
 
-        it('should export the dataset', () => {
+        it.skip('should export the dataset', () => {
             searchDrawer.openSearchDrawer();
             cy.get('.search-result').should('have.length', 10);
             cy.get('.export').click();
@@ -38,7 +38,7 @@ describe('Search', () => {
                 .should('be.visible');
         });
 
-        it('should do a search, and its result redirect to a resource', () => {
+        it.skip('should do a search, and its result redirect to a resource', () => {
             searchDrawer.openSearchDrawer();
             searchDrawer.search('Annals of the rheumatic');
 
@@ -55,28 +55,29 @@ describe('Search', () => {
 
         it('should be able to load more search results several times', () => {
             searchDrawer.openSearchDrawer();
-            cy.get('.search-result').should('have.length', 10);
-            cy.get('.drawer- .load-more button').should('be.visible');
+
+            searchDrawer.checkResultsCount(10);
+            searchDrawer.checkMoreResultsCount(10, 12);
 
             searchDrawer.loadMore(); // Call load more for the first time
 
-            cy.get('.search-result').should('have.length', 12);
-            cy.get('.drawer- .load-more button').should('not.be.visible');
+            searchDrawer.checkResultsCount(12);
+            searchDrawer.checkMoreResultsNotExist();
 
             searchDrawer.search('bezoar');
             searchDrawer.search('dragoncelle');
             searchDrawer.clearSearch();
 
-            cy.get('.search-result').should('have.length', 10);
-            cy.get('.drawer- .load-more button').should('be.visible');
+            searchDrawer.checkResultsCount(10);
+            searchDrawer.checkMoreResultsCount(10, 12);
 
             searchDrawer.loadMore(); // Call load more for the second time
 
-            cy.get('.search-result').should('have.length', 12);
-            cy.get('.drawer- .load-more button').should('not.be.visible');
+            searchDrawer.checkResultsCount(12);
+            searchDrawer.checkMoreResultsNotExist();
         });
 
-        it('should mark active resource on the result list', () => {
+        it.skip('should mark active resource on the result list', () => {
             searchDrawer.openSearchDrawer();
             searchDrawer.search('Annals of the rheumatic');
 
@@ -91,7 +92,7 @@ describe('Search', () => {
             cy.get('.search-result-link[class*=activeLink_]').should('exist');
         });
 
-        it('should keep track of the current search after changing page', () => {
+        it.skip('should keep track of the current search after changing page', () => {
             const query = 'Annals of the rheumatic';
             searchDrawer.openSearchDrawer();
             searchDrawer.search(query);
@@ -109,7 +110,7 @@ describe('Search', () => {
             searchDrawer.searchInput().should('have.value', query);
         });
 
-        it('should sort result by pertinence', () => {
+        it.skip('should sort result by pertinence', () => {
             searchDrawer.openSearchDrawer();
             searchDrawer.search('medicine');
             cy.get('.search-result').should('have.length', 2);
@@ -131,7 +132,7 @@ describe('Search', () => {
         });
     });
 
-    describe('Advanced Search', () => {
+    describe.skip('Advanced Search', () => {
         beforeEach(initSearchDataset());
 
         it('should filter search results by facets', () => {
@@ -221,7 +222,7 @@ describe('Search', () => {
         });
     });
 
-    describe('Edge Cases', () => {
+    describe.skip('Edge Cases', () => {
         beforeEach(
             initSearchDataset(
                 'dataset/exotic-search-dataset.csv',

--- a/cypress/support/searchDrawer.js
+++ b/cypress/support/searchDrawer.js
@@ -32,6 +32,8 @@ export const search = value => {
     cy.wait(500); // Wait for the debounce
 };
 
+export const clearSearch = () => cy.get('button.search-clear').click();
+
 export const findSearchResultByTitle = value =>
     cy
         .get('.drawer .search-result-title')

--- a/cypress/support/searchDrawer.js
+++ b/cypress/support/searchDrawer.js
@@ -53,7 +53,9 @@ export const checkResultList = titles => {
 };
 
 export const loadMore = () => {
-    cy.get('.drawer .load-more button').click();
+    cy.get('.drawer .load-more button')
+        .scrollIntoView()
+        .click();
 };
 
 export const waitForLoading = () => {
@@ -120,13 +122,23 @@ export const sortFacet = (name, sortName) => {
     cy.wait(500);
 };
 
-export const checkMoreCount = (count, total) => {
-    cy.get('.load-more')
+export const checkMoreResultsExist = () => {
+    cy.get('.load-more button').should('exist');
+};
+
+export const checkMoreResultsNotExist = () => {
+    cy.get('.load-more button').should('not.exist');
+};
+
+export const checkMoreResultsCount = (count, total) => {
+    cy.get('.load-more button')
         .scrollIntoView()
-        .contains(count)
         .should('be.visible')
-        .contains(total)
-        .should('be.visible');
+        .contains(`${count} / ${total}`);
+};
+
+export const checkResultsCount = count => {
+    cy.get('.search-result').should('have.length', count);
 };
 
 export const goToResourceNumber = nb => {

--- a/src/app/js/public/search/Search.js
+++ b/src/app/js/public/search/Search.js
@@ -312,7 +312,7 @@ class Search extends Component {
                             ref={this.textInput}
                         />
                         <IconButton
-                            classname="search-clear"
+                            className="search-clear"
                             iconStyle={{ color: theme.green.primary }}
                             onClick={this.handleClearFilter}
                         >

--- a/src/app/js/public/search/Search.js
+++ b/src/app/js/public/search/Search.js
@@ -312,6 +312,7 @@ class Search extends Component {
                             ref={this.textInput}
                         />
                         <IconButton
+                            classname="search-clear"
                             iconStyle={{ color: theme.green.primary }}
                             onClick={this.handleClearFilter}
                         >

--- a/src/app/js/public/search/reducer.js
+++ b/src/app/js/public/search/reducer.js
@@ -119,6 +119,7 @@ export default handleActions(
             ...state,
             loading: false,
             dataset: payload.dataset || [],
+            page: payload.page || 0,
             total: payload.total || 0,
             fields: payload.fields || state.fields,
         }),


### PR DESCRIPTION
[Trello Card #74](https://trello.com/c/Blp1Tvuz/74-recherche-et-filtres-impossibilit%C3%A9-dafficher-tous-les-r%C3%A9sultats)

In the search page, I can click on the Load More button to display the 10 next results. But it's possible only one time because the page counter is not reset between different searches.

It's possible to reproduce this bug with the following scenario :

- Perform a search with 12 results
- Click on the load more button
- Perform a search with 10 or fewer results
- Perform a search with 12 results
- Click on the load more button

=> The next results are not loaded

## Todo

- [x] Reset the page counter when performing a new search
- [x] Improve the current e2e tests by implementing the described scenario