### PR TITLE
Close the export menu after exporting values

### DIFF
--- a/src/app/js/public/ExportButton.js
+++ b/src/app/js/public/ExportButton.js
@@ -5,7 +5,6 @@ import IconButton from 'material-ui/IconButton';
 import Popover, { PopoverAnimationVertical } from 'material-ui/Popover';
 import Menu from 'material-ui/Menu';
 import withWidth from 'material-ui/utils/withWidth';
-import ExportIcon from 'material-ui/svg-icons/editor/vertical-align-bottom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 

--- a/src/app/js/public/ExportButton.js
+++ b/src/app/js/public/ExportButton.js
@@ -23,7 +23,7 @@ import theme from '../theme';
 import ExportItem from './export/ExportMenuItem';
 
 const ExportButton = ({ exporters, onExport, uri, p: polyglot, width }) => {
-    const [popover, setPopover] = useState(null);
+    const [popover, setPopover] = useState({ open: false });
 
     const handleOpen = event => {
         // This prevents ghost click.

--- a/src/app/js/public/ExportButton.js
+++ b/src/app/js/public/ExportButton.js
@@ -22,16 +22,10 @@ import {
 import theme from '../theme';
 import ExportItem from './export/ExportMenuItem';
 
-const ExportButton = ({
-    exporters,
-    handleExportClick,
-    uri,
-    p: polyglot,
-    width,
-}) => {
-    const [popover, setPopover] = useState({ open: false });
+const ExportButton = ({ exporters, onExport, uri, p: polyglot, width }) => {
+    const [popover, setPopover] = useState(null);
 
-    const handleClick = event => {
+    const handleOpen = event => {
         // This prevents ghost click.
         event.preventDefault();
 
@@ -41,10 +35,15 @@ const ExportButton = ({
         });
     };
 
-    const handleRequestClose = () => {
+    const handleClose = () => {
         setPopover({
             open: false,
         });
+    };
+
+    const handleExport = event => {
+        handleClose();
+        onExport(event);
     };
 
     if (!exporters || !exporters.length) {
@@ -59,7 +58,7 @@ const ExportButton = ({
             {width > 2 && (
                 <FlatButton
                     primary
-                    onClick={handleClick}
+                    onClick={handleOpen}
                     label={label}
                     icon={<FontAwesomeIcon icon={faDownload} height={20} />}
                     className="export"
@@ -67,7 +66,7 @@ const ExportButton = ({
             )}
             {width <= 2 && (
                 <IconButton
-                    onClick={handleClick}
+                    onClick={handleOpen}
                     iconStyle={{ color: theme.green.primary }}
                     className="export"
                 >
@@ -80,7 +79,7 @@ const ExportButton = ({
                 anchorEl={popover.anchorEl}
                 anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
                 targetOrigin={{ horizontal: 'left', vertical: 'top' }}
-                onRequestClose={handleRequestClose}
+                onRequestClose={handleClose}
                 animation={PopoverAnimationVertical}
             >
                 <Menu>
@@ -89,7 +88,7 @@ const ExportButton = ({
                             key={name}
                             type={name}
                             uri={uri}
-                            onClick={handleExportClick}
+                            onClick={handleExport}
                         />
                     ))}
                 </Menu>
@@ -100,7 +99,7 @@ const ExportButton = ({
 
 ExportButton.propTypes = {
     exporters: PropTypes.arrayOf(PropTypes.object),
-    handleExportClick: PropTypes.func.isRequired,
+    onExport: PropTypes.func.isRequired,
     preLoadExporters: PropTypes.func.isRequired,
     p: polyglotPropTypes.isRequired,
     uri: PropTypes.string,
@@ -115,7 +114,7 @@ const mapDispatchToProps = dispatch =>
     bindActionCreators(
         {
             preLoadExporters,
-            handleExportClick: exportPublishedDatasetAction,
+            onExport: exportPublishedDatasetAction,
         },
         dispatch,
     );


### PR DESCRIPTION
[Trello Card #85](https://trello.com/c/kgx0t6ad/85-adaptation-du-menu-export-%C3%A0-la-nouvelle-barre-de-navigation)

The export menu is not closed when the values are exported.

## Todo

- [x] Close the export menu after exporting value

## Screenshots

![Peek 08-11-2019 15-41](https://user-images.githubusercontent.com/5584839/68484952-a0f72200-023e-11ea-9d6f-7980167c8a0a.gif)
