### PR TITLE
Graph - Do not show trailing zeros in Streamgraph

### DIFF
--- a/src/app/js/formats/streamgraph/Streamgraph.js
+++ b/src/app/js/formats/streamgraph/Streamgraph.js
@@ -453,12 +453,9 @@ class Streamgraph extends PureComponent {
                     this.mouseIsOverStream = true;
                     this.hoveredKey = d3.select(nodes[i]).attr('name');
 
-                    this.hoveredValue = d
-                        .find(
-                            elem =>
-                                elem.data.date.getFullYear() === parseInt(date),
-                        )
-                        .data[this.hoveredKey].toFixed(3);
+                    this.hoveredValue = d.find(
+                        elem => elem.data.date.getFullYear() === parseInt(date),
+                    ).data[this.hoveredKey];
 
                     this.hoveredColor = colorNameList.find(
                         elem => elem.name === this.hoveredKey,

--- a/src/app/js/formats/streamgraph/utils.js
+++ b/src/app/js/formats/streamgraph/utils.js
@@ -89,7 +89,7 @@ export function transformDataIntoMapArray(formatData) {
                                 parseInt(elem.source)
                             ) {
                                 var sum = valueElem.value + elem.weight;
-                                valueElem.value = +sum.toFixed(3);
+                                valueElem.value = parseFloat(sum.toFixed(3));
                                 addValueAsSum = true;
                                 break;
                             }


### PR DESCRIPTION
[Trello Card #18](https://trello.com/c/lYSLkO0B/18-graphique-de-flux-certains-poids-sont-affich%C3%A9s-avec-une-valeur-d%C3%A9cimale-%C3%A0-17-chiffres)

## Todo

- [x] Remove trailing zeros

## Screrenshot
![screenshot-localhost_3000-2019 12 (1)](https://user-images.githubusercontent.com/4921926/70814198-4ddb3680-1dcb-11ea-9849-775fd7a53bf2.png)
