### PR TITLE
Change the icon of the export button

### DIFF
--- a/src/app/js/public/ExportButton.js
+++ b/src/app/js/public/ExportButton.js
@@ -6,7 +6,7 @@ import Popover, { PopoverAnimationVertical } from 'material-ui/Popover';
 import Menu from 'material-ui/Menu';
 import withWidth from 'material-ui/utils/withWidth';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faDownload } from '@fortawesome/free-solid-svg-icons';
+import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 
 import translate from 'redux-polyglot/translate';
 import { bindActionCreators } from 'redux';
@@ -60,7 +60,9 @@ const ExportButton = ({ exporters, onExport, uri, p: polyglot, width }) => {
                     primary
                     onClick={handleOpen}
                     label={label}
-                    icon={<FontAwesomeIcon icon={faDownload} height={20} />}
+                    icon={
+                        <FontAwesomeIcon icon={faExternalLinkAlt} height={20} />
+                    }
                     className="export"
                 />
             )}
@@ -70,7 +72,7 @@ const ExportButton = ({ exporters, onExport, uri, p: polyglot, width }) => {
                     iconStyle={{ color: theme.green.primary }}
                     className="export"
                 >
-                    <FontAwesomeIcon icon={faDownload} height={20} />
+                    <FontAwesomeIcon icon={faExternalLinkAlt} height={20} />
                 </IconButton>
             )}
 


### PR DESCRIPTION
[Trello Card #99](https://trello.com/c/vmssd0g3/99-expliciter-les-icones-sur-le-volet-recherche-%C3%A0-compl%C3%A9ter-inist)

The current icon used by the export button is the same as the icon used by the download button in the Istex theme.

It should be replaced by the following one:

![image](https://user-images.githubusercontent.com/5584839/70250454-332b1100-177e-11ea-8648-7832afe04d0e.png)

Source: https://fontawesome.com/icons/external-link-alt?style=solid

## Todo

- [x] Replace the current icon of the export button by the external link icon

## Screenshot

![Sélection_002](https://user-images.githubusercontent.com/5584839/70250161-c748a880-177d-11ea-9cf7-c6b6ea6a601a.png)
