### PR TITLE
Fix duplication of uri when the value of a format already contains one

### DIFF
--- a/src/app/js/formats/asterPlotChart/AsterPlotChartView.js
+++ b/src/app/js/formats/asterPlotChart/AsterPlotChartView.js
@@ -92,6 +92,6 @@ const mapStateToProps = (_, { formatData, history, p: polyglot }) => ({
 export default compose(
     translate,
     withRouter,
-    injectData(),
+    injectData(null, null, true),
     connect(mapStateToProps),
 )(AsterPlotChartView);

--- a/src/app/js/formats/injectData.js
+++ b/src/app/js/formats/injectData.js
@@ -35,7 +35,11 @@ const getCreateUrl = url => {
     return ({ field, resource }) => resource[field.name];
 };
 
-export default (url, checkFormatLoaded = null) => FormatView => {
+export default (
+    url = null,
+    checkFormatLoaded = null,
+    withUri = false,
+) => FormatView => {
     const createUrl = getCreateUrl(url);
 
     class GraphItem extends Component {
@@ -60,7 +64,7 @@ export default (url, checkFormatLoaded = null) => FormatView => {
                 return;
             }
 
-            loadFormatData({ ...this.props, value });
+            loadFormatData({ ...this.props, value, withUri });
         };
 
         UNSAFE_componentWillMount() {
@@ -100,6 +104,7 @@ export default (url, checkFormatLoaded = null) => FormatView => {
                 field,
                 value: createUrl(this.props),
                 filter,
+                withUri,
             });
         };
 

--- a/src/app/js/formats/injectData.js
+++ b/src/app/js/formats/injectData.js
@@ -55,6 +55,7 @@ export default (url, checkFormatLoaded = null) => FormatView => {
             const { loadFormatData } = this.props;
 
             const value = createUrl(this.props);
+
             if (!value) {
                 return;
             }
@@ -173,10 +174,7 @@ export default (url, checkFormatLoaded = null) => FormatView => {
     };
 
     return compose(
-        connect(
-            mapStateToProps,
-            mapDispatchToProps,
-        ),
+        connect(mapStateToProps, mapDispatchToProps),
         translate,
     )(GraphItem);
 };

--- a/src/app/js/formats/lodex-field/LodexFieldView.js
+++ b/src/app/js/formats/lodex-field/LodexFieldView.js
@@ -216,22 +216,24 @@ export default compose(
             return null;
         }
 
-        if (isURL(value)) {
-            const source = URL.parse(value);
-            if (source.pathname.search(/^\/\w+:/) === 0) {
-                const uri = source.pathname.slice(1);
-                const target = {
-                    protocol: source.protocol,
-                    hostname: source.hostname,
-                    slashes: source.slashes,
-                    port: source.port,
-                    pathname: '/api/export/jsonallvalue',
-                    search: '?uri=' + uri,
-                };
-                return URL.format(target);
-            }
-            return value;
+        if (!isURL(value)) {
+            return '/api/export/jsonallvalue?uri=' + resource[field.name];
         }
-        return '/api/export/jsonallvalue/?uri=' + resource[field.name];
+
+        const source = URL.parse(value);
+        if (source.pathname.search(/^\/\w+:/) === 0) {
+            const uri = source.pathname.slice(1);
+            const target = {
+                protocol: source.protocol,
+                hostname: source.hostname,
+                slashes: source.slashes,
+                port: source.port,
+                pathname: '/api/export/jsonallvalue',
+                search: '?uri=' + uri,
+            };
+            return URL.format(target);
+        }
+
+        return value;
     }),
 )(LodexFieldView);

--- a/src/app/js/formats/sagas.js
+++ b/src/app/js/formats/sagas.js
@@ -90,7 +90,7 @@ export function* loadFormatData(name, url, queryString) {
 }
 
 export function* handleLoadFormatDataRequest({
-    payload: { field, filter, value, resource } = {},
+    payload: { field, filter, value, resource, withUri } = {},
 }) {
     const name = field && field.name;
 
@@ -114,8 +114,8 @@ export function* handleLoadFormatDataRequest({
     const queryString = yield call(getQueryString, {
         params: {
             ...params,
-            uri,
             ...(filter || {}),
+            ...(withUri && { uri }),
         },
     });
 

--- a/src/app/js/formats/sagas.spec.js
+++ b/src/app/js/formats/sagas.spec.js
@@ -279,6 +279,7 @@ describe('format sagas', () => {
                     field: { name: 'fieldName' },
                     filter: { filterKey: 'filterValue' },
                     value: 'url',
+                    withUri: false,
                 },
             });
 
@@ -311,12 +312,54 @@ describe('format sagas', () => {
             });
         });
 
+        it('should loadFormatData with the resource uri for field', () => {
+            const iterator = handleLoadFormatDataRequest({
+                payload: {
+                    field: { name: 'fieldName' },
+                    filter: { filterKey: 'filterValue' },
+                    resource: { uri: 'thisIsAnUri' },
+                    value: 'url',
+                    withUri: true,
+                },
+            });
+
+            expect(iterator.next()).toEqual({
+                done: false,
+                value: select(
+                    fromFields.getGraphFieldParamsByName,
+                    'fieldName',
+                ),
+            });
+
+            expect(iterator.next({ paramsKey: 'paramsValue' })).toEqual({
+                done: false,
+                value: call(getQueryString, {
+                    params: {
+                        filterKey: 'filterValue',
+                        paramsKey: 'paramsValue',
+                        uri: 'thisIsAnUri',
+                    },
+                }),
+            });
+
+            expect(iterator.next('queryString')).toEqual({
+                done: false,
+                value: call(loadFormatData, 'fieldName', 'url', 'queryString'),
+            });
+
+            expect(iterator.next()).toEqual({
+                done: true,
+                value: undefined,
+            });
+        });
+
         it('should put loadFormatDataError if value is not a string', () => {
             const iterator = handleLoadFormatDataRequest({
                 payload: {
                     field: { name: 'fieldName' },
                     filter: { filterKey: 'filterValue' },
                     value: ['an', 'incorrect', 'value'],
+                    withUri: false,
                 },
             });
 
@@ -342,6 +385,7 @@ describe('format sagas', () => {
                     field: {},
                     filter: { filterKey: 'filterValue' },
                     value: 'url',
+                    withUri: false,
                 },
             });
 
@@ -357,6 +401,7 @@ describe('format sagas', () => {
                     field: null,
                     filter: { filterKey: 'filterValue' },
                     value: 'url',
+                    withUri: false,
                 },
             });
 


### PR DESCRIPTION
[Trello Card #](https://trello.com/c/uFQVAo1n/113-les-donn%C3%A9es-du-format-lodex-champ-ne-saffichent-plus)

Ref. https://github.com/Inist-CNRS/lodex/pull/986

The AsterPlot feature introduced a bug in some formats due to a duplication of the URI in the query URL.

It's the case with the LodexField format, which has a value equals to:
`https://publication-language.data.istex.fr/api/export/jsonallvalue?uri=ark:/67375/KM1-FNPPMN4Q-S`

Due to the similar resources feature introduced by the AsterPlot format, we needed to pass the current resource URI to get similar resources. And we decided to do it for all formats.

But as a result, when the base URL already contains a URI, we have the following duplication:
`https://publication-language.data.istex.fr/api/export/jsonallvalue?uri=ark:/67375/KM1-FNPPMN4Q-S?uri=uid%3A%2F12WDH7ZW`

So we need to change the default behaviour to inject the uri only when it's necessary (and so currently only in the AsterPlot format).

## Todo

- [x] Add options to the inject data method to include the URI only when it's needed
- [x] Update the load format saga to not send the URI when it's not needed
- [x] Fix tests

## Screenshots

![Sélection_003](https://user-images.githubusercontent.com/5584839/70702877-4df60c00-1ccf-11ea-8e7a-31c80d86325c.png)

