### PR TITLE
Graph - Fix padding in mouse tooltips

### DIFF
--- a/src/app/js/formats/shared/MouseIcon.js
+++ b/src/app/js/formats/shared/MouseIcon.js
@@ -22,11 +22,11 @@ const MouseIcon = ({ polyglot }) => (
         </svg>
 
         <ReactTooltip id="mouseIconTooltip" effect="solid">
-            <ul>
+            <div>
                 {polyglot.t('user_can_interact_with_mouse_1')}
                 {<br />}
                 {polyglot.t('user_can_interact_with_mouse_2')}
-            </ul>
+            </div>
         </ReactTooltip>
     </>
 );


### PR DESCRIPTION
[Trello Card #39](https://trello.com/c/cVElTaRy/39-flux-r%C3%A9seau-hi%C3%A9rarchie-probl%C3%A8me-du-padding-left-dans-les-tooltips)

There is padding between the text of the tooltip and the border. This is due to bad usage of the `<ul/>` tag.

## Todo

- [x] Change `ul` by `div` in MouseIcon

## Screenshots
![screenshot-localhost_3000-2019 12 (1)](https://user-images.githubusercontent.com/4921926/70617730-93540400-1c11-11ea-9a5f-abd562f7e8fd.png)
