### PR TITLE
Remove Bootstrap - Fix spaces between home page properties

### DIFF
--- a/src/app/js/public/Property/index.js
+++ b/src/app/js/public/Property/index.js
@@ -53,14 +53,14 @@ const styles = {
     }),
     language: memoize(hide => ({
         marginRight: '1rem',
-        fontSize: '0.6em',
+        fontSize: '0.6rem',
         color: 'grey',
         textTransform: 'uppercase',
         visibility: hide ? 'hidden' : 'visible',
     })),
     scheme: {
         fontWeight: 'normale',
-        fontSize: '0.75em',
+        fontSize: '0.75rem',
         alignSelf: 'flex-end',
     },
     schemeLink: {
@@ -81,7 +81,7 @@ const styles = {
     value: {
         flexGrow: 2,
         width: '100%',
-        padding: '0px',
+        padding: '0.75rem 0.75rem 0.75rem 0',
         textAlign: 'justify',
     },
 };


### PR DESCRIPTION
[Trello Card #101](https://trello.com/c/rX9zz19a/101-supprimer-bootstrap-dans-le-th%C3%A8me-par-d%C3%A9faut)

Removing Bootstrap created some layout issues in the spaces.

Fixes https://github.com/Inist-CNRS/lodex/pull/1007

## Todo

- [x] Fix spaces between properties

## Screenshots

**Without spaces**

![Sélection_006](https://user-images.githubusercontent.com/5584839/71678704-0f131d80-2d86-11ea-919e-10ea1eefba4f.png)

**With spaces**

![Sélection_005](https://user-images.githubusercontent.com/5584839/71678712-12a6a480-2d86-11ea-9d89-7b2ec08b90ff.png)

