### PR TITLE
Ultimate Prettier Format

### DIFF
--- a/src/api/controller/api/export.js
+++ b/src/api/controller/api/export.js
@@ -75,9 +75,7 @@ const middlewareScript = async (ctx, scriptNameCalled, field1, field2) => {
     if (filter.$and && !filter.$and.length) {
         delete filter.$and;
     }
-    const connectionStringURI = `mongodb://${config.mongo.host}/${
-        config.mongo.dbName
-    }`;
+    const connectionStringURI = `mongodb://${config.mongo.host}/${config.mongo.dbName}`;
     // context is the intput for LodexReduceQuery & LodexRunQuery & LodexDocuments
     const context = {
         // /*
@@ -122,7 +120,7 @@ const middlewareScript = async (ctx, scriptNameCalled, field1, field2) => {
     };
     ctx.body = input
         .pipe(ezs('LodexRunQuery', {}, environment))
-        .pipe(ezs('greater', { path: 'total', 'than': 1 }))
+        .pipe(ezs('greater', { path: 'total', than: 1 }))
         .pipe(ezs('filterVersions'))
         .pipe(ezs('filterContributions'))
         .pipe(ezs(statement, { commands, key: ctx.url }, environment))

--- a/src/api/controller/api/fetchLineBy.js
+++ b/src/api/controller/api/fetchLineBy.js
@@ -1,12 +1,11 @@
 export default ctx => (fieldName, value) =>
     value
-        ? ctx.dataset.findBy(fieldName, value).then(
-              line =>
-                  line
-                      ? {
-                            ...line,
-                            uri: `uri to ${fieldName}: ${value}`,
-                        }
-                      : null,
+        ? ctx.dataset.findBy(fieldName, value).then(line =>
+              line
+                  ? {
+                        ...line,
+                        uri: `uri to ${fieldName}: ${value}`,
+                    }
+                  : null,
           )
         : null;

--- a/src/api/controller/api/field.js
+++ b/src/api/controller/api/field.js
@@ -82,7 +82,11 @@ export const exportFields = async ctx => {
     ctx.attachment('lodex_export.json');
     ctx.type = 'application/json';
 
-    ctx.body = JSON.stringify(fields.map(f => omit(f, ['_id'])), null, 4);
+    ctx.body = JSON.stringify(
+        fields.map(f => omit(f, ['_id'])),
+        null,
+        4,
+    );
 };
 
 const simplifyTransformers = field => {
@@ -118,7 +122,9 @@ export const getUploadedFields = (
     asyncBusboyImpl,
     streamToStringImpl,
 ) => async req => {
-    const { files: [fieldsStream] } = await asyncBusboyImpl(req);
+    const {
+        files: [fieldsStream],
+    } = await asyncBusboyImpl(req);
 
     return JSON.parse(await streamToStringImpl(fieldsStream));
 };

--- a/src/api/controller/api/field.spec.js
+++ b/src/api/controller/api/field.spec.js
@@ -145,14 +145,12 @@ describe('field routes', () => {
         it('should call ctx.field.findAll and pass the result to ctx.body with correct headers', async () => {
             const ctx = {
                 field: {
-                    findAll: jest
-                        .fn()
-                        .mockImplementation(() =>
-                            Promise.resolve([
-                                { name: 'field1', _id: 'id1' },
-                                { name: 'field2', _id: 'id2' },
-                            ]),
-                        ),
+                    findAll: jest.fn().mockImplementation(() =>
+                        Promise.resolve([
+                            { name: 'field1', _id: 'id1' },
+                            { name: 'field2', _id: 'id2' },
+                        ]),
+                    ),
                 },
                 attachment: jest.fn(),
             };
@@ -183,12 +181,10 @@ describe('field routes', () => {
         };
 
         beforeEach(() => {
-            getUploadedFields = jest
-                .fn()
-                .mockImplementation(() => [
-                    { name: 'field1', label: 'Field 1' },
-                    { name: 'field2', label: 'Field 2' },
-                ]);
+            getUploadedFields = jest.fn().mockImplementation(() => [
+                { name: 'field1', label: 'Field 1' },
+                { name: 'field2', label: 'Field 2' },
+            ]);
             ctx.field.create.mockClear();
             ctx.field.remove.mockClear();
         });
@@ -241,12 +237,10 @@ describe('field routes', () => {
         });
 
         it('should rearrange the position to avoid gap', async () => {
-            getUploadedFields = jest
-                .fn()
-                .mockImplementation(() => [
-                    { name: 'field1', label: 'Field 1', position: 5 },
-                    { name: 'field2', label: 'Field 2', position: 6 },
-                ]);
+            getUploadedFields = jest.fn().mockImplementation(() => [
+                { name: 'field1', label: 'Field 1', position: 5 },
+                { name: 'field2', label: 'Field 2', position: 6 },
+            ]);
 
             await importFields(getUploadedFields)(ctx);
 
@@ -264,13 +258,11 @@ describe('field routes', () => {
         });
 
         it('should ensure uri is first', async () => {
-            getUploadedFields = jest
-                .fn()
-                .mockImplementation(() => [
-                    { name: 'field1', label: 'Field 1', position: 5 },
-                    { name: 'field2', label: 'Field 2', position: 6 },
-                    { name: 'uri', label: 'Uri', position: 10 },
-                ]);
+            getUploadedFields = jest.fn().mockImplementation(() => [
+                { name: 'field1', label: 'Field 1', position: 5 },
+                { name: 'field2', label: 'Field 2', position: 6 },
+                { name: 'uri', label: 'Uri', position: 10 },
+            ]);
 
             await importFields(getUploadedFields)(ctx);
 

--- a/src/api/controller/api/publish.spec.js
+++ b/src/api/controller/api/publish.spec.js
@@ -1,4 +1,3 @@
-/* eslint max-len: off */
 import { doPublish, preparePublish, handlePublishError } from './publish';
 import publishCharacteristics from '../../services/publishCharacteristics';
 import publishDocuments from '../../services/publishDocuments';

--- a/src/api/controller/api/publishFacets.spec.js
+++ b/src/api/controller/api/publishFacets.spec.js
@@ -1,4 +1,3 @@
-/* eslint max-len: off */
 import publishFacets from './publishFacets';
 
 describe('publishFacets', () => {

--- a/src/api/controller/api/publishedDataset.spec.js
+++ b/src/api/controller/api/publishedDataset.spec.js
@@ -70,7 +70,11 @@ describe('publishedDataset', () => {
             await getPage(ctx);
 
             expect(ctx.body).toEqual({
-                data: [{ uri: 1, v: 2 }, { uri: 2, v: 3 }, { uri: 3, v: 1 }],
+                data: [
+                    { uri: 1, v: 2 },
+                    { uri: 2, v: 3 },
+                    { uri: 3, v: 1 },
+                ],
                 total: 42,
                 fullTotal: 'fullTotal',
             });

--- a/src/api/models/dataset.js
+++ b/src/api/models/dataset.js
@@ -29,7 +29,7 @@ export default db => {
         (await collection.countNotUnique(fieldName)) === 0;
 
     collection.findBy = async (fieldName, value) => {
-        if (!await collection.ensureIsUnique(fieldName)) {
+        if (!(await collection.ensureIsUnique(fieldName))) {
             throw new Error(
                 `${fieldName} value is not unique for every document`,
             );

--- a/src/api/models/field.js
+++ b/src/api/models/field.js
@@ -8,22 +8,20 @@ import { COVER_DOCUMENT, COVER_COLLECTION } from '../../common/cover';
 import generateUid from '../services/generateUid';
 
 export const buildInvalidPropertiesMessage = name =>
-    `Invalid data for field ${name} which need a name, a label, a cover, a valid scheme if specified and a transformers array`; // eslint-disable-line
+    `Invalid data for field ${name} which need a name, a label, a cover, a valid scheme if specified and a transformers array`;
 
 export const buildInvalidTransformersMessage = name =>
-    `Invalid transformers for field ${name}: transformers must have a valid operation and an args array`; // eslint-disable-line
+    `Invalid transformers for field ${name}: transformers must have a valid operation and an args array`;
 
 export const validateField = (data, isContribution) => {
     const validation = validateFieldIsomorphic(data, isContribution);
 
     if (!validation.propertiesAreValid) {
-        // eslint-disable-next-line no-console
         console.error('propertiesAreValid', JSON.stringify(validation));
         throw new Error(buildInvalidPropertiesMessage(data.label));
     }
 
     if (!validation.transformersAreValid) {
-        // eslint-disable-next-line no-console
         console.error('transformersAreValid', JSON.stringify(validation));
         throw new Error(buildInvalidTransformersMessage(data.label));
     }

--- a/src/api/models/getPublishedDatasetFilter.js
+++ b/src/api/models/getPublishedDatasetFilter.js
@@ -44,7 +44,6 @@ export const addFieldsToFilters = matchableFields => filters => {
     };
 };
 
-
 export const getValueQueryFragment = (name, value, inverted) => {
     if (Array.isArray(value) && value.length > 1) {
         return {

--- a/src/api/models/getPublishedDatasetFilter.spec.js
+++ b/src/api/models/getPublishedDatasetFilter.spec.js
@@ -15,7 +15,10 @@ describe('getPublishedDatasetFilter', () => {
             };
             const facetNames = ['facet', 'otherFacet'];
             expect(
-                addFacetToFilters(facets, facetNames)({
+                addFacetToFilters(
+                    facets,
+                    facetNames,
+                )({
                     filter: 'data',
                 }),
             ).toEqual({
@@ -34,7 +37,10 @@ describe('getPublishedDatasetFilter', () => {
             };
             const facetNames = ['facet', 'otherFacet'];
             expect(
-                addFacetToFilters(facets, facetNames)({
+                addFacetToFilters(
+                    facets,
+                    facetNames,
+                )({
                     filter: 'data',
                 }),
             ).toEqual({
@@ -52,7 +58,10 @@ describe('getPublishedDatasetFilter', () => {
             };
             const facetNames = ['facet', 'otherFacet'];
             expect(
-                addFacetToFilters(facets, facetNames)({
+                addFacetToFilters(
+                    facets,
+                    facetNames,
+                )({
                     filter: 'data',
                 }),
             ).toEqual({
@@ -75,7 +84,10 @@ describe('getPublishedDatasetFilter', () => {
             };
             const facetNames = ['otherFacet'];
             expect(
-                addFacetToFilters(facets, facetNames)({
+                addFacetToFilters(
+                    facets,
+                    facetNames,
+                )({
                     filter: 'data',
                 }),
             ).toEqual({
@@ -88,7 +100,10 @@ describe('getPublishedDatasetFilter', () => {
             const facets = null;
             const facetNames = ['facet', 'otherFacet'];
             expect(
-                addFacetToFilters(facets, facetNames)({
+                addFacetToFilters(
+                    facets,
+                    facetNames,
+                )({
                     filter: 'data',
                 }),
             ).toEqual({
@@ -103,7 +118,10 @@ describe('getPublishedDatasetFilter', () => {
             };
             const facetNames = null;
             expect(
-                addFacetToFilters(facets, facetNames)({
+                addFacetToFilters(
+                    facets,
+                    facetNames,
+                )({
                     filter: 'data',
                 }),
             ).toEqual({
@@ -236,7 +254,10 @@ describe('getPublishedDatasetFilter', () => {
     describe('addKeyToFilters', () => {
         it('should add value at key to filters', () => {
             expect(
-                addKeyToFilters('key', 'value')({
+                addKeyToFilters(
+                    'key',
+                    'value',
+                )({
                     filter: 'data',
                 }),
             ).toEqual({
@@ -247,7 +268,10 @@ describe('getPublishedDatasetFilter', () => {
 
         it('should return filters if no values', () => {
             expect(
-                addKeyToFilters('key', null)({
+                addKeyToFilters(
+                    'key',
+                    null,
+                )({
                     filter: 'data',
                 }),
             ).toEqual({

--- a/src/api/reducers/count.js
+++ b/src/api/reducers/count.js
@@ -3,19 +3,19 @@
 // MongoDB JS functions
 //
 
-module.exports.map = function () {
+module.exports.map = function() {
     var doc = this;
     var dta = doc.versions[doc.versions.length - 1];
     dta.uri = doc.uri;
     fields
         .filter(function(key) {
-            return (dta[key] || doc[key]);
+            return dta[key] || doc[key];
         })
         .forEach(function(field) {
             emit(field, 1);
         });
 };
 
-module.exports.reduce = function (key, values) {
-  return Array.sum(values);
+module.exports.reduce = function(key, values) {
+    return Array.sum(values);
 };

--- a/src/api/reducers/count.js
+++ b/src/api/reducers/count.js
@@ -1,4 +1,5 @@
-/* eslint-disable */
+/* global fields, emit */
+
 //
 // MongoDB JS functions
 //

--- a/src/api/reducers/distinct.js
+++ b/src/api/reducers/distinct.js
@@ -3,29 +3,28 @@
 // MongoDB JS functions
 //
 
-module.exports.map = function () {
+module.exports.map = function() {
     var doc = this;
     var dta = doc.versions[doc.versions.length - 1];
     dta.uri = doc.uri;
     fields
         .filter(function(key) {
-            return (dta[key] || doc[key]);
+            return dta[key] || doc[key];
         })
         .map(function(key) {
             return dta[key] || doc[key];
         })
         .forEach(function(field) {
             if (Array.isArray(field)) {
-                field.forEach(function (fld) {
+                field.forEach(function(fld) {
                     emit(fld, 1);
                 });
-            }
-            else {
+            } else {
                 emit(field, 1);
             }
         });
 };
 
-module.exports.reduce = function (key, values) {
+module.exports.reduce = function(key, values) {
     return Array.sum(values);
 };

--- a/src/api/reducers/distinct.js
+++ b/src/api/reducers/distinct.js
@@ -1,4 +1,5 @@
-/* eslint-disable */
+/* global fields, emit */
+
 //
 // MongoDB JS functions
 //
@@ -7,6 +8,7 @@ module.exports.map = function() {
     var doc = this;
     var dta = doc.versions[doc.versions.length - 1];
     dta.uri = doc.uri;
+
     fields
         .filter(function(key) {
             return dta[key] || doc[key];

--- a/src/api/reducers/graph.js
+++ b/src/api/reducers/graph.js
@@ -1,4 +1,5 @@
-/* eslint-disable */
+/* global fields, emit */
+
 //
 // MongoDB JS functions
 //
@@ -50,7 +51,7 @@ module.exports.map = function() {
     });
 };
 
-module.exports.reduce = function(key, values) {
+module.exports.reduce = function(_, values) {
     return Array.sum(values);
 };
 

--- a/src/api/reducers/graph.js
+++ b/src/api/reducers/graph.js
@@ -3,7 +3,7 @@
 // MongoDB JS functions
 //
 
-module.exports.map = function () {
+module.exports.map = function() {
     var doc = this;
     var dta = doc.versions[doc.versions.length - 1];
     dta.uri = doc.uri;
@@ -20,8 +20,7 @@ module.exports.map = function () {
                 return o;
             });
         }
-    }
-    else if (fields.length > 1) {
+    } else if (fields.length > 1) {
         values = fields
             .map(function(field) {
                 var fieldValues = {};
@@ -31,32 +30,29 @@ module.exports.map = function () {
             .reduce(function(previous, current) {
                 var field = Object.keys(current)[0];
                 if (Array.isArray(current[field])) {
-                    current[field].sort().forEach(function (value) {
-                        var o    = {};
+                    current[field].sort().forEach(function(value) {
+                        var o = {};
                         o[field] = value;
                         previous.push(o);
                     });
-                }
-                else {
-                    var o    = {};
+                } else {
+                    var o = {};
                     o[field] = current[field];
                     previous.push(o);
                 }
                 return previous;
             }, []);
     }
-    values
-        .forEach(function(v, i) {
-            values.slice(i + 1).forEach(function(w) {
-                emit(JSON.stringify([v, w]), 1);
-            });
+    values.forEach(function(v, i) {
+        values.slice(i + 1).forEach(function(w) {
+            emit(JSON.stringify([v, w]), 1);
         });
+    });
 };
 
-module.exports.reduce = function (key, values) {
+module.exports.reduce = function(key, values) {
     return Array.sum(values);
 };
-
 
 module.exports.finalize = function finalize(key, value) {
     var vector = JSON.parse(key);
@@ -66,6 +62,6 @@ module.exports.finalize = function finalize(key, value) {
         source: vector[0][sourceKey],
         target: vector[1][targetKey],
         weight: value,
-    }
+    };
     return obj;
 };

--- a/src/api/reducers/groupby.js
+++ b/src/api/reducers/groupby.js
@@ -3,29 +3,28 @@
 // MongoDB JS functions
 //
 
-module.exports.map = function () {
+module.exports.map = function() {
     var doc = this;
     var dta = doc.versions[doc.versions.length - 1];
     dta.uri = doc.uri;
     fields
         .filter(function(key) {
-            return (dta[key] || doc[key]);
+            return dta[key] || doc[key];
         })
         .map(function(key) {
             return dta[key] || doc[key];
         })
         .forEach(function(field) {
             if (field instanceof Array) {
-                field.forEach(function (fld) {
+                field.forEach(function(fld) {
                     emit(fld, dta);
                 });
-            }
-            else {
+            } else {
                 emit(field, dta);
             }
         });
 };
 
-module.exports.reduce = function (key, values) {
+module.exports.reduce = function(key, values) {
     return { docs: values };
 };

--- a/src/api/reducers/groupby.js
+++ b/src/api/reducers/groupby.js
@@ -1,4 +1,5 @@
-/* eslint-disable */
+/* global fields, emit */
+
 //
 // MongoDB JS functions
 //

--- a/src/api/reducers/keys.js
+++ b/src/api/reducers/keys.js
@@ -1,4 +1,5 @@
-/* eslint-disable */
+/* global emit */
+
 //
 // MongoDB JS functions
 //

--- a/src/api/reducers/keys.js
+++ b/src/api/reducers/keys.js
@@ -3,15 +3,15 @@
 // MongoDB JS functions
 //
 
-module.exports.map = function () {
+module.exports.map = function() {
     var doc = this;
     var dta = doc.versions[doc.versions.length - 1];
     dta.uri = doc.uri;
-    Object.keys(dta).forEach(function (key) {
-      emit(key, 1);
+    Object.keys(dta).forEach(function(key) {
+        emit(key, 1);
     });
 };
 
-module.exports.reduce = function (key, values) {
-  return Array.sum(values);
+module.exports.reduce = function(key, values) {
+    return Array.sum(values);
 };

--- a/src/api/reducers/max.js
+++ b/src/api/reducers/max.js
@@ -3,27 +3,28 @@
 // MongoDB JS functions
 //
 
-module.exports.map = function () {
+module.exports.map = function() {
     var doc = this;
     var dta = doc.versions[doc.versions.length - 1];
     dta.uri = doc.uri;
     fields
         .filter(function(key) {
-            return (dta[key] || doc[key]);
+            return dta[key] || doc[key];
         })
         .forEach(function(key) {
             var field = dta[key] || doc[key];
             if (field instanceof Array) {
-                field.forEach(function (fld) {
+                field.forEach(function(fld) {
                     emit(key, Number(fld));
                 });
-            }
-            else {
+            } else {
                 emit(key, Number(field));
             }
         });
 };
 
-module.exports.reduce = function (key, values) {
-    return values.reduce(function (a, b) { return a > b ? a : b; });
+module.exports.reduce = function(key, values) {
+    return values.reduce(function(a, b) {
+        return a > b ? a : b;
+    });
 };

--- a/src/api/reducers/max.js
+++ b/src/api/reducers/max.js
@@ -1,4 +1,5 @@
-/* eslint-disable */
+/* global fields, emit */
+
 //
 // MongoDB JS functions
 //

--- a/src/api/reducers/merge.js
+++ b/src/api/reducers/merge.js
@@ -3,35 +3,33 @@
 // MongoDB JS functions
 //
 
-module.exports.map = function () {
+module.exports.map = function() {
     var doc = this;
     var dta = doc.versions[doc.versions.length - 1];
     dta.uri = doc.uri;
     fields
         .filter(function(key) {
-            return (dta[key] || doc[key]);
+            return dta[key] || doc[key];
         })
         .map(function(key) {
             return dta[key] || doc[key];
         })
         .forEach(function(field) {
             if (field instanceof Array) {
-                field.forEach(function (fld) {
+                field.forEach(function(fld) {
                     emit(fld, dta);
                 });
-            }
-            else {
+            } else {
                 emit(field, dta);
             }
         });
 };
 
-module.exports.reduce = function (key, values) {
-    var target = {}
-        , length = values.length
-        , name
-        , i = 1
-    ;
+module.exports.reduce = function(key, values) {
+    var target = {},
+        length = values.length,
+        name,
+        i = 1;
     for (; i < length; ++i) {
         if (values[i]) {
             for (name in values[i]) {

--- a/src/api/reducers/merge.js
+++ b/src/api/reducers/merge.js
@@ -1,4 +1,5 @@
-/* eslint-disable */
+/* global fields, emit */
+
 //
 // MongoDB JS functions
 //

--- a/src/api/reducers/min.js
+++ b/src/api/reducers/min.js
@@ -3,27 +3,28 @@
 // MongoDB JS functions
 //
 
-module.exports.map = function () {
+module.exports.map = function() {
     var doc = this;
     var dta = doc.versions[doc.versions.length - 1];
     dta.uri = doc.uri;
     fields
         .filter(function(key) {
-            return (dta[key] || doc[key]);
+            return dta[key] || doc[key];
         })
         .forEach(function(key) {
             var field = dta[key] || doc[key];
             if (field instanceof Array) {
-                field.forEach(function (fld) {
+                field.forEach(function(fld) {
                     emit(key, Number(fld));
                 });
-            }
-            else {
+            } else {
                 emit(key, Number(field));
             }
         });
 };
 
-module.exports.reduce = function (key, values) {
-    return values.reduce(function (a, b) { return a < b ? a : b; });
+module.exports.reduce = function(key, values) {
+    return values.reduce(function(a, b) {
+        return a < b ? a : b;
+    });
 };

--- a/src/api/reducers/min.js
+++ b/src/api/reducers/min.js
@@ -1,4 +1,5 @@
-/* eslint-disable */
+/* global fields, emit */
+
 //
 // MongoDB JS functions
 //

--- a/src/api/reducers/pairing.js
+++ b/src/api/reducers/pairing.js
@@ -3,7 +3,7 @@
 // MongoDB JS functions
 //
 
-module.exports.map = function () {
+module.exports.map = function() {
     var doc = this;
     var dta = doc.versions[doc.versions.length - 1];
     dta.uri = doc.uri;
@@ -16,28 +16,26 @@ module.exports.map = function () {
         }
         return value;
     });
-    values
-        .forEach(function(v, i) {
-            var allValues = values.slice(i + 1).reduce(function(previous, current) {
-                current.forEach(function(val) {
-                    previous.push(val);
+    values.forEach(function(v, i) {
+        var allValues = values.slice(i + 1).reduce(function(previous, current) {
+            current.forEach(function(val) {
+                previous.push(val);
+            });
+            return previous;
+        }, []);
+        if (allValues) {
+            v.forEach(function(w) {
+                allValues.forEach(function(x) {
+                    emit(JSON.stringify([w, x]), 1);
                 });
-                return previous;
-            }, []);
-            if (allValues) {
-                v.forEach(function(w) {
-                    allValues.forEach(function(x) {
-                        emit(JSON.stringify([w, x]), 1);
-                    });
-                })
-            }
-        });
+            });
+        }
+    });
 };
 
-module.exports.reduce = function (key, values) {
+module.exports.reduce = function(key, values) {
     return Array.sum(values);
 };
-
 
 module.exports.finalize = function finalize(key, value) {
     var vector = JSON.parse(key);
@@ -45,6 +43,6 @@ module.exports.finalize = function finalize(key, value) {
         source: vector[0],
         target: vector[1],
         weight: value,
-    }
+    };
     return obj;
 };

--- a/src/api/reducers/pairing.js
+++ b/src/api/reducers/pairing.js
@@ -1,4 +1,5 @@
-/* eslint-disable */
+/* global fields, emit */
+
 //
 // MongoDB JS functions
 //

--- a/src/api/reducers/stats.js
+++ b/src/api/reducers/stats.js
@@ -3,36 +3,35 @@
 // MongoDB JS functions
 //
 
-module.exports.map = function () {
+module.exports.map = function() {
     var doc = this;
     var dta = doc.versions[doc.versions.length - 1];
     dta.uri = doc.uri;
     fields
         .filter(function(key) {
-            return (dta[key] || doc[key]);
+            return dta[key] || doc[key];
         })
         .forEach(function(key) {
             var field = dta[key] || doc[key];
             if (field instanceof Array) {
-                field.forEach(function (fld) {
+                field.forEach(function(fld) {
                     var val = Number(fld);
                     emit(key, {
-                        sum: val || 0,
-                        min: val || 0,
-                        max: val || 0,
+                        sum: val || 0,
+                        min: val || 0,
+                        max: val || 0,
                         count: 1,
-                        diff: 0
+                        diff: 0,
                     });
                 });
-            }
-            else {
+            } else {
                 var val = Number(field);
                 emit(key, {
-                    sum: val || 0,
-                    min: val || 0,
-                    max: val || 0,
+                    sum: val || 0,
+                    min: val || 0,
+                    max: val || 0,
                     count: 1,
-                    diff: 0
+                    diff: 0,
                 });
             }
         });
@@ -41,14 +40,15 @@ module.exports.map = function () {
 module.exports.reduce = function reduce(key, values) {
     return values.reduce(function reduce(previous, current, index, array) {
         var delta = previous.sum / previous.count - current.sum / current.count;
-        var weight = previous.count * current.count / (previous.count + current.count);
+        var weight =
+            (previous.count * current.count) / (previous.count + current.count);
 
         return {
             sum: previous.sum + current.sum,
             min: Math.min(previous.min, current.min),
             max: Math.max(previous.max, current.max),
             count: previous.count + current.count,
-            diff: previous.diff + current.diff + delta * delta * weight
+            diff: previous.diff + current.diff + delta * delta * weight,
         };
     });
 };

--- a/src/api/reducers/stats.js
+++ b/src/api/reducers/stats.js
@@ -1,4 +1,5 @@
-/* eslint-disable */
+/* global fields, emit */
+
 //
 // MongoDB JS functions
 //

--- a/src/api/reducers/total.js
+++ b/src/api/reducers/total.js
@@ -3,31 +3,30 @@
 // MongoDB JS functions :  to sum all values from a field
 //
 
-module.exports.map = function () {
+module.exports.map = function() {
     var doc = this;
     var dta = doc.versions[doc.versions.length - 1];
     dta.uri = doc.uri;
     fields
         .filter(function(key) {
-            return (dta[key] || doc[key]);
+            return dta[key] || doc[key];
         })
         .map(function(key) {
-            return { key: key, val: dta[key] || doc[key] };
+            return { key: key, val: dta[key] || doc[key] };
         })
         .forEach(function(item) {
             var key = item.key;
             var val = item.val;
             if (Array.isArray(val)) {
-                val.forEach(function (v) {
+                val.forEach(function(v) {
                     emit(key, Number(v));
                 });
-            }
-            else {
+            } else {
                 emit(key, Number(val));
             }
         });
 };
 
-module.exports.reduce = function (key, values) {
-  return Array.sum(values);
+module.exports.reduce = function(key, values) {
+    return Array.sum(values);
 };

--- a/src/api/reducers/total.js
+++ b/src/api/reducers/total.js
@@ -1,4 +1,5 @@
-/* eslint-disable */
+/* global fields, emit */
+
 //
 // MongoDB JS functions :  to sum all values from a field
 //

--- a/src/api/reducers/ventilate.js
+++ b/src/api/reducers/ventilate.js
@@ -3,27 +3,26 @@
 // MongoDB JS functions
 //
 
-module.exports.map = function () {
+module.exports.map = function() {
     var doc = this;
     var dta = doc.versions[doc.versions.length - 1];
     dta.uri = doc.uri;
     fields
         .filter(function(key) {
-            return (dta[key] || doc[key]);
+            return dta[key] || doc[key];
         })
         .forEach(function(key) {
             var field = dta[key] || doc[key];
             if (field instanceof Array) {
-                field.forEach(function (fld) {
+                field.forEach(function(fld) {
                     emit(JSON.stringify([key, fld]), 1);
                 });
-            }
-            else {
+            } else {
                 emit(JSON.stringify([key, field]), 1);
             }
         });
 };
 
-module.exports.reduce = function (key, values) {
+module.exports.reduce = function(key, values) {
     return Array.sum(values);
 };

--- a/src/api/reducers/ventilate.js
+++ b/src/api/reducers/ventilate.js
@@ -1,4 +1,5 @@
-/* eslint-disable */
+/* global fields, emit */
+
 //
 // MongoDB JS functions
 //

--- a/src/api/services/ezMasterConfig.js
+++ b/src/api/services/ezMasterConfig.js
@@ -26,7 +26,7 @@ export const validateConfig = config => {
 
 export default async (ctx, next) => {
     try {
-        const config = require('../../../config.json'); // eslint-disable-line
+        const config = require('../../../config.json');
 
         validateConfig(config);
 
@@ -34,7 +34,7 @@ export default async (ctx, next) => {
     } catch (err) {
         const error = new Error(
             `Invalid configuration from EzMaster: ${err.message}`,
-        ); // eslint-disable-line
+        );
         throw error;
     }
 

--- a/src/api/services/ezMasterConfig.js
+++ b/src/api/services/ezMasterConfig.js
@@ -32,7 +32,9 @@ export default async (ctx, next) => {
 
         ctx.ezMasterConfig = config;
     } catch (err) {
-        const error = new Error(`Invalid configuration from EzMaster: ${err.message}`); // eslint-disable-line
+        const error = new Error(
+            `Invalid configuration from EzMaster: ${err.message}`,
+        ); // eslint-disable-line
         throw error;
     }
 

--- a/src/api/services/publishCharacteristics.spec.js
+++ b/src/api/services/publishCharacteristics.spec.js
@@ -1,4 +1,3 @@
-/* eslint max-len: off */
 import { publishCharacteristicsFactory } from './publishCharacteristics';
 
 describe('publishCharacteristics', () => {

--- a/src/api/statements/index.js
+++ b/src/api/statements/index.js
@@ -1,2 +1,1 @@
-export default {
-};
+export default {};

--- a/src/app/js/admin/ActionButton.js
+++ b/src/app/js/admin/ActionButton.js
@@ -38,7 +38,7 @@ const styles = {
 
 export class ActionButtonComponent extends Component {
     static propTypes = {
-        editedColumn: PropTypes.object, // eslint-disable-line
+        editedColumn: PropTypes.object,
         onAddNewColumn: PropTypes.func.isRequired,
         onHideExistingColumns: PropTypes.func.isRequired,
         onShowExistingColumns: PropTypes.func.isRequired,

--- a/src/app/js/admin/Admin.js
+++ b/src/app/js/admin/Admin.js
@@ -86,10 +86,7 @@ const mapDispatchToProps = {
 
 export default compose(
     withInitialData,
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     lifecycle({
         componentWillMount() {
             this.props.preLoadLoaders();

--- a/src/app/js/admin/Appbar/ClearDialog.js
+++ b/src/app/js/admin/Appbar/ClearDialog.js
@@ -38,7 +38,6 @@ class ClearDialogComponent extends Component {
 
     UNSAFE_componentWillReceiveProps(nextProps) {
         if (nextProps.succeeded) {
-            // eslint-disable-line
             window.location.reload();
         }
     }
@@ -145,6 +144,7 @@ class ClearDialogComponent extends Component {
 
 ClearDialogComponent.propTypes = {
     type: PropTypes.string.isRequired,
+    succeeded: PropTypes.bool.isRequired,
     p: polyglotPropTypes.isRequired,
     onClose: PropTypes.func.isRequired,
     clearDataset: PropTypes.func.isRequired,

--- a/src/app/js/admin/Appbar/ClearDialog.js
+++ b/src/app/js/admin/Appbar/ClearDialog.js
@@ -37,7 +37,8 @@ class ClearDialogComponent extends Component {
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) {
-        if (nextProps.succeeded) { // eslint-disable-line
+        if (nextProps.succeeded) {
+            // eslint-disable-line
             window.location.reload();
         }
     }
@@ -166,8 +167,5 @@ const mapDispatchToProps = {
 
 export default compose(
     translate,
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
 )(ClearDialogComponent);

--- a/src/app/js/admin/Appbar/ImportFieldsDialog.js
+++ b/src/app/js/admin/Appbar/ImportFieldsDialog.js
@@ -34,7 +34,6 @@ const styles = {
 class ImportFieldsDialogComponent extends Component {
     UNSAFE_componentWillReceiveProps(nextProps) {
         if (nextProps.succeeded) {
-            // eslint-disable-line
             this.props.onClose();
         }
     }
@@ -89,6 +88,7 @@ class ImportFieldsDialogComponent extends Component {
 }
 
 ImportFieldsDialogComponent.propTypes = {
+    succeeded: PropTypes.bool.isRequired,
     failed: PropTypes.bool.isRequired,
     importFields: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,

--- a/src/app/js/admin/Appbar/ImportFieldsDialog.js
+++ b/src/app/js/admin/Appbar/ImportFieldsDialog.js
@@ -33,7 +33,8 @@ const styles = {
 
 class ImportFieldsDialogComponent extends Component {
     UNSAFE_componentWillReceiveProps(nextProps) {
-        if (nextProps.succeeded) { // eslint-disable-line
+        if (nextProps.succeeded) {
+            // eslint-disable-line
             this.props.onClose();
         }
     }
@@ -105,8 +106,5 @@ const mapDispatchToProps = {
 
 export default compose(
     translate,
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
 )(ImportFieldsDialogComponent);

--- a/src/app/js/admin/Appbar/ModelMenu.js
+++ b/src/app/js/admin/Appbar/ModelMenu.js
@@ -124,9 +124,6 @@ const mapDispatchToProps = {
 
 export default compose(
     withRouter,
-    connect(
-        null,
-        mapDispatchToProps,
-    ),
+    connect(null, mapDispatchToProps),
     translate,
 )(ModelMenuComponent);

--- a/src/app/js/admin/Appbar/SignInButton.js
+++ b/src/app/js/admin/Appbar/SignInButton.js
@@ -34,6 +34,7 @@ const mapDispatchToProps = dispatch =>
         dispatch,
     );
 
-export default compose(connect(undefined, mapDispatchToProps), translate)(
-    SignInButtonComponent,
-);
+export default compose(
+    connect(undefined, mapDispatchToProps),
+    translate,
+)(SignInButtonComponent);

--- a/src/app/js/admin/Appbar/SignOutButton.js
+++ b/src/app/js/admin/Appbar/SignOutButton.js
@@ -40,6 +40,7 @@ const mapDispatchToProps = dispatch =>
         dispatch,
     );
 
-export default compose(connect(undefined, mapDispatchToProps), translate)(
-    SignOutButtonComponent,
-);
+export default compose(
+    connect(undefined, mapDispatchToProps),
+    translate,
+)(SignOutButtonComponent);

--- a/src/app/js/admin/Appbar/index.js
+++ b/src/app/js/admin/Appbar/index.js
@@ -139,7 +139,4 @@ const mapStateToProps = state => ({
     isAdmin: fromUser.isAdmin(state),
 });
 
-export default compose(
-    translate,
-    connect(mapStateToProps),
-)(AppbarComponent);
+export default compose(translate, connect(mapStateToProps))(AppbarComponent);

--- a/src/app/js/admin/Statistics.js
+++ b/src/app/js/admin/Statistics.js
@@ -100,6 +100,7 @@ const mapDispatchToProps = {
     handleHideExistingColumns: hideAddColumns,
 };
 
-export default compose(connect(mapStateToProps, mapDispatchToProps), translate)(
-    StatisticsComponent,
-);
+export default compose(
+    connect(mapStateToProps, mapDispatchToProps),
+    translate,
+)(StatisticsComponent);

--- a/src/app/js/admin/contributedResources/ContributedResourceList.js
+++ b/src/app/js/admin/contributedResources/ContributedResourceList.js
@@ -183,6 +183,7 @@ const mapDispatchToProps = {
     onChangeFilter: changeContributedResourceFilter,
 };
 
-export default compose(connect(mapStateToProps, mapDispatchToProps), translate)(
-    ContributedResourceListComponent,
-);
+export default compose(
+    connect(mapStateToProps, mapDispatchToProps),
+    translate,
+)(ContributedResourceListComponent);

--- a/src/app/js/admin/parsing/ParsingExcerpt.js
+++ b/src/app/js/admin/parsing/ParsingExcerpt.js
@@ -106,9 +106,6 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        undefined,
-        mapDispatchToProps,
-    ),
+    connect(undefined, mapDispatchToProps),
     pure,
 )(ParsingExcerptComponent);

--- a/src/app/js/admin/parsing/ParsingExcerptAddColumn.js
+++ b/src/app/js/admin/parsing/ParsingExcerptAddColumn.js
@@ -43,7 +43,7 @@ ParsingExcerptAddColumnComponent.propTypes = {
     atTop: PropTypes.bool.isRequired,
     handleAddColumn: PropTypes.func.isRequired,
     name: PropTypes.string.isRequired,
-    style: PropTypes.object, // eslint-disable-line
+    style: PropTypes.object,
     p: polyglotPropTypes.isRequired,
 };
 

--- a/src/app/js/admin/parsing/ParsingExcerptColumn.js
+++ b/src/app/js/admin/parsing/ParsingExcerptColumn.js
@@ -28,7 +28,7 @@ export const ParsingExcerptColumnComponent = ({ children, style, value }) =>
 
 ParsingExcerptColumnComponent.propTypes = {
     children: PropTypes.node,
-    style: PropTypes.object, // eslint-disable-line
+    style: PropTypes.object,
     value: PropTypes.string.isRequired,
 };
 

--- a/src/app/js/admin/parsing/ParsingExcerptHeaderColumn.js
+++ b/src/app/js/admin/parsing/ParsingExcerptHeaderColumn.js
@@ -26,7 +26,7 @@ export const ParsingExcerptHeaderColumnComponent = ({ style, column }) =>
     );
 
 ParsingExcerptHeaderColumnComponent.propTypes = {
-    style: PropTypes.object, // eslint-disable-line
+    style: PropTypes.object,
     column: PropTypes.string.isRequired,
 };
 

--- a/src/app/js/admin/parsing/ParsingResult.js
+++ b/src/app/js/admin/parsing/ParsingResult.js
@@ -99,9 +99,6 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     translate,
 )(ParsingResultComponent);

--- a/src/app/js/admin/preview/Excerpt.js
+++ b/src/app/js/admin/preview/Excerpt.js
@@ -104,8 +104,8 @@ ExcerptComponent.propTypes = {
     areHeadersClickable: PropTypes.bool.isRequired,
     className: PropTypes.string,
     columns: PropTypes.arrayOf(fieldPropTypes).isRequired,
-    colStyle: PropTypes.object, // eslint-disable-line
-    isPreview: PropTypes.bool, // eslint-disable-line
+    colStyle: PropTypes.object,
+    isPreview: PropTypes.bool,
     lines: PropTypes.arrayOf(PropTypes.object).isRequired,
     onCellClick: PropTypes.func.isRequired,
     onHeaderClick: PropTypes.func.isRequired,

--- a/src/app/js/admin/preview/Excerpt.spec.js
+++ b/src/app/js/admin/preview/Excerpt.spec.js
@@ -11,7 +11,10 @@ describe('<Excerpt />', () => {
             { name: 'foo', label: 'foo' },
             { name: 'bar', label: 'Super Bar' },
         ],
-        lines: [{ foo: 'foo1', bar: 'bar1' }, { foo: 'foo2', bar: 'bar2' }],
+        lines: [
+            { foo: 'foo1', bar: 'bar1' },
+            { foo: 'foo2', bar: 'bar2' },
+        ],
         p: { t: key => key },
     };
 

--- a/src/app/js/admin/preview/ExcerptHeader.js
+++ b/src/app/js/admin/preview/ExcerptHeader.js
@@ -13,14 +13,13 @@ import {
 import getFieldClassName from '../../lib/getFieldClassName';
 import { isLongText, getShortText } from '../../lib/longTexts';
 
-const getStyle = memoize(
-    field =>
-        field.cover === 'dataset'
-            ? {
-                  fontWeight: 'bold',
-                  color: 'black',
-              }
-            : null,
+const getStyle = memoize(field =>
+    field.cover === 'dataset'
+        ? {
+              fontWeight: 'bold',
+              color: 'black',
+          }
+        : null,
 );
 
 const ensureTextIsShort = text =>
@@ -80,6 +79,7 @@ const mapStateToProps = (state, { field }) => ({
     compositeFields: fromFields.getCompositeFieldsNamesByField(state, field),
 });
 
-export default compose(connect(mapStateToProps), translate)(
-    ExcerptHeaderComponent,
-);
+export default compose(
+    connect(mapStateToProps),
+    translate,
+)(ExcerptHeaderComponent);

--- a/src/app/js/admin/preview/ExcerptRemoveColumn.js
+++ b/src/app/js/admin/preview/ExcerptRemoveColumn.js
@@ -48,6 +48,7 @@ const mapDispatchtoProps = (dispatch, { field: { name } }) =>
         dispatch,
     );
 
-export default compose(connect(undefined, mapDispatchtoProps), translate)(
-    ExcerptRemoveColumnComponent,
-);
+export default compose(
+    connect(undefined, mapDispatchtoProps),
+    translate,
+)(ExcerptRemoveColumnComponent);

--- a/src/app/js/admin/preview/publication/PublicationPreview.js
+++ b/src/app/js/admin/preview/publication/PublicationPreview.js
@@ -77,9 +77,6 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        null,
-        mapDispatchToProps,
-    ),
+    connect(null, mapDispatchToProps),
     translate,
 )(PublicationPreviewComponent);

--- a/src/app/js/admin/progress/Progress.js
+++ b/src/app/js/admin/progress/Progress.js
@@ -109,8 +109,5 @@ const mapDispatchToProps = {
 
 export default compose(
     translate,
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
 )(Progress);

--- a/src/app/js/admin/publish/ConfirmPublication.js
+++ b/src/app/js/admin/publish/ConfirmPublication.js
@@ -72,6 +72,7 @@ const mapDispatchToProps = {
     cancelPublication: publishCancel,
 };
 
-export default compose(translate, connect(mapStateToProps, mapDispatchToProps))(
-    ConfirmPublicationComponent,
-);
+export default compose(
+    translate,
+    connect(mapStateToProps, mapDispatchToProps),
+)(ConfirmPublicationComponent);

--- a/src/app/js/admin/publish/PublishButton.js
+++ b/src/app/js/admin/publish/PublishButton.js
@@ -81,9 +81,6 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     translate,
 )(PublishButtonComponent);

--- a/src/app/js/admin/publish/ValidationButton.js
+++ b/src/app/js/admin/publish/ValidationButton.js
@@ -62,7 +62,7 @@ const ValidationButtonComponent = ({
 );
 
 ValidationButtonComponent.propTypes = {
-    popover: PropTypes.object, // eslint-disable-line
+    popover: PropTypes.object,
     handleEditField: PropTypes.func.isRequired,
     fields: PropTypes.arrayOf(validationFieldPropType).isRequired,
     handleHideErrors: PropTypes.func.isRequired,

--- a/src/app/js/admin/publish/sagas.js
+++ b/src/app/js/admin/publish/sagas.js
@@ -15,10 +15,10 @@ import { FINISH_PROGRESS, ERROR_PROGRESS } from '../progress/reducer';
 export function* handlePublishRequest() {
     const verifyUriRequest = yield select(fromUser.getVerifyUriRequest);
 
-    const { error: verifyError, response: { nbInvalidUri } } = yield call(
-        fetchSaga,
-        verifyUriRequest,
-    );
+    const {
+        error: verifyError,
+        response: { nbInvalidUri },
+    } = yield call(fetchSaga, verifyUriRequest);
 
     if (verifyError) {
         yield put(publishError(verifyError));

--- a/src/app/js/admin/removedResources/RemovedResourceList.js
+++ b/src/app/js/admin/removedResources/RemovedResourceList.js
@@ -159,9 +159,6 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     translate,
 )(RemovedResourceListComponent);

--- a/src/app/js/admin/upload/Upload.js
+++ b/src/app/js/admin/upload/Upload.js
@@ -96,9 +96,6 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        mapsStateToProps,
-        mapDispatchToProps
-    ),
-    translate
+    connect(mapsStateToProps, mapDispatchToProps),
+    translate,
 )(UploadComponent);

--- a/src/app/js/admin/upload/UploadButton.js
+++ b/src/app/js/admin/upload/UploadButton.js
@@ -96,8 +96,5 @@ const mapDispatchToProps = {
 
 export default compose(
     translate,
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
 )(UploadButtonComponent);

--- a/src/app/js/admin/upload/UploadDialog.js
+++ b/src/app/js/admin/upload/UploadDialog.js
@@ -169,8 +169,5 @@ const mapDispatchToProps = {
 
 export default compose(
     translate,
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
 )(UploadDialogComponent);

--- a/src/app/js/admin/withInitialData.js
+++ b/src/app/js/admin/withInitialData.js
@@ -51,10 +51,7 @@ export default BaseComponent => {
     });
 
     return compose(
-        connect(
-            mapStateToProps,
-            mapDispatchToProps,
-        ),
+        connect(mapStateToProps, mapDispatchToProps),
         translate,
     )(withInitialDataHoc(BaseComponent));
 };

--- a/src/app/js/configureStore.js
+++ b/src/app/js/configureStore.js
@@ -44,11 +44,7 @@ export default function configureStore(
     const store = createStore(
         reducer,
         initialState,
-        compose(
-            middlewares,
-            persistStateEnhancer,
-            devtools,
-        ),
+        compose(middlewares, persistStateEnhancer, devtools),
     );
 
     sagaMiddleware.run(sagas);

--- a/src/app/js/configureStoreServer.js
+++ b/src/app/js/configureStoreServer.js
@@ -23,10 +23,7 @@ export default function configureStoreServer(
     const store = createStore(
         connectRouter(history)(reducer),
         initialState,
-        compose(
-            middlewares,
-            devtools,
-        ),
+        compose(middlewares, devtools),
     );
 
     sagaMiddleware.run(sagas);

--- a/src/app/js/fields/ClassList.js
+++ b/src/app/js/fields/ClassList.js
@@ -26,8 +26,6 @@ const styles = {
     },
 };
 
-// FIXME: the props are declared, but ESLint warns!
-// eslint-disable-next-line react/prop-types
 const ClassList = ({ fields, p: polyglot }) => (
     <div>
         <div style={styles.header}>
@@ -53,11 +51,12 @@ const ClassList = ({ fields, p: polyglot }) => (
     </div>
 );
 
-ClassList.PropTypes = {
+ClassList.propTypes = {
     fields: PropTypes.shape({
         map: PropTypes.func.isRequired,
         get: PropTypes.func.isRequired,
         remove: PropTypes.func.isRequired,
+        push: PropTypes.func.isRequired,
     }).isRequired,
     p: polyglotPropTypes.isRequired,
     onChangeClass: PropTypes.func.isRequired,

--- a/src/app/js/fields/ClassListItem.js
+++ b/src/app/js/fields/ClassListItem.js
@@ -129,9 +129,6 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     translate,
 )(ClassListItem);

--- a/src/app/js/fields/ComposedOf.js
+++ b/src/app/js/fields/ComposedOf.js
@@ -108,6 +108,7 @@ const mapDispatchToProps = {
     removeComposedOf: () => change('field', 'composedOf', undefined),
 };
 
-export default compose(translate, connect(null, mapDispatchToProps))(
-    ComposedOfComponent,
-);
+export default compose(
+    translate,
+    connect(null, mapDispatchToProps),
+)(ComposedOfComponent);

--- a/src/app/js/fields/ComposedOfColumn.js
+++ b/src/app/js/fields/ComposedOfColumn.js
@@ -47,9 +47,7 @@ const ComposedOfColumn = ({
         </SelectField>
         {index > 1 && (
             <IconButton
-                className={`btn-remove-composite-field btn-remove-composite-field-${
-                    index
-                }`}
+                className={`btn-remove-composite-field btn-remove-composite-field-${index}`}
                 onClick={handleRemoveColumn}
                 title={polyglot.t('remove_composition_column')}
             >

--- a/src/app/js/fields/ComposedOfFieldListItem.js
+++ b/src/app/js/fields/ComposedOfFieldListItem.js
@@ -47,6 +47,7 @@ const mapStateToProps = (state, { fieldName }) => ({
     availableFields: fromFields.getFieldsExceptEdited(state),
 });
 
-export default compose(translate, connect(mapStateToProps))(
-    ComposedOfFieldListItemComponent,
-);
+export default compose(
+    translate,
+    connect(mapStateToProps),
+)(ComposedOfFieldListItemComponent);

--- a/src/app/js/fields/FieldComposedOf.js
+++ b/src/app/js/fields/FieldComposedOf.js
@@ -144,6 +144,7 @@ const mapDispatchToProps = (dispatch, { FORM_NAME = FIELD_FORM_NAME }) => ({
     },
 });
 
-export default compose(connect(mapStateToProps, mapDispatchToProps), translate)(
-    FieldComposedOf,
-);
+export default compose(
+    connect(mapStateToProps, mapDispatchToProps),
+    translate,
+)(FieldComposedOf);

--- a/src/app/js/fields/FieldLabelInput.js
+++ b/src/app/js/fields/FieldLabelInput.js
@@ -47,6 +47,7 @@ const mapStateToProps = state => ({
     fields: fromFields.getFields(state),
 });
 
-export default compose(connect(mapStateToProps), translate)(
-    FieldLabelInputComponent,
-);
+export default compose(
+    connect(mapStateToProps),
+    translate,
+)(FieldLabelInputComponent);

--- a/src/app/js/fields/FieldWidthInput.js
+++ b/src/app/js/fields/FieldWidthInput.js
@@ -10,7 +10,8 @@ const FieldWidthInput = () => (
             name="width"
             component={FormPercentField}
             labelKey="field_width"
-        />%
+        />
+        %
     </div>
 );
 

--- a/src/app/js/fields/InvalidFieldProperties.js
+++ b/src/app/js/fields/InvalidFieldProperties.js
@@ -40,6 +40,7 @@ const mapStateToprops = state => ({
     invalidProperties: fromFields.getInvalidProperties(state),
 });
 
-export default compose(translate, connect(mapStateToprops))(
-    InvalidFieldProperties,
-);
+export default compose(
+    translate,
+    connect(mapStateToprops),
+)(InvalidFieldProperties);

--- a/src/app/js/fields/TransformerArgList.js
+++ b/src/app/js/fields/TransformerArgList.js
@@ -1,4 +1,3 @@
-/* eslint react/no-array-index-key: off */
 import React from 'react';
 import PropTypes from 'prop-types';
 import pure from 'recompose/pure';
@@ -21,6 +20,8 @@ const TransformerArgList = ({ fields }) => (
 TransformerArgList.propTypes = {
     fields: PropTypes.shape({
         map: PropTypes.func.isRequired,
+        remove: PropTypes.func.isRequired,
+        get: PropTypes.func.isRequired,
     }).isRequired,
 };
 

--- a/src/app/js/fields/TransformerListItem.js
+++ b/src/app/js/fields/TransformerListItem.js
@@ -83,6 +83,7 @@ const mapDispatchToProps = {
     onChangeOperation: changeOperation,
 };
 
-export default compose(connect(mapStateToProps, mapDispatchToProps), translate)(
-    TransformerListItem,
-);
+export default compose(
+    connect(mapStateToProps, mapDispatchToProps),
+    translate,
+)(TransformerListItem);

--- a/src/app/js/fields/addCharacteristic/AddCharacteristic.js
+++ b/src/app/js/fields/addCharacteristic/AddCharacteristic.js
@@ -27,6 +27,7 @@ const mapDispatchToProps = {
     handleClose: () => addCharacteristicCancel(),
 };
 
-export default compose(translate, connect(mapStateToProps, mapDispatchToProps))(
-    ButtonWithDialogForm,
-);
+export default compose(
+    translate,
+    connect(mapStateToProps, mapDispatchToProps),
+)(ButtonWithDialogForm);

--- a/src/app/js/fields/addField/AddField.js
+++ b/src/app/js/fields/addField/AddField.js
@@ -28,8 +28,5 @@ const mapDispatchToProps = {
 
 export default compose(
     translate,
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
 )(ButtonWithDialogForm);

--- a/src/app/js/fields/addField/AddFieldForm.js
+++ b/src/app/js/fields/addField/AddFieldForm.js
@@ -71,10 +71,7 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     withHandlers({
         onSubmit: ({ addFieldToResource, resource }) => () => {
             addFieldToResource(resource.uri);

--- a/src/app/js/fields/addField/Contributor.js
+++ b/src/app/js/fields/addField/Contributor.js
@@ -8,7 +8,7 @@ import { polyglot as polyglotPropTypes } from '../../propTypes';
 const required = value => (value ? undefined : 'Required');
 const validMail = value =>
     value.match(
-        /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/, // eslint-disable-line
+        /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
     )
         ? undefined
         : 'Invalid mail';

--- a/src/app/js/fields/addField/SelectFieldToAdd.js
+++ b/src/app/js/fields/addField/SelectFieldToAdd.js
@@ -70,6 +70,7 @@ const mapDispatchToProps = {
     onSelectField: selectField,
 };
 
-export default compose(connect(mapStateToProps, mapDispatchToProps), translate)(
-    SelectFieldToAddComponent,
-);
+export default compose(
+    connect(mapStateToProps, mapDispatchToProps),
+    translate,
+)(SelectFieldToAddComponent);

--- a/src/app/js/fields/editFieldValue/EditButton.js
+++ b/src/app/js/fields/editFieldValue/EditButton.js
@@ -72,10 +72,7 @@ const mapDispatchToProps = {
 
 export default compose(
     translate,
-    connect(
-        null,
-        mapDispatchToProps,
-    ),
+    connect(null, mapDispatchToProps),
     withHandlers({
         onSaveProperty: ({
             updateCharacteristics,

--- a/src/app/js/fields/ontology/EditOntologyFieldButton.js
+++ b/src/app/js/fields/ontology/EditOntologyFieldButton.js
@@ -43,8 +43,5 @@ const mapDispatchToProps = (dispatch, { field: { name } }) => ({
 
 export default compose(
     translate,
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
 )(ButtonWithDialogForm);

--- a/src/app/js/fields/ontology/EditOntologyFieldForm.js
+++ b/src/app/js/fields/ontology/EditOntologyFieldForm.js
@@ -74,10 +74,7 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     withHandlers({
         onSubmit: ({ onSaveField }) => values => {
             onSaveField(values);

--- a/src/app/js/fields/ontology/Ontology.js
+++ b/src/app/js/fields/ontology/Ontology.js
@@ -92,10 +92,7 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        null,
-        mapDispatchToProps,
-    ),
+    connect(null, mapDispatchToProps),
     redirectToDashboardIfNoField,
     translate,
 )(OntologyComponent);

--- a/src/app/js/fields/ontology/OntologyTable.js
+++ b/src/app/js/fields/ontology/OntologyTable.js
@@ -100,10 +100,7 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     withHandlers({
         handleChangePosition: ({ changePositionAction }) => field => {
             changePositionAction(field);

--- a/src/app/js/fields/selectors.js
+++ b/src/app/js/fields/selectors.js
@@ -59,27 +59,22 @@ const getParams = (_, params) => params;
 
 const getEditedField = state => state.byName[state.editedFieldName];
 
-export const getCollectionFields = createSelector(
-    getFields,
-    fields => fields.filter(f => f.cover === COVER_COLLECTION),
+export const getCollectionFields = createSelector(getFields, fields =>
+    fields.filter(f => f.cover === COVER_COLLECTION),
 );
 
-const getDocumentFields = createSelector(
-    getFields,
-    fields =>
-        fields
-            .filter(f => f.display_in_resource || f.contribution)
-            .filter(f => f.cover === COVER_DOCUMENT),
+const getDocumentFields = createSelector(getFields, fields =>
+    fields
+        .filter(f => f.display_in_resource || f.contribution)
+        .filter(f => f.cover === COVER_DOCUMENT),
 );
 
-const getDatasetFields = createSelector(
-    getFields,
-    fields => fields.filter(f => f.cover === COVER_DATASET),
+const getDatasetFields = createSelector(getFields, fields =>
+    fields.filter(f => f.cover === COVER_DATASET),
 );
 
-const getComposedFields = createSelector(
-    getFields,
-    fields => fields.filter(({ composedOf }) => !!composedOf),
+const getComposedFields = createSelector(getFields, fields =>
+    fields.filter(({ composedOf }) => !!composedOf),
 );
 
 export const isACompositeFields = (name, composedFields) =>
@@ -115,19 +110,16 @@ const getResourceFields = createSelector(
             : [],
 );
 
-const getListFields = createSelector(
-    getCollectionFields,
-    fields => fields.filter(f => f.name === 'uri').filter(f => !f.composedOf),
+const getListFields = createSelector(getCollectionFields, fields =>
+    fields.filter(f => f.name === 'uri').filter(f => !f.composedOf),
 );
 
-const getGraphFields = createSelector(
-    getDatasetFields,
-    fields => fields.filter(f => f.display_in_graph),
+const getGraphFields = createSelector(getDatasetFields, fields =>
+    fields.filter(f => f.display_in_graph),
 );
 
-const getAllListFields = createSelector(
-    getCollectionFields,
-    fields => fields.filter(f => !f.composedOf),
+const getAllListFields = createSelector(getCollectionFields, fields =>
+    fields.filter(f => !f.composedOf),
 );
 
 const findFieldWithOverviewID = id => fields => {
@@ -141,9 +133,8 @@ export const getFieldByName = createSelector(
     (name, fields) => fields.find(f => f.name === name),
 );
 
-export const getGraphFieldParamsByName = createSelector(
-    getFieldByName,
-    field => get(field, 'format.args.params', {}),
+export const getGraphFieldParamsByName = createSelector(getFieldByName, field =>
+    get(field, 'format.args.params', {}),
 );
 
 export const getFieldsExceptEdited = createSelector(
@@ -250,9 +241,8 @@ const getCompositeFieldsNamesByField = createSelector(
 
 const hasPublishedDataset = ({ published }) => published;
 
-const getContributionFields = createSelector(
-    getFields,
-    fields => fields.filter(f => f.contribution),
+const getContributionFields = createSelector(getFields, fields =>
+    fields.filter(f => f.contribution),
 );
 
 const getSelectedField = ({ selectedField }) => selectedField;
@@ -317,9 +307,8 @@ const isSaving = state => state.isSaving;
 const isAdding = state => state.isAdding;
 const getError = state => state.error;
 
-const getFacetFields = createSelector(
-    getFields,
-    allFields => allFields.filter(f => f.isFacet),
+const getFacetFields = createSelector(getFields, allFields =>
+    allFields.filter(f => f.isFacet),
 );
 
 const hasFacetFields = createSelector(
@@ -360,9 +349,8 @@ const isFieldConfigured = createSelector(
 export const getNewCharacteristicFormData = state =>
     state.form[NEW_CHARACTERISTIC_FORM_NAME].values;
 
-const getFieldFormatArgs = createSelector(
-    getFieldByName,
-    field => get(field, 'format.args', {}),
+const getFieldFormatArgs = createSelector(getFieldByName, field =>
+    get(field, 'format.args', {}),
 );
 
 const getInvalidProperties = state => state.invalidProperties || [];

--- a/src/app/js/fields/wizard/ConcatField.js
+++ b/src/app/js/fields/wizard/ConcatField.js
@@ -1,5 +1,3 @@
-/* eslint react/no-array-index-key: off */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import IconButton from 'material-ui/IconButton';

--- a/src/app/js/fields/wizard/SelectDatasetField.js
+++ b/src/app/js/fields/wizard/SelectDatasetField.js
@@ -58,6 +58,7 @@ const mapStateToProps = state => ({
     datasetFields: fromParsing.getParsedExcerptColumns(state),
 });
 
-export default compose(connect(mapStateToProps), translate)(
-    SelectDatasetFieldComponent,
-);
+export default compose(
+    connect(mapStateToProps),
+    translate,
+)(SelectDatasetFieldComponent);

--- a/src/app/js/fields/wizard/Step.js
+++ b/src/app/js/fields/wizard/Step.js
@@ -47,7 +47,7 @@ StepComponent.propTypes = {
     disabled: PropTypes.bool,
     index: PropTypes.number.isRequired,
     last: PropTypes.bool,
-    style: PropTypes.object, // eslint-disable-line
+    style: PropTypes.object,
     icon: PropTypes.node,
 
     handleSelectStep: PropTypes.func.isRequired,

--- a/src/app/js/fields/wizard/StepDisplay.js
+++ b/src/app/js/fields/wizard/StepDisplay.js
@@ -31,7 +31,7 @@ export const StepDisplayComponent = ({ cover, p: polyglot, ...props }) => (
 StepDisplayComponent.propTypes = {
     transformers: PropTypes.arrayOf(PropTypes.object).isRequired,
     cover: PropTypes.oneOf(COVERS),
-    format: PropTypes.object, // eslint-disable-line
+    format: PropTypes.object,
     p: polyglotPropTypes.isRequired,
 };
 

--- a/src/app/js/fields/wizard/StepUriConcat.js
+++ b/src/app/js/fields/wizard/StepUriConcat.js
@@ -1,5 +1,3 @@
-/* eslint react/no-array-index-key: off */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import RadioButton from 'material-ui/RadioButton';

--- a/src/app/js/fields/wizard/StepValueConcat.js
+++ b/src/app/js/fields/wizard/StepValueConcat.js
@@ -1,5 +1,3 @@
-/* eslint react/no-array-index-key: off */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import RadioButton from 'material-ui/RadioButton';

--- a/src/app/js/fields/wizard/index.js
+++ b/src/app/js/fields/wizard/index.js
@@ -233,9 +233,6 @@ const mapDispatchToProps = {
     saveField: saveFieldAction,
 };
 
-export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
-)(FieldEditionWizardComponent);
+export default compose(connect(mapStateToProps, mapDispatchToProps))(
+    FieldEditionWizardComponent,
+);

--- a/src/app/js/formats/DefaultFormat/DefaultEdition.js
+++ b/src/app/js/formats/DefaultFormat/DefaultEdition.js
@@ -46,8 +46,5 @@ const mapDispatchToProps = {
 
 export default compose(
     translate,
-    connect(
-        null,
-        mapDispatchToProps,
-    ),
+    connect(null, mapDispatchToProps),
 )(DefaultEditon);

--- a/src/app/js/formats/bubbleChart/BubbleView.js
+++ b/src/app/js/formats/bubbleChart/BubbleView.js
@@ -71,7 +71,4 @@ const mapStateToProps = (state, { formatData, diameter: stringDiameter }) => {
     };
 };
 
-export default compose(
-    injectData(),
-    connect(mapStateToProps),
-)(BubbleView);
+export default compose(injectData(), connect(mapStateToProps))(BubbleView);

--- a/src/app/js/formats/cartography/CartographyView.js
+++ b/src/app/js/formats/cartography/CartographyView.js
@@ -252,8 +252,5 @@ const mapDispatchToProps = {};
 
 export default compose(
     injectData(),
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
 )(CartographyView);

--- a/src/app/js/formats/code/CodeAdmin.js
+++ b/src/app/js/formats/code/CodeAdmin.js
@@ -35,7 +35,10 @@ class AdminComponent extends Component {
     };
 
     render() {
-        const { p: polyglot, args: { languageToHighlight } } = this.props;
+        const {
+            p: polyglot,
+            args: { languageToHighlight },
+        } = this.props;
 
         return (
             <div style={styles.container}>

--- a/src/app/js/formats/distributionChart/global-bar-chart/BarChartView.js
+++ b/src/app/js/formats/distributionChart/global-bar-chart/BarChartView.js
@@ -176,7 +176,4 @@ const mapStateToProps = (
     };
 };
 
-export default compose(
-    injectData(),
-    connect(mapStateToProps),
-)(BarChartView);
+export default compose(injectData(), connect(mapStateToProps))(BarChartView);

--- a/src/app/js/formats/heatmap/HeatMapView.js
+++ b/src/app/js/formats/heatmap/HeatMapView.js
@@ -217,7 +217,4 @@ const mapStateToProps = (state, { formatData, colorScheme, flipAxis }) => {
     };
 };
 
-export default compose(
-    injectData(),
-    connect(mapStateToProps),
-)(HeatMapView);
+export default compose(injectData(), connect(mapStateToProps))(HeatMapView);

--- a/src/app/js/formats/html/HtmlView.js
+++ b/src/app/js/formats/html/HtmlView.js
@@ -1,4 +1,3 @@
-/* eslint react/no-danger: off */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { field as fieldPropTypes } from '../../propTypes';
@@ -13,7 +12,7 @@ const HtmlView = ({ className, resource, field }) => (
 HtmlView.propTypes = {
     className: PropTypes.string,
     field: fieldPropTypes.isRequired,
-    resource: PropTypes.object.isRequired, // eslint-disable-line
+    resource: PropTypes.object.isRequired,
 };
 
 HtmlView.defaultProps = {

--- a/src/app/js/formats/identifier-badge/IdentifierBadgeView.js
+++ b/src/app/js/formats/identifier-badge/IdentifierBadgeView.js
@@ -59,7 +59,7 @@ IdentifierBadgeView.propTypes = {
     field: fieldPropTypes.isRequired,
     typid: PropTypes.string.isRequired,
     colors: PropTypes.string.isRequired,
-    resource: PropTypes.object.isRequired, // eslint-disable-line
+    resource: PropTypes.object.isRequired,
 };
 
 export default IdentifierBadgeView;

--- a/src/app/js/formats/image/ImageView.js
+++ b/src/app/js/formats/image/ImageView.js
@@ -21,7 +21,7 @@ const ImageView = ({ resource, field, imageWidth }) => {
 
 ImageView.propTypes = {
     field: fieldPropTypes.isRequired,
-    resource: PropTypes.object.isRequired, // eslint-disable-line
+    resource: PropTypes.object.isRequired,
     imageWidth: PropTypes.string.isRequired,
 };
 

--- a/src/app/js/formats/istex/IstexView.js
+++ b/src/app/js/formats/istex/IstexView.js
@@ -76,7 +76,7 @@ export const IstexView = ({
 
 IstexView.propTypes = {
     fieldStatus: PropTypes.string,
-    resource: PropTypes.object.isRequired, // eslint-disable-line
+    resource: PropTypes.object.isRequired,
     field: fieldPropTypes.isRequired,
     data: PropTypes.shape({
         hits: PropTypes.array.isRequired,

--- a/src/app/js/formats/istex/ListComponent.js
+++ b/src/app/js/formats/istex/ListComponent.js
@@ -27,7 +27,7 @@ const IstexView = ({ fieldStatus, field, resource }) => {
 
 IstexView.propTypes = {
     fieldStatus: PropTypes.string,
-    resource: PropTypes.object.isRequired, // eslint-disable-line
+    resource: PropTypes.object.isRequired,
     field: fieldPropTypes.isRequired,
 };
 

--- a/src/app/js/formats/istexSummary/IstexSummaryList.js
+++ b/src/app/js/formats/istexSummary/IstexSummaryList.js
@@ -23,7 +23,7 @@ const IstexSummaryList = ({ fieldStatus, field, resource }) => {
             style={styles.text(fieldStatus)}
             href={`${url}`}
             target="_blank"
-            rel="noopener"
+            rel="noopener noreferrer"
         >
             {url}
         </a>
@@ -32,7 +32,7 @@ const IstexSummaryList = ({ fieldStatus, field, resource }) => {
 
 IstexSummaryList.propTypes = {
     fieldStatus: PropTypes.string,
-    resource: PropTypes.object.isRequired, // eslint-disable-line
+    resource: PropTypes.object.isRequired,
     field: fieldPropTypes.isRequired,
 };
 

--- a/src/app/js/formats/link-image/LinkImageAdmin.js
+++ b/src/app/js/formats/link-image/LinkImageAdmin.js
@@ -56,7 +56,10 @@ class LinkImageAdmin extends Component {
     };
 
     render() {
-        const { p: polyglot, args: { type, value, maxHeight } } = this.props;
+        const {
+            p: polyglot,
+            args: { type, value, maxHeight },
+        } = this.props;
 
         return (
             <div style={styles.container}>

--- a/src/app/js/formats/lodex-field/LodexFieldAdmin.js
+++ b/src/app/js/formats/lodex-field/LodexFieldAdmin.js
@@ -66,7 +66,10 @@ class LodexFieldAdmin extends Component {
     };
 
     render() {
-        const { p: polyglot, args: { param } } = this.props;
+        const {
+            p: polyglot,
+            args: { param },
+        } = this.props;
         const { labelArray, hiddenInfo } = param || defaultArgs.param;
         const label = labelArray.join(';');
 

--- a/src/app/js/formats/markdown/MarkdownView.js
+++ b/src/app/js/formats/markdown/MarkdownView.js
@@ -1,4 +1,3 @@
-/* eslint react/no-danger: off */
 import React from 'react';
 import PropTypes from 'prop-types';
 import MarkdownIt from 'markdown-it';
@@ -32,7 +31,7 @@ const MarkdownView = ({ className, resource, field }) => {
 MarkdownView.propTypes = {
     className: PropTypes.string,
     field: fieldPropTypes.isRequired,
-    resource: PropTypes.object.isRequired, // eslint-disable-line
+    resource: PropTypes.object.isRequired,
 };
 
 MarkdownView.defaultProps = {

--- a/src/app/js/formats/network/NetworkView.js
+++ b/src/app/js/formats/network/NetworkView.js
@@ -173,7 +173,4 @@ const mapStateToProps = (state, { formatData }) => {
     };
 };
 
-export default compose(
-    injectData(),
-    connect(mapStateToProps),
-)(Network);
+export default compose(injectData(), connect(mapStateToProps))(Network);

--- a/src/app/js/formats/paragraph/ParagraphAdmin.js
+++ b/src/app/js/formats/paragraph/ParagraphAdmin.js
@@ -36,7 +36,10 @@ class ParagraphAdmin extends Component {
     };
 
     render() {
-        const { p: polyglot, args: { paragraphWidth } } = this.props;
+        const {
+            p: polyglot,
+            args: { paragraphWidth },
+        } = this.props;
 
         return (
             <div style={styles.container}>

--- a/src/app/js/formats/pdf/PDFView.js
+++ b/src/app/js/formats/pdf/PDFView.js
@@ -36,7 +36,7 @@ const PDFView = ({ resource, field, PDFWidth }) => {
 
 PDFView.propTypes = {
     field: fieldPropTypes.isRequired,
-    resource: PropTypes.object.isRequired, // eslint-disable-line
+    resource: PropTypes.object.isRequired,
     PDFWidth: PropTypes.string.isRequired,
 };
 

--- a/src/app/js/formats/redirect/RedirectView.js
+++ b/src/app/js/formats/redirect/RedirectView.js
@@ -128,7 +128,4 @@ const mapStateToProps = () => ({
     classes: styles,
 });
 
-export default compose(
-    connect(mapStateToProps),
-    translate,
-)(RedirectView);
+export default compose(connect(mapStateToProps), translate)(RedirectView);

--- a/src/app/js/formats/sentence/SentenceAdmin.js
+++ b/src/app/js/formats/sentence/SentenceAdmin.js
@@ -42,7 +42,10 @@ class SentenceAdmin extends Component {
     };
 
     render() {
-        const { p: polyglot, args: { prefix, suffix } } = this.props;
+        const {
+            p: polyglot,
+            args: { prefix, suffix },
+        } = this.props;
 
         return (
             <div style={styles.container}>

--- a/src/app/js/formats/sparql/SparqlRequest.js
+++ b/src/app/js/formats/sparql/SparqlRequest.js
@@ -241,10 +241,7 @@ export default url => FormatView => {
     };
 
     return compose(
-        connect(
-            mapStateToProps,
-            mapDispatchToProps,
-        ),
+        connect(mapStateToProps, mapDispatchToProps),
         translate,
     )(SparqlRequest);
 };

--- a/src/app/js/formats/uri/UriAdmin.js
+++ b/src/app/js/formats/uri/UriAdmin.js
@@ -44,7 +44,10 @@ class UriAdmin extends Component {
     };
 
     render() {
-        const { p: polyglot, args: { type, value } } = this.props;
+        const {
+            p: polyglot,
+            args: { type, value },
+        } = this.props;
 
         return (
             <div style={styles.container}>

--- a/src/app/js/formats/vega-lite/VegaLiteView.js
+++ b/src/app/js/formats/vega-lite/VegaLiteView.js
@@ -54,7 +54,4 @@ const mapStateToProps = (state, { formatData }) => {
     };
 };
 
-export default compose(
-    injectData(),
-    connect(mapStateToProps),
-)(VegaLiteView);
+export default compose(injectData(), connect(mapStateToProps))(VegaLiteView);

--- a/src/app/js/lib/components/Alert.js
+++ b/src/app/js/lib/components/Alert.js
@@ -20,7 +20,7 @@ const Alert = ({ children, style }) => (
 
 Alert.propTypes = {
     children: PropTypes.node.isRequired,
-    style: PropTypes.object, // eslint-disable-line
+    style: PropTypes.object,
 };
 
 Alert.defaultProps = {

--- a/src/app/js/lib/components/ButtonWithDialogForm.js
+++ b/src/app/js/lib/components/ButtonWithDialogForm.js
@@ -125,10 +125,7 @@ PureButtonWithDialogForm.propTypes = {
 const mapDispatchToProps = { submit: submitAction };
 
 export default compose(
-    connect(
-        null,
-        mapDispatchToProps,
-    ),
+    connect(null, mapDispatchToProps),
     withHandlers({
         handleSubmit: ({ submit, formName }) => () => {
             submit(formName);

--- a/src/app/js/lib/components/ButtonWithDialogForm.js
+++ b/src/app/js/lib/components/ButtonWithDialogForm.js
@@ -113,8 +113,8 @@ PureButtonWithDialogForm.propTypes = {
     saving: PropTypes.bool.isRequired,
     open: PropTypes.bool,
     show: PropTypes.bool,
-    buttonStyle: PropTypes.object, // eslint-disable-line
-    style: PropTypes.object, // eslint-disable-line
+    buttonStyle: PropTypes.object,
+    style: PropTypes.object,
     form: PropTypes.node.isRequired,
     icon: PropTypes.node,
     label: PropTypes.string.isRequired,

--- a/src/app/js/lib/components/Card.js
+++ b/src/app/js/lib/components/Card.js
@@ -15,7 +15,7 @@ const CardComponent = ({ children, style, ...props }) => (
 
 CardComponent.propTypes = {
     children: PropTypes.node.isRequired,
-    style: PropTypes.object, // eslint-disable-line
+    style: PropTypes.object,
 };
 
 export default CardComponent;

--- a/src/app/js/lib/components/ColorScalePreview.js
+++ b/src/app/js/lib/components/ColorScalePreview.js
@@ -18,11 +18,9 @@ const styles = {
 
 const ColorScalePreview = ({ colorScale }) => (
     <div style={styles.preview}>
-        {colorScale
-            .range()
-            .map(value => (
-                <div key={value} style={styles.previewColor(value)} />
-            ))}
+        {colorScale.range().map(value => (
+            <div key={value} style={styles.previewColor(value)} />
+        ))}
     </div>
 );
 

--- a/src/app/js/lib/components/FloatingActionButton.js
+++ b/src/app/js/lib/components/FloatingActionButton.js
@@ -51,7 +51,7 @@ FloatingActionButtonComponent.propTypes = {
     handleMouseLeave: PropTypes.func.isRequired,
     setShowTooltip: PropTypes.func.isRequired,
     showTooltip: PropTypes.bool.isRequired,
-    style: PropTypes.object, // eslint-disable-line
+    style: PropTypes.object,
     tooltip: PropTypes.string,
 };
 

--- a/src/app/js/lib/components/FormAutoCompleteField.js
+++ b/src/app/js/lib/components/FormAutoCompleteField.js
@@ -72,9 +72,6 @@ const handleComplete = ({
 };
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     withHandlers({ handleValueChosen, handleComplete }),
 )(FormAutoCompleteField);

--- a/src/app/js/lib/components/Tooltip.js
+++ b/src/app/js/lib/components/Tooltip.js
@@ -32,12 +32,7 @@ function getStyles(props, context, state) {
         rootWhenShownTop = 36;
     }
 
-    const {
-        baseTheme,
-        zIndex,
-        tooltip,
-        borderRadius,
-    } = context.muiTheme;
+    const { baseTheme, zIndex, tooltip, borderRadius } = context.muiTheme;
 
     const styles = {
         root: {
@@ -54,12 +49,21 @@ function getStyles(props, context, state) {
             userSelect: 'none',
             opacity: 0,
             right: horizontalPosition === 'left' ? 70 : null,
-            left: horizontalPosition === 'center' ?
-                (state.offsetWidth - 48) / 2 * -1 :
-                horizontalPosition === 'right' ? 12 : null,
-            transition: `${transitions.easeOut('0ms', 'top', '450ms')}, ${
-                transitions.easeOut('450ms', 'transform', '0ms')}, ${
-                transitions.easeOut('450ms', 'opacity', '0ms')}`,
+            left:
+                horizontalPosition === 'center'
+                    ? ((state.offsetWidth - 48) / 2) * -1
+                    : horizontalPosition === 'right'
+                    ? 12
+                    : null,
+            transition: `${transitions.easeOut(
+                '0ms',
+                'top',
+                '450ms',
+            )}, ${transitions.easeOut(
+                '450ms',
+                'transform',
+                '0ms',
+            )}, ${transitions.easeOut('450ms', 'opacity', '0ms')}`,
         },
         label: {
             position: 'relative',
@@ -67,23 +71,39 @@ function getStyles(props, context, state) {
         },
         ripple: {
             position: 'absolute',
-            left: horizontalPosition === 'center' ? '50%' :
-                horizontalPosition === 'left' ? '100%' : '0%',
+            left:
+                horizontalPosition === 'center'
+                    ? '50%'
+                    : horizontalPosition === 'left'
+                    ? '100%'
+                    : '0%',
             top: verticalPosition === 'bottom' ? 0 : '100%',
             transform: 'translate(-50%, -50%)',
             borderRadius: '50%',
             backgroundColor: 'transparent',
-            transition: `${transitions.easeOut('0ms', 'width', '450ms')}, ${
-                transitions.easeOut('0ms', 'height', '450ms')}, ${
-                transitions.easeOut('450ms', 'backgroundColor', '0ms')}`,
+            transition: `${transitions.easeOut(
+                '0ms',
+                'width',
+                '450ms',
+            )}, ${transitions.easeOut(
+                '0ms',
+                'height',
+                '450ms',
+            )}, ${transitions.easeOut('450ms', 'backgroundColor', '0ms')}`,
         },
         rootWhenShown: {
             top: rootWhenShownTop,
             opacity: 0.9,
             transform: `translate(0px, ${offset}px)`,
-            transition: `${transitions.easeOut('0ms', 'top', '0ms')}, ${
-                transitions.easeOut('450ms', 'transform', '0ms')}, ${
-                transitions.easeOut('450ms', 'opacity', '0ms')}`,
+            transition: `${transitions.easeOut(
+                '0ms',
+                'top',
+                '0ms',
+            )}, ${transitions.easeOut(
+                '450ms',
+                'transform',
+                '0ms',
+            )}, ${transitions.easeOut('450ms', 'opacity', '0ms')}`,
         },
         rootWhenTouched: {
             fontSize: '14px',
@@ -92,9 +112,15 @@ function getStyles(props, context, state) {
         },
         rippleWhenShown: {
             backgroundColor: tooltip.rippleBackgroundColor,
-            transition: `${transitions.easeOut('450ms', 'width', '0ms')}, ${
-                transitions.easeOut('450ms', 'height', '0ms')}, ${
-                transitions.easeOut('450ms', 'backgroundColor', '0ms')}`,
+            transition: `${transitions.easeOut(
+                '450ms',
+                'width',
+                '0ms',
+            )}, ${transitions.easeOut(
+                '450ms',
+                'height',
+                '0ms',
+            )}, ${transitions.easeOut('450ms', 'backgroundColor', '0ms')}`,
         },
     };
 
@@ -142,11 +168,15 @@ class Tooltip extends Component {
     setRippleSize() {
         const ripple = this.refs.ripple;
         const tooltip = this.refs.tooltip;
-        const tooltipWidth = parseInt(tooltip.offsetWidth, 10) /
-        (this.props.horizontalPosition === 'center' ? 2 : 1);
+        const tooltipWidth =
+            parseInt(tooltip.offsetWidth, 10) /
+            (this.props.horizontalPosition === 'center' ? 2 : 1);
         const tooltipHeight = parseInt(tooltip.offsetHeight, 10);
 
-        const rippleDiameter = Math.ceil((Math.sqrt(Math.pow(tooltipHeight, 2) + Math.pow(tooltipWidth, 2)) * 2));
+        const rippleDiameter = Math.ceil(
+            Math.sqrt(Math.pow(tooltipHeight, 2) + Math.pow(tooltipWidth, 2)) *
+                2,
+        );
         if (this.props.show) {
             ripple.style.height = `${rippleDiameter}px`;
             ripple.style.width = `${rippleDiameter}px`;
@@ -162,12 +192,12 @@ class Tooltip extends Component {
 
     render() {
         const {
-        horizontalPosition, // eslint-disable-line no-unused-vars
-        label,
-        show, // eslint-disable-line no-unused-vars
-        touch, // eslint-disable-line no-unused-vars
-        verticalPosition, // eslint-disable-line no-unused-vars
-        ...other
+            horizontalPosition, // eslint-disable-line no-unused-vars
+            label,
+            show, // eslint-disable-line no-unused-vars
+            touch, // eslint-disable-line no-unused-vars
+            verticalPosition, // eslint-disable-line no-unused-vars
+            ...other
         } = this.props;
 
         const { prepareStyles } = this.context.muiTheme;
@@ -177,23 +207,25 @@ class Tooltip extends Component {
             <div
                 {...other}
                 ref="tooltip"
-                style={prepareStyles(Object.assign(
-                    styles.root,
-                    this.props.show && styles.rootWhenShown,
-                    this.props.touch && styles.rootWhenTouched,
-                    this.props.style,
-                ))}
+                style={prepareStyles(
+                    Object.assign(
+                        styles.root,
+                        this.props.show && styles.rootWhenShown,
+                        this.props.touch && styles.rootWhenTouched,
+                        this.props.style,
+                    ),
+                )}
             >
                 <div
                     ref="ripple"
-                    style={prepareStyles(Object.assign(
-                        styles.ripple,
-                        this.props.show && styles.rippleWhenShown,
-                    ))}
+                    style={prepareStyles(
+                        Object.assign(
+                            styles.ripple,
+                            this.props.show && styles.rippleWhenShown,
+                        ),
+                    )}
                 />
-                <span style={prepareStyles(styles.label)}>
-                    {label}
-                </span>
+                <span style={prepareStyles(styles.label)}>{label}</span>
             </div>
         );
     }

--- a/src/app/js/lib/components/Tooltip.js
+++ b/src/app/js/lib/components/Tooltip.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+
 /*
  * Duplicated from original Material-ui tooltip and modified to suit our needs until
  * v7 is out
@@ -192,11 +193,11 @@ class Tooltip extends Component {
 
     render() {
         const {
-            horizontalPosition, // eslint-disable-line no-unused-vars
+            horizontalPosition,
             label,
-            show, // eslint-disable-line no-unused-vars
-            touch, // eslint-disable-line no-unused-vars
-            verticalPosition, // eslint-disable-line no-unused-vars
+            show,
+            touch,
+            verticalPosition,
             ...other
         } = this.props;
 

--- a/src/app/js/lib/getQueryString.js
+++ b/src/app/js/lib/getQueryString.js
@@ -17,20 +17,18 @@ export const addKeyToLiteral = (key, value) => (literal = {}) => {
     };
 };
 
-export default (
-    {
-        match,
-        facets,
-        params,
-        invertedFacets,
-        sort = {},
-        page,
-        perPage,
-        limit,
-        skip,
-        uri,
-    } = {},
-) =>
+export default ({
+    match,
+    facets,
+    params,
+    invertedFacets,
+    sort = {},
+    page,
+    perPage,
+    limit,
+    skip,
+    uri,
+} = {}) =>
     compose(
         qs.stringify,
         addLiteralToLiteral(facets),

--- a/src/app/js/lib/selectors.js
+++ b/src/app/js/lib/selectors.js
@@ -3,10 +3,8 @@ import { createSelector } from 'reselect';
 export const getProps = (state, props) => props;
 
 export const createGlobalSelector = (getLocalState, selector) =>
-    createSelector(
-        getLocalState,
-        getProps,
-        (localState, props) => selector(localState, props),
+    createSelector(getLocalState, getProps, (localState, props) =>
+        selector(localState, props),
     );
 
 export const createGlobalSelectors = (getLocalState, selectors) =>

--- a/src/app/js/propTypes.js
+++ b/src/app/js/propTypes.js
@@ -1,4 +1,3 @@
-/* eslint import/prefer-default-export: off */
 import PropTypes from 'prop-types';
 
 import { PROPOSED, VALIDATED, REJECTED } from '../../common/propositionStatus';

--- a/src/app/js/public/Home.js
+++ b/src/app/js/public/Home.js
@@ -116,9 +116,6 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     translate,
 )(HomeComponent);

--- a/src/app/js/public/Property/ModerateButton.js
+++ b/src/app/js/public/Property/ModerateButton.js
@@ -101,6 +101,7 @@ const mapStateToProps = (state, { fieldName }) => ({
     isAdmin: fromUser.isAdmin(state),
 });
 
-export default compose(translate, connect(mapStateToProps))(
-    ModerateButtonComponent,
-);
+export default compose(
+    translate,
+    connect(mapStateToProps),
+)(ModerateButtonComponent);

--- a/src/app/js/public/Property/PropertyContributor.js
+++ b/src/app/js/public/Property/PropertyContributor.js
@@ -67,6 +67,7 @@ const mapStateToProps = (state, { fieldName }) => ({
     contributor: fromResource.getResourceContributorForField(state, fieldName),
 });
 
-export default compose(translate, connect(mapStateToProps))(
-    PropertyContributorComponent,
-);
+export default compose(
+    translate,
+    connect(mapStateToProps),
+)(PropertyContributorComponent);

--- a/src/app/js/public/Routes.js
+++ b/src/app/js/public/Routes.js
@@ -99,7 +99,4 @@ const mapDispatchToProps = {
     loadMenu,
 };
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(Routes);
+export default connect(mapStateToProps, mapDispatchToProps)(Routes);

--- a/src/app/js/public/breadcrumb/Breadcrumb.js
+++ b/src/app/js/public/breadcrumb/Breadcrumb.js
@@ -89,7 +89,4 @@ const mapStateToProps = state => {
     };
 };
 
-export default compose(
-    connect(mapStateToProps),
-    withRouter,
-)(Breadcrumb);
+export default compose(connect(mapStateToProps), withRouter)(Breadcrumb);

--- a/src/app/js/public/dataset/AppliedDatasetFacet.js
+++ b/src/app/js/public/dataset/AppliedDatasetFacet.js
@@ -15,10 +15,7 @@ const mapStateToProps = (state, { name }) => ({
 const mapDispatchToProps = { onClearFacet: facetActions.clearFacet };
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     withHandlers({
         onRequestDelete: ({ name, onClearFacet }) => () => onClearFacet(name),
     }),

--- a/src/app/js/public/dataset/Dataset.js
+++ b/src/app/js/public/dataset/Dataset.js
@@ -182,9 +182,6 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     translate,
 )(DatasetComponent);

--- a/src/app/js/public/dataset/DatasetColumnHeader.js
+++ b/src/app/js/public/dataset/DatasetColumnHeader.js
@@ -45,6 +45,7 @@ const mapDispatchToProps = {
     sortDataset: sortDatasetAction,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(
-    DatasetColumnHeader,
-);
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(DatasetColumnHeader);

--- a/src/app/js/public/dataset/DefaultColumn.js
+++ b/src/app/js/public/dataset/DefaultColumn.js
@@ -27,7 +27,7 @@ const DatasetColumn = ({ column, columns, resource }) => (
 DatasetColumn.propTypes = {
     column: fieldPropTypes.isRequired,
     columns: PropTypes.arrayOf(fieldPropTypes).isRequired,
-    resource: PropTypes.object.isRequired, // eslint-disable-line
+    resource: PropTypes.object.isRequired,
 };
 
 export default DatasetColumn;

--- a/src/app/js/public/dataset/Filter.js
+++ b/src/app/js/public/dataset/Filter.js
@@ -130,9 +130,6 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     translate,
 )(FilterComponent);

--- a/src/app/js/public/dataset/UriColumn.js
+++ b/src/app/js/public/dataset/UriColumn.js
@@ -24,8 +24,8 @@ const UriColumn = ({ column, resource, indice }) => (
 
 UriColumn.propTypes = {
     column: fieldPropTypes.isRequired,
-    resource: PropTypes.object.isRequired, // eslint-disable-line
-    indice: PropTypes.number, // eslint-disable-line
+    resource: PropTypes.object.isRequired,
+    indice: PropTypes.number,
 };
 
 export default UriColumn;

--- a/src/app/js/public/export/ExportFieldsButton.js
+++ b/src/app/js/public/export/ExportFieldsButton.js
@@ -41,10 +41,7 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        undefined,
-        mapDispatchToProps,
-    ),
+    connect(undefined, mapDispatchToProps),
     withHandlers({
         handleClick: ({ exportFields }) => () => {
             exportFields();

--- a/src/app/js/public/export/ExportFieldsReadyButton.js
+++ b/src/app/js/public/export/ExportFieldsReadyButton.js
@@ -44,10 +44,7 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        undefined,
-        mapDispatchToProps,
-    ),
+    connect(undefined, mapDispatchToProps),
     withHandlers({
         handleClick: ({ exportFields }) => () => {
             exportFields();

--- a/src/app/js/public/facet/FacetList.js
+++ b/src/app/js/public/facet/FacetList.js
@@ -83,9 +83,6 @@ const mapDispatchToProps = (dispatch, { page }) => ({
 });
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     translate,
 )(FacetList);

--- a/src/app/js/public/graph/GraphPage.js
+++ b/src/app/js/public/graph/GraphPage.js
@@ -166,8 +166,5 @@ const mapDispatchToProps = {
 
 export default compose(
     translate,
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
 )(GraphPage);

--- a/src/app/js/public/menu/NavBar.js
+++ b/src/app/js/public/menu/NavBar.js
@@ -292,9 +292,6 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     translate,
 )(NavBar);

--- a/src/app/js/public/resource/CreateResource.js
+++ b/src/app/js/public/resource/CreateResource.js
@@ -56,8 +56,5 @@ const mapDispatchToProps = {
 
 export default compose(
     translate,
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
 )(CreateResource);

--- a/src/app/js/public/resource/CreateResourceForm.js
+++ b/src/app/js/public/resource/CreateResourceForm.js
@@ -84,10 +84,7 @@ const mapDispatchToProps = {
 
 export default compose(
     translate,
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     reduxForm({
         form: CREATE_RESOURCE_FORM_NAME,
         validate,

--- a/src/app/js/public/resource/HideResource.js
+++ b/src/app/js/public/resource/HideResource.js
@@ -30,8 +30,5 @@ const mapDispatchToProps = {
 
 export default compose(
     translate,
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
 )(ButtonWithDialogForm);

--- a/src/app/js/public/resource/RemovedDetail.js
+++ b/src/app/js/public/resource/RemovedDetail.js
@@ -58,8 +58,5 @@ const mapDispatchToProps = {};
 
 export default compose(
     translate,
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
 )(RemovedDetailComponent);

--- a/src/app/js/public/resource/Resource.js
+++ b/src/app/js/public/resource/Resource.js
@@ -225,10 +225,7 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     translate,
     withRouter,
 )(ResourceComponent);

--- a/src/app/js/public/resource/SelectVersion.js
+++ b/src/app/js/public/resource/SelectVersion.js
@@ -107,6 +107,7 @@ const mapDispatchToProps = {
     onSelectVersion: selectVersion,
 };
 
-export default compose(connect(mapStateToProps, mapDispatchToProps), translate)(
-    SelectVersionComponent,
-);
+export default compose(
+    connect(mapStateToProps, mapDispatchToProps),
+    translate,
+)(SelectVersionComponent);

--- a/src/app/js/public/search/AppliedSearchFacet.js
+++ b/src/app/js/public/search/AppliedSearchFacet.js
@@ -15,10 +15,7 @@ const mapStateToProps = (state, { name }) => ({
 const mapDispatchToProps = { onClearFacet: facetActions.clearFacet };
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     withHandlers({
         onRequestDelete: ({ name, onClearFacet }) => () => onClearFacet(name),
     }),

--- a/src/app/js/user/Login.js
+++ b/src/app/js/user/Login.js
@@ -67,9 +67,6 @@ export const mapDispatchToProps = dispatch =>
     );
 
 export default compose(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    ),
+    connect(mapStateToProps, mapDispatchToProps),
     translate,
 )(LoginComponent);

--- a/src/common/languages.js
+++ b/src/common/languages.js
@@ -1,4 +1,3 @@
-/* eslint max-len: off */
 export default [
     {
         code: 'fr',

--- a/src/common/mongoCleanup.js
+++ b/src/common/mongoCleanup.js
@@ -1,4 +1,3 @@
-/* eslint no-console: off */
 // Remove LODEX's mongoDB base
 import { MongoClient } from 'mongodb';
 import config from 'config';

--- a/src/common/transformers/DEFAULT.spec.js
+++ b/src/common/transformers/DEFAULT.spec.js
@@ -36,5 +36,4 @@ describe('DEFAULT', () => {
     it('should return value if object', () => {
         expect(defval({ a: 'Ya' }, 'Yo')).toEqual({ a: 'Ya' });
     });
-
 });

--- a/src/common/transformers/memoizeTransformer.js
+++ b/src/common/transformers/memoizeTransformer.js
@@ -2,7 +2,9 @@ import memoize from 'lodash.memoize';
 
 export default transformer => {
     const fn = (context, args) =>
-        memoize(transformer(context, args), doc => (doc._id ? doc._id : JSON.stringify(doc))); // eslint-disable-line
+        memoize(transformer(context, args), doc =>
+            doc._id ? doc._id : JSON.stringify(doc),
+        ); // eslint-disable-line
 
     const memoizedFn = memoize(fn, (_, args) => JSON.stringify(args));
     memoizedFn.getMetas = transformer.getMetas;

--- a/src/common/transformers/memoizeTransformer.js
+++ b/src/common/transformers/memoizeTransformer.js
@@ -4,7 +4,7 @@ export default transformer => {
     const fn = (context, args) =>
         memoize(transformer(context, args), doc =>
             doc._id ? doc._id : JSON.stringify(doc),
-        ); // eslint-disable-line
+        );
 
     const memoizedFn = memoize(fn, (_, args) => JSON.stringify(args));
     memoizedFn.getMetas = transformer.getMetas;


### PR DESCRIPTION
Eslint is disabled in a lot of files. This often hides a bad practice.

There are 114 files in error running the following command: `npx prettier --list-different "src/**/*.js" | wc -l`

## Todo

- [x] Fix all files using prettier
- [x] Remove `eslint-disable` every time it's possible

## Screenshots

** Before**

![Peek 12-12-2019 15-07](https://user-images.githubusercontent.com/5584839/70718976-89a1cd80-1cf1-11ea-89af-a45efeca42f6.gif)

**After**

![Sélection_005](https://user-images.githubusercontent.com/5584839/70719136-ba820280-1cf1-11ea-963c-30d2920e0a73.png)
