### PR TITLE
Display the results count in the same way in graph and search pages

### DIFF
--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -56,6 +56,7 @@ describe('Search', () => {
         it('should be able to load more search results several times', () => {
             menu.openSearchDrawer();
 
+            searchDrawer.checkStatsCount(12, 12);
             searchDrawer.checkResultsCount(10);
             searchDrawer.checkMoreResultsCount(10, 12);
 
@@ -112,6 +113,7 @@ describe('Search', () => {
         it('should sort result by pertinence', () => {
             menu.openSearchDrawer();
             searchDrawer.search('medicine');
+            searchDrawer.checkStatsCount(2, 12);
             searchDrawer.checkResultsCount(2);
 
             searchDrawer.checkResultList([

--- a/cypress/support/searchDrawer.js
+++ b/cypress/support/searchDrawer.js
@@ -120,6 +120,12 @@ export const checkMoreResultsCount = (count, total) => {
         .contains(`${count} / ${total}`);
 };
 
+export const checkStatsCount = (current, count) => {
+    cy.get('.stats')
+        .contains(`Found ${current} on ${count}`)
+        .should('be.visible');
+};
+
 export const checkResultsCount = count => {
     cy.get('.search-result').should('have.length', count);
 };

--- a/src/app/custom/translations.tsv
+++ b/src/app/custom/translations.tsv
@@ -453,7 +453,6 @@
 "allow_to_load_more"	"Allow to load more resources"	"Autoriser à charger plus de ressources"
 "items_per_page"	"Resource number per page"	"Nombre de ressources par page"
 "see_more"	"See more"	"Voir plus"
-"results"	"%{smart_count} result |||| %{smart_count} results"	"%{smart_count} résultat |||| %{smart_count} résultats"
 "no_result"	"No matching resource found"	"Aucune correspondance trouvée"
 "no_result_details"	"Please change your search terms or facets"	"Veuillez changer vos filtres ou termes de recherche"
 "max_char_number_in_labels"	"Maximum character number in labels"	"Nombre max de caractères dans les intitulés"

--- a/src/app/js/public/Stats.js
+++ b/src/app/js/public/Stats.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import compose from 'recompose/compose';
 import translate from 'redux-polyglot/translate';
 
-import { fromDataset } from './selectors';
-import { fromFields } from '../sharedSelectors';
 import { polyglot as polyglotPropTypes } from '../propTypes';
 
 const styles = {
@@ -30,19 +26,9 @@ export const StatsComponent = ({
 );
 
 StatsComponent.propTypes = {
-    nbColumns: PropTypes.number.isRequired,
     nbResources: PropTypes.number.isRequired,
     currentNbResources: PropTypes.number.isRequired,
     p: polyglotPropTypes.isRequired,
 };
 
-const mapStateToProps = state => ({
-    nbColumns: fromFields.getNbColumns(state),
-    currentNbResources: fromDataset.getDatasetTotal(state),
-    nbResources: fromDataset.getDatasetFullTotal(state),
-});
-
-export default compose(
-    connect(mapStateToProps),
-    translate,
-)(StatsComponent);
+export default translate()(StatsComponent);

--- a/src/app/js/public/dataset/DatasetStats.js
+++ b/src/app/js/public/dataset/DatasetStats.js
@@ -1,23 +1,12 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import Stats from '../Stats';
 
 import { fromDataset } from '../selectors';
 
-export const StatsComponent = ({ nbResources, currentNbResources }) => (
-    <Stats currentNbResources={currentNbResources} nbResources={nbResources} />
-);
-
-StatsComponent.propTypes = {
-    nbResources: PropTypes.number.isRequired,
-    currentNbResources: PropTypes.number.isRequired,
-};
-
 const mapStateToProps = state => ({
     currentNbResources: fromDataset.getDatasetTotal(state),
     nbResources: fromDataset.getDatasetFullTotal(state),
 });
 
-export default connect(mapStateToProps)(StatsComponent);
+export default connect(mapStateToProps)(Stats);

--- a/src/app/js/public/dataset/DatasetStats.js
+++ b/src/app/js/public/dataset/DatasetStats.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import Stats from '../Stats';
+
+import { fromDataset } from '../selectors';
+
+export const StatsComponent = ({ nbResources, currentNbResources }) => (
+    <Stats currentNbResources={currentNbResources} nbResources={nbResources} />
+);
+
+StatsComponent.propTypes = {
+    nbResources: PropTypes.number.isRequired,
+    currentNbResources: PropTypes.number.isRequired,
+};
+
+const mapStateToProps = state => ({
+    currentNbResources: fromDataset.getDatasetTotal(state),
+    nbResources: fromDataset.getDatasetFullTotal(state),
+});
+
+export default connect(mapStateToProps)(StatsComponent);

--- a/src/app/js/public/graph/GraphPage.js
+++ b/src/app/js/public/graph/GraphPage.js
@@ -22,7 +22,7 @@ import EditOntologyFieldButton from '../../fields/ontology/EditOntologyFieldButt
 import PropertyLinkedFields from '../Property/PropertyLinkedFields';
 import CompositeProperty from '../Property/CompositeProperty';
 import { grey500 } from 'material-ui/styles/colors';
-import Stats from '../Stats';
+import DatasetStats from '../dataset/DatasetStats';
 import getTitle from '../../lib/getTitle';
 import { preLoadPublication } from '../../fields';
 import { preLoadDatasetPage as preLoadDatasetPageAction } from '../dataset';
@@ -82,7 +82,7 @@ class GraphPage extends Component {
                     <Toolbar name={name} />
                 </div>
                 <div style={styles.centerColumn}>
-                    <Stats />
+                    <DatasetStats />
                     <AppliedFacetList style={styles.section} />
                     {graphField && (
                         <Card style={styles.section} className="graph">

--- a/src/app/js/public/search/Search.js
+++ b/src/app/js/public/search/Search.js
@@ -36,6 +36,7 @@ import SearchResultList from './SearchResultList';
 import SearchResultSort from './SearchResultSort';
 import stylesToClassname from '../../lib/stylesToClassName';
 import ExportButton from '../ExportButton';
+import SearchStats from './SearchStats';
 
 const styles = stylesToClassname(
     {
@@ -348,20 +349,7 @@ class Search extends Component {
                         )}
                     >
                         <div className={styles.advancedTopBar}>
-                            {(everythingIsOk || noResults) && (
-                                <div
-                                    className={classnames(
-                                        'search-message',
-                                        styles.searchMessage,
-                                    )}
-                                >
-                                    {loading
-                                        ? polyglot.t('loading')
-                                        : polyglot.t('results', {
-                                              smart_count: total,
-                                          })}
-                                </div>
-                            )}
+                            {(everythingIsOk || noResults) && <SearchStats />}
                         </div>
                     </div>
                 </div>

--- a/src/app/js/public/search/SearchStats.js
+++ b/src/app/js/public/search/SearchStats.js
@@ -1,23 +1,12 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import Stats from '../Stats';
 
 import { fromSearch } from '../selectors';
 
-export const StatsComponent = ({ nbResources, currentNbResources }) => (
-    <Stats currentNbResources={currentNbResources} nbResources={nbResources} />
-);
-
-StatsComponent.propTypes = {
-    nbResources: PropTypes.number.isRequired,
-    currentNbResources: PropTypes.number.isRequired,
-};
-
 const mapStateToProps = state => ({
     currentNbResources: fromSearch.getDatasetTotal(state),
     nbResources: fromSearch.getDatasetFullTotal(state),
 });
 
-export default connect(mapStateToProps)(StatsComponent);
+export default connect(mapStateToProps)(Stats);

--- a/src/app/js/public/search/SearchStats.js
+++ b/src/app/js/public/search/SearchStats.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import Stats from '../Stats';
+
+import { fromSearch } from '../selectors';
+
+export const StatsComponent = ({ nbResources, currentNbResources }) => (
+    <Stats currentNbResources={currentNbResources} nbResources={nbResources} />
+);
+
+StatsComponent.propTypes = {
+    nbResources: PropTypes.number.isRequired,
+    currentNbResources: PropTypes.number.isRequired,
+};
+
+const mapStateToProps = state => ({
+    currentNbResources: fromSearch.getDatasetTotal(state),
+    nbResources: fromSearch.getDatasetFullTotal(state),
+});
+
+export default connect(mapStateToProps)(StatsComponent);

--- a/src/app/js/public/search/reducer.js
+++ b/src/app/js/public/search/reducer.js
@@ -27,6 +27,8 @@ export const loadMoreFailed = createAction(SEARCH_LOAD_MORE_ERROR);
 export const fromSearch = {
     isLoading: state => state.loading,
     getDataset: state => state.dataset,
+    getDatasetTotal: state => state.total,
+    getDatasetFullTotal: state => state.fullTotal,
     getSort: state => state.sort,
     getFieldNames: state => state.fields,
     getPage: state => state.page,
@@ -121,6 +123,7 @@ export default handleActions(
             dataset: payload.dataset || [],
             page: payload.page || 0,
             total: payload.total || 0,
+            fullTotal: payload.fullTotal || 0,
             fields: payload.fields || state.fields,
         }),
         [SEARCH_LOAD_MORE]: state => ({

--- a/src/app/js/public/search/sagas.js
+++ b/src/app/js/public/search/sagas.js
@@ -67,6 +67,7 @@ const handleSearch = function*() {
             dataset: response.data,
             fields,
             total: response.total,
+            fullTotal: response.fullTotal,
         }),
     );
 };


### PR DESCRIPTION
[Trello Card #109](https://trello.com/c/Q6SFYfK1/109-homog%C3%A9n%C3%A9isation-du-filtrage)

## Todo

- [x] Use graph dataset result display in search drawer

## Screenshot
![screenshot-localhost_3000-2019 12](https://user-images.githubusercontent.com/4921926/70522506-87007600-1b41-11ea-834d-4a5aa833be00.png)
