### PR TITLE
Login - Fix blank page when the login token expires

### DIFF
--- a/src/app/js/lib/sagas/fetchSaga.js
+++ b/src/app/js/lib/sagas/fetchSaga.js
@@ -26,6 +26,7 @@ export default function* fetchSaga(
                     pathname: `/login?page=${encodeURIComponent(pathname)}`,
                 }),
             );
+            window.location.reload();
         }
 
         yield put(logout());


### PR DESCRIPTION
[Trello Card #67](https://trello.com/c/tgZevOei/67-page-blanche-lorsque-le-login-expire-et-quon-click-sur-le-drawer-recherche)

Follows https://github.com/Inist-CNRS/lodex/pull/972

When the login token expires, the user is redirected to the login page, which is not loaded due to an issue in the router. The solution is to force the reload after the redirection.
 
## Todo

- [x] Fix blank page
- [ ] ~~Add tests~~ - Will be done in the PR

## Screenshots

![Sélection_003](https://user-images.githubusercontent.com/5584839/68390569-dc71ed80-0165-11ea-8548-9aae8fcef5f9.png)
