### PR TITLE
Fix loading styles and increase loading box height

### DIFF
--- a/src/app/js/characteristic/DatasetCharacteristicItem.js
+++ b/src/app/js/characteristic/DatasetCharacteristicItem.js
@@ -7,14 +7,16 @@ import Property from '../public/Property';
 import { fromFields, fromCharacteristic } from '../sharedSelectors';
 import { field as fieldPropTypes } from '../propTypes';
 
+const LOADING_BOX_HEIGHT = 250;
+
 const styles = {
     loading: {
-        height: '500px !important',
-        width: '100% !important',
+        height: `${LOADING_BOX_HEIGHT}px`,
+        width: '100%',
     },
     loaded: {
-        height: '0px !important',
-        width: '0px !important',
+        height: '0px',
+        width: '0px',
     },
 };
 
@@ -25,7 +27,7 @@ export const DatasetCharacteristicItemComponent = ({
 }) => {
     const [ref, inView] = useInView({
         triggerOnce: true,
-        rootMargin: '50px 0px',
+        rootMargin: `${LOADING_BOX_HEIGHT * 2}px 0px`,
     });
 
     return (


### PR DESCRIPTION
[Trello Card #91](https://trello.com/c/Ww0Q2rGN/91-affichage-progressif-de-la-page-daccueil)

Fixes https://github.com/Inist-CNRS/lodex/pull/1018

The `!important` css property could not be passed using the `style` prop.

## Todo

- [x] Fix styles that break the intersection

## Screenshots

![Sélection_001](https://user-images.githubusercontent.com/5584839/70424393-a202b580-1a6f-11ea-9e5e-777be0abdd5d.png)

![ezgif com-optimize](https://user-images.githubusercontent.com/5584839/70424823-4be24200-1a70-11ea-951e-4332370e2dfc.gif)
