### PR TITLE
Remove padding-left on refresh button

### DIFF
--- a/src/app/js/formats/shared/CenterIcon.js
+++ b/src/app/js/formats/shared/CenterIcon.js
@@ -13,7 +13,7 @@ const CenterIcon = ({ polyglot }) => (
             height={30}
         />
         <ReactTooltip id="centerIconTooltip" place="right" effect="solid">
-            <ul>{polyglot.t('graph_reinit')}</ul>
+            {polyglot.t('graph_reinit')}
         </ReactTooltip>
     </>
 );


### PR DESCRIPTION
[Trello Card #39](https://trello.com/c/cVElTaRy/39-flux-r%C3%A9seau-hi%C3%A9rarchie-probl%C3%A8me-du-padding-left-dans-les-tooltips)

There is padding between the text of the tooltip and the border. This is due to bad usage of the `<ul/>` tag.

## Todo

- [x] Change `ul` by `div` in CenterIcon

## Screrenshot
![screenshot-localhost_3000-2019 12](https://user-images.githubusercontent.com/4921926/70812754-83325500-1dc8-11ea-8fe6-84e8efcc583e.png)
