### PR TITLE
Graph - Fix Sort Button style

### DIFF
--- a/src/app/js/lib/components/SortButton.js
+++ b/src/app/js/lib/components/SortButton.js
@@ -8,8 +8,6 @@ import { isLongText, getShortText } from '../../lib/longTexts';
 const styles = {
     sortButton: {
         minWidth: 40,
-        paddingLeft: '1rem',
-        paddingRight: '1rem',
     },
     iconSortBy: {
         transition: 'transform 100ms ease-in-out',


### PR DESCRIPTION
[Trello Card #86](https://trello.com/c/8e6krAiR/86-disparition-de-lic%C3%B4ne-de-tri-ascendant-ou-descendant-dans-les-facettes-de-graphiques-navigateur-firefox) - The Sort Button icon is not displayed in Firefox

## Todo

- [x] Fix style in Firefox

## Screenshots

**Firefox**

![Sélection_002](https://user-images.githubusercontent.com/5584839/70315643-54413f80-181a-11ea-8384-4013823d7ce5.png)

**Google Chrome**

![Sélection_004](https://user-images.githubusercontent.com/5584839/70315631-4ee3f500-181a-11ea-86db-c4c8557e768b.png)
