### PR TITLE
Replace material-ui icons by font-awesome icons

### DIFF
--- a/src/app/js/admin/ActionButton.js
+++ b/src/app/js/admin/ActionButton.js
@@ -3,11 +3,9 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import translate from 'redux-polyglot/translate';
-
 import Popover, { PopoverAnimationVertical } from 'material-ui/Popover';
-import ActionDescription from 'material-ui/svg-icons/action/description';
-import ContentAdd from 'material-ui/svg-icons/content/add';
-import ContentClear from 'material-ui/svg-icons/content/clear';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlus, faTimes, faFileAlt } from '@fortawesome/free-solid-svg-icons';
 
 import FloatingActionButton from '../lib/components/FloatingActionButton';
 import { fromFields } from '../sharedSelectors';
@@ -154,7 +152,7 @@ export class ActionButtonComponent extends Component {
                         style={styles.button}
                         tooltip={polyglot.t('add_column_from_original_dataset')}
                     >
-                        <ActionDescription />
+                        <FontAwesomeIcon icon={faFileAlt} />
                     </FloatingActionButton>
 
                     <FloatingActionButton
@@ -164,12 +162,16 @@ export class ActionButtonComponent extends Component {
                         style={styles.button}
                         tooltip="Add a new column"
                     >
-                        <ContentAdd />
+                        <FontAwesomeIcon icon={faPlus} />
                     </FloatingActionButton>
                 </Popover>
                 <div ref={this.storeAnchorRef}>
-                    {!showCancel && <ContentAdd style={styles.icon} />}
-                    {showCancel && <ContentClear style={styles.icon} />}
+                    {!showCancel && (
+                        <FontAwesomeIcon icon={faPlus} style={styles.icon} />
+                    )}
+                    {showCancel && (
+                        <FontAwesomeIcon icon={faTimes} style={styles.icon} />
+                    )}
                 </div>
             </FloatingActionButton>
         );

--- a/src/app/js/admin/ActionButton.js
+++ b/src/app/js/admin/ActionButton.js
@@ -29,8 +29,8 @@ const styles = {
     },
     icon: {
         color: 'white',
-        height: 56,
-        lineHeight: 56,
+        width: '20px',
+        height: '20px',
     },
 };
 
@@ -152,9 +152,8 @@ export class ActionButtonComponent extends Component {
                         style={styles.button}
                         tooltip={polyglot.t('add_column_from_original_dataset')}
                     >
-                        <FontAwesomeIcon icon={faFileAlt} />
+                        <FontAwesomeIcon icon={faFileAlt} style={styles.icon} />
                     </FloatingActionButton>
-
                     <FloatingActionButton
                         className="btn-add-free-column"
                         label={polyglot.t('add_column')}
@@ -162,7 +161,7 @@ export class ActionButtonComponent extends Component {
                         style={styles.button}
                         tooltip="Add a new column"
                     >
-                        <FontAwesomeIcon icon={faPlus} />
+                        <FontAwesomeIcon icon={faPlus} style={styles.icon} />
                     </FloatingActionButton>
                 </Popover>
                 <div ref={this.storeAnchorRef}>

--- a/src/app/js/admin/Appbar/Settings.js
+++ b/src/app/js/admin/Appbar/Settings.js
@@ -7,7 +7,8 @@ import compose from 'recompose/compose';
 import { connect } from 'react-redux';
 import translate from 'redux-polyglot/translate';
 import Popover, { PopoverAnimationVertical } from 'material-ui/Popover';
-import ArrowDown from 'material-ui/svg-icons/hardware/keyboard-arrow-down';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
 
 import { polyglot as polyglotPropTypes } from '../../propTypes';
 
@@ -102,7 +103,7 @@ class SettingsComponent extends Component {
                     onClick={this.handleTouchTap}
                     label={polyglot.t('clear')}
                     labelPosition="before"
-                    icon={<ArrowDown />}
+                    icon={<FontAwesomeIcon icon={faChevronDown} />}
                     style={styles.button}
                 />
                 <Popover

--- a/src/app/js/admin/Appbar/SignInButton.js
+++ b/src/app/js/admin/Appbar/SignInButton.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
-
 import translate from 'redux-polyglot/translate';
 import IconButton from 'material-ui/IconButton';
-import LockOutlineIcon from 'material-ui/svg-icons/action/lock-outline';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faLock } from '@fortawesome/free-solid-svg-icons';
 
 import { polyglot as polyglotPropTypes } from '../../propTypes';
 import { toggleLogin as toggleLoginAction } from '../../user';
@@ -17,7 +17,7 @@ export const SignInButtonComponent = ({ onToggleLogin, p: polyglot }) => (
         tooltip={polyglot.t('Sign in')}
         onClick={onToggleLogin}
     >
-        <LockOutlineIcon color="white" />
+        <FontAwesomeIcon icon={faLock} color="white" />
     </IconButton>
 );
 

--- a/src/app/js/admin/upload/Upload.js
+++ b/src/app/js/admin/upload/Upload.js
@@ -4,8 +4,9 @@ import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import translate from 'redux-polyglot/translate';
 import classnames from 'classnames';
-import ArchiveIcon from 'material-ui/svg-icons/content/archive';
 import { lightBlue500 } from 'material-ui/styles/colors';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFileUpload } from '@fortawesome/free-solid-svg-icons';
 
 import Alert from '../../lib/components/Alert';
 import { uploadFile } from './';
@@ -64,7 +65,7 @@ export const UploadComponent = ({
             <p>{polyglot.t('easy-update')}</p>
             <UploadButton
                 raised
-                icon={<ArchiveIcon />}
+                icon={<FontAwesomeIcon icon={faFileUpload} />}
                 label={polyglot.t('first-upload')}
             />
             <p>

--- a/src/app/js/admin/upload/Upload.js
+++ b/src/app/js/admin/upload/Upload.js
@@ -80,6 +80,7 @@ UploadComponent.propTypes = {
     error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
     onFileLoad: PropTypes.func.isRequired,
     p: polyglotPropTypes.isRequired,
+    loaders: PropTypes.array.isRequired,
 };
 
 UploadComponent.defaultProps = {

--- a/src/app/js/admin/upload/UploadButton.js
+++ b/src/app/js/admin/upload/UploadButton.js
@@ -6,7 +6,8 @@ import compose from 'recompose/compose';
 import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
-import ArchiveIcon from 'material-ui/svg-icons/content/archive';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFileUpload } from '@fortawesome/free-solid-svg-icons';
 
 import UploadDialog from './UploadDialog';
 import { fromUpload } from '../selectors';
@@ -44,7 +45,7 @@ const UploadButtonComponent = ({
                 <RaisedButton
                     style={styles.button}
                     className="open-upload"
-                    icon={<ArchiveIcon />}
+                    icon={<FontAwesomeIcon icon={faFileUpload} />}
                     label={label}
                     primary
                     onClick={handleOpen}

--- a/src/app/js/fields/ClassList.js
+++ b/src/app/js/fields/ClassList.js
@@ -4,7 +4,9 @@ import compose from 'recompose/compose';
 import translate from 'redux-polyglot/translate';
 import pure from 'recompose/pure';
 import FloatingActionButton from 'material-ui/FloatingActionButton';
-import ContentAdd from 'material-ui/svg-icons/content/add';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+
 import { polyglot as polyglotPropTypes } from '../propTypes';
 import ListItem from './ClassListItem';
 
@@ -36,7 +38,7 @@ const ClassList = ({ fields, p: polyglot }) => (
                 mini
                 style={styles.add}
             >
-                <ContentAdd />
+                <FontAwesomeIcon icon={faPlus} />;
             </FloatingActionButton>
         </div>
         <div style={styles.tab}>

--- a/src/app/js/fields/ClassListItem.js
+++ b/src/app/js/fields/ClassListItem.js
@@ -6,7 +6,9 @@ import translate from 'redux-polyglot/translate';
 import { Field } from 'redux-form';
 import MenuItem from 'material-ui/MenuItem';
 import IconButton from 'material-ui/IconButton';
-import ActionDeleteIcon from 'material-ui/svg-icons/action/delete';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+
 import FormAutoCompleteField from '../lib/components/FormAutoCompleteField';
 import { fromFields } from '../sharedSelectors';
 import { polyglot as polyglotPropTypes } from '../propTypes';
@@ -88,7 +90,7 @@ export const ClassListItem = ({
         </div>
         <span>
             <IconButton tooltip={polyglot.t('remove_class')} onClick={onRemove}>
-                <ActionDeleteIcon />
+                <FontAwesomeIcon icon={faTrash} />
             </IconButton>
         </span>
     </div>

--- a/src/app/js/fields/ComposedOfColumn.js
+++ b/src/app/js/fields/ComposedOfColumn.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import IconButton from 'material-ui/IconButton';
-import IconDelete from 'material-ui/svg-icons/action/delete';
 import translate from 'redux-polyglot/translate';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
 
 import {
     polyglot as polyglotPropTypes,
@@ -51,7 +52,7 @@ const ComposedOfColumn = ({
                 onClick={handleRemoveColumn}
                 title={polyglot.t('remove_composition_column')}
             >
-                <IconDelete />
+                <FontAwesomeIcon icon={faTrash} />
             </IconButton>
         )}
     </div>

--- a/src/app/js/fields/TransformerListItem.js
+++ b/src/app/js/fields/TransformerListItem.js
@@ -2,12 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import compose from 'recompose/compose';
 import { connect } from 'react-redux';
+import { Field, FieldArray } from 'redux-form';
+import memoize from 'lodash.memoize';
 import translate from 'redux-polyglot/translate';
 import IconButton from 'material-ui/IconButton';
 import MenuItem from 'material-ui/MenuItem';
-import ActionDeleteIcon from 'material-ui/svg-icons/action/delete';
-import { Field, FieldArray } from 'redux-form';
-import memoize from 'lodash.memoize';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
 
 import { polyglot as polyglotPropTypes } from '../propTypes';
 import { fromFields } from '../sharedSelectors';
@@ -55,7 +57,7 @@ const TransformerListItem = ({
             tooltip={polyglot.t('remove_transformer')}
             onClick={onRemove}
         >
-            <ActionDeleteIcon />
+            <FontAwesomeIcon icon={faTrash} />
         </IconButton>
     </div>
 );

--- a/src/app/js/fields/editFieldValue/EditButton.js
+++ b/src/app/js/fields/editFieldValue/EditButton.js
@@ -3,8 +3,9 @@ import classnames from 'classnames';
 import { connect } from 'react-redux';
 import translate from 'redux-polyglot/translate';
 import compose from 'recompose/compose';
-import EditIcon from 'material-ui/svg-icons/editor/mode-edit';
 import withHandlers from 'recompose/withHandlers';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPen } from '@fortawesome/free-solid-svg-icons';
 
 import EditFieldForm, { FORM_NAME } from './EditFieldForm';
 import { fromResource } from '../../public/selectors';
@@ -59,7 +60,7 @@ const mapStateToProps = (state, { field, resource, onSaveProperty, p }) => ({
             <span className={styles.name}>#{field.name}</span>
         </p>
     ),
-    icon: <EditIcon viewBox="-10 0 32 32" />,
+    icon: <FontAwesomeIcon icon={faPen} />,
     buttonStyle: { padding: 0, height: 'auto', width: 'auto' },
 });
 

--- a/src/app/js/fields/editFieldValue/EditButton.js
+++ b/src/app/js/fields/editFieldValue/EditButton.js
@@ -6,6 +6,7 @@ import compose from 'recompose/compose';
 import withHandlers from 'recompose/withHandlers';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPen } from '@fortawesome/free-solid-svg-icons';
+import { grey400 } from 'material-ui/styles/colors';
 
 import EditFieldForm, { FORM_NAME } from './EditFieldForm';
 import { fromResource } from '../../public/selectors';
@@ -20,7 +21,6 @@ import { openEditFieldValue, closeEditFieldValue } from '../';
 import { COVER_DATASET } from '../../../../common/cover';
 import { saveResource } from '../../public/resource';
 import { updateCharacteristics } from '../../characteristic';
-import { grey400 } from 'material-ui/styles/colors';
 
 import stylesToClassname from '../../lib/stylesToClassName';
 
@@ -61,7 +61,6 @@ const mapStateToProps = (state, { field, resource, onSaveProperty, p }) => ({
         </p>
     ),
     icon: <FontAwesomeIcon icon={faPen} />,
-    buttonStyle: { padding: 0, height: 'auto', width: 'auto' },
 });
 
 const mapDispatchToProps = {

--- a/src/app/js/fields/ontology/DragButton.js
+++ b/src/app/js/fields/ontology/DragButton.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Reorder from 'material-ui/svg-icons/editor/format-line-spacing';
 import { SortableHandle } from 'react-sortable-hoc';
 import { grey400 } from 'material-ui/styles/colors';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faGripVertical } from '@fortawesome/free-solid-svg-icons';
 
 import stylesToClassname from '../../lib/stylesToClassName';
 
@@ -20,7 +21,10 @@ const styles = stylesToClassname(
 );
 
 const DragIcon = ({ disabled }) => (
-    <Reorder className={disabled ? styles.iconDisabled : styles.icon} />
+    <FontAwesomeIcon
+        icon={faGripVertical}
+        className={disabled ? styles.iconDisabled : styles.icon}
+    />
 );
 
 DragIcon.propTypes = {

--- a/src/app/js/fields/ontology/EditOntologyFieldButton.js
+++ b/src/app/js/fields/ontology/EditOntologyFieldButton.js
@@ -3,7 +3,8 @@ import classnames from 'classnames';
 import { connect } from 'react-redux';
 import translate from 'redux-polyglot/translate';
 import compose from 'recompose/compose';
-import SettingsIcon from 'material-ui/svg-icons/action/settings';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCog } from '@fortawesome/free-solid-svg-icons';
 
 import getFieldClassName from '../../lib/getFieldClassName';
 import EditOntologyFieldForm, { FORM_NAME } from './EditOntologyFieldForm';
@@ -33,7 +34,7 @@ const mapStateToProps = (state, { field, p }) => ({
     ),
     form: <EditOntologyFieldForm field={field} />,
     formName: FORM_NAME,
-    icon: <SettingsIcon />,
+    icon: <FontAwesomeIcon icon={faCog} />,
 });
 
 const mapDispatchToProps = (dispatch, { field: { name } }) => ({

--- a/src/app/js/fields/wizard/ConcatField.js
+++ b/src/app/js/fields/wizard/ConcatField.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import IconButton from 'material-ui/IconButton';
-import ActionDeleteIcon from 'material-ui/svg-icons/action/delete';
 import translate from 'redux-polyglot/translate';
 import compose from 'recompose/compose';
 import withHandlers from 'recompose/withHandlers';
 import { connect } from 'react-redux';
+import IconButton from 'material-ui/IconButton';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+
 import SelectDatasetField from './SelectDatasetField';
 
 import { polyglot as polyglotPropTypes } from '../../propTypes';
@@ -41,7 +43,7 @@ export const ConcatFieldComponent = ({
                 tooltip={polyglot.t('remove_column')}
                 onClick={handleRemoveColumn}
             >
-                <ActionDeleteIcon />
+                <FontAwesomeIcon icon={faTrash} />
             </IconButton>
         )}
     </div>

--- a/src/app/js/formats/InvalidFormat.js
+++ b/src/app/js/formats/InvalidFormat.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import translate from 'redux-polyglot/translate';
-import Warning from 'material-ui/svg-icons/alert/warning';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 
 import { polyglot as polyglotPropTypes } from '../propTypes';
 import AdminOnlyAlert from '../lib/components/AdminOnlyAlert';
@@ -62,7 +63,10 @@ const InvalidFormat = ({ p: polyglot, format, value }) => (
                 <strong>{polyglot.t('bad_format_error')}</strong>
             </span>
             <span className={styles.titleLogo}>
-                <Warning iconStyle={iconStyle} style={iconStyle} />
+                <FontAwesomeIcon
+                    icon={faExclamationTriangle}
+                    style={iconStyle}
+                />
             </span>
         </div>
         <p className={styles.details}>{polyglot.t('bad_format_details')}</p>

--- a/src/app/js/formats/cartography/CartographyView.js
+++ b/src/app/js/formats/cartography/CartographyView.js
@@ -8,11 +8,11 @@ import {
 import { connect } from 'react-redux';
 import memoize from 'lodash.memoize';
 import PropTypes from 'prop-types';
-import ZoomIn from 'material-ui/svg-icons/action/zoom-in';
-import ZoomOut from 'material-ui/svg-icons/action/zoom-out';
 import IconButton from 'material-ui/IconButton';
 import compose from 'recompose/compose';
 import ReactTooltip from 'react-tooltip';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSearchMinus, faSearchPlus } from '@fortawesome/free-solid-svg-icons';
 
 import injectData from '../injectData';
 import getGradientScaleAndLegend from '../../lib/components/getGradientScaleAndLegend';
@@ -122,13 +122,13 @@ class CartographyView extends Component {
                             disabled={zoom >= maxZoom}
                             onClick={this.zoomIn}
                         >
-                            <ZoomIn />
+                            <FontAwesomeIcon icon={faSearchPlus} />
                         </IconButton>
                         <IconButton
                             disabled={zoom <= minZoom}
                             onClick={this.zoomOut}
                         >
-                            <ZoomOut />
+                            <FontAwesomeIcon icon={faSearchMinus} />
                         </IconButton>
                     </div>
                     <ComposableMap

--- a/src/app/js/formats/istex/IstexItem.js
+++ b/src/app/js/formats/istex/IstexItem.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Book from 'material-ui/svg-icons/av/library-books';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBookmark } from '@fortawesome/free-solid-svg-icons';
 
 import Link from '../../lib/components/Link';
 import stylesToClassname from '../../lib/stylesToClassName';
@@ -43,7 +44,11 @@ export const IstexItemComponent = ({
     <article>
         <div className={styles.article}>
             <div className={styles.title}>
-                <Book size="20" className={styles.titleIcon} />
+                <FontAwesomeIcon
+                    icon={faBookmark}
+                    size="20"
+                    className={styles.titleIcon}
+                />
                 <Link href={url}>{title}</Link>
             </div>
             {authors && (

--- a/src/app/js/formats/istexSummary/EmbedButton.js
+++ b/src/app/js/formats/istexSummary/EmbedButton.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import IconButton from 'material-ui/IconButton';
-import CodeIcon from 'material-ui/svg-icons/action/code';
 import classnames from 'classnames';
+import IconButton from 'material-ui/IconButton';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCode } from '@fortawesome/free-solid-svg-icons';
 
 import { polyglot as polyglotPropTypes } from '../../propTypes';
 import ButtonWithDialog from '../../lib/components/ButtonWithDialog';
@@ -29,7 +30,7 @@ class EmbedButton extends Component {
                 tooltip={polyglot.t('embed_istex_summary')}
                 onClick={this.handleOpen}
             >
-                <CodeIcon />
+                <FontAwesomeIcon icon={faCode} />
             </IconButton>
         );
     };

--- a/src/app/js/formats/istexSummary/FetchFold.js
+++ b/src/app/js/formats/istexSummary/FetchFold.js
@@ -1,16 +1,26 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Folder from 'material-ui/svg-icons/file/folder';
-import FolderOpen from 'material-ui/svg-icons/file/folder-open';
-import Arrow from 'material-ui/svg-icons/hardware/keyboard-arrow-down';
+import get from 'lodash.get';
 import Button from 'material-ui/FlatButton';
 import CircularProgress from 'material-ui/CircularProgress';
-import get from 'lodash.get';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+    faFolder,
+    faFolderOpen,
+    faChevronDown,
+} from '@fortawesome/free-solid-svg-icons';
 
 import { polyglot as polyglotPropTypes } from '../../propTypes';
 import AdminOnlyAlert from '../../lib/components/AdminOnlyAlert';
 import SkipFold from './SkipFold';
 import stylesToClassname from '../../lib/stylesToClassName';
+
+export const FolderIcon = props => (
+    <FontAwesomeIcon icon={faFolder} {...props} />
+);
+export const FolderOpenIcon = props => (
+    <FontAwesomeIcon icon={faFolderOpen} {...props} />
+);
 
 const styles = stylesToClassname(
     {
@@ -108,12 +118,13 @@ class FetchFold extends Component {
                 <div>
                     <Button onClick={isOpen ? this.close : this.open}>
                         <div className={styles.buttonLabel}>
-                            <Arrow
+                            <FontAwesomeIcon
+                                icon={faChevronDown}
                                 className={
                                     isOpen ? undefined : styles.arrowClose
                                 }
                             />
-                            {isOpen ? <FolderOpen /> : <Folder />}
+                            {isOpen ? <FolderIcon /> : <FolderOpenIcon />}
                             <span className={styles.labelText}>{label}</span>
                             <span className={styles.count}>{count}</span>
                             {isLoading && circularProgress}

--- a/src/app/js/formats/istexSummary/FetchFold.spec.js
+++ b/src/app/js/formats/istexSummary/FetchFold.spec.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import Folder from 'material-ui/svg-icons/file/folder';
-import FolderOpen from 'material-ui/svg-icons/file/folder-open';
+import { StyleSheetTestUtils } from 'aphrodite';
 import Button from 'material-ui/FlatButton';
 import { CircularProgress } from 'material-ui';
-import { StyleSheetTestUtils } from 'aphrodite';
 
-import FetchFold from './FetchFold';
+import FetchFold, { FolderIcon, FolderOpenIcon } from './FetchFold';
 import AdminOnlyAlert from '../../lib/components/AdminOnlyAlert';
 
 describe('FetchFold', () => {
@@ -27,8 +25,8 @@ describe('FetchFold', () => {
 
     it('should render closed', () => {
         const wrapper = shallow(<FetchFold {...defaultProps} />);
-        expect(wrapper.find(Folder).length).toBe(1);
-        expect(wrapper.find(FolderOpen).length).toBe(0);
+        expect(wrapper.find(FolderIcon).length).toBe(1);
+        expect(wrapper.find(FolderOpenIcon).length).toBe(0);
         expect(wrapper.find('li').length).toBe(0);
         expect(defaultProps.children).toHaveBeenCalledTimes(0);
         expect(defaultProps.getData).toHaveBeenCalledTimes(0);
@@ -57,8 +55,8 @@ describe('FetchFold', () => {
         await dataPromise; // wait for dataPromise to be resolved by component
         wrapper.update();
         expect(wrapper.find(CircularProgress).length).toBe(0);
-        expect(wrapper.find(Folder).length).toBe(0);
-        expect(wrapper.find(FolderOpen)).toHaveLength(1);
+        expect(wrapper.find(FolderIcon).length).toBe(0);
+        expect(wrapper.find(FolderOpenIcon)).toHaveLength(1);
         expect(wrapper.find('.children')).toHaveLength(1);
         expect(defaultProps.children).toHaveBeenCalledWith({
             ...defaultProps,
@@ -90,8 +88,8 @@ describe('FetchFold', () => {
         await dataPromise.catch(v => v); // wait for dataPromise to get rejected by component
         wrapper.update();
         expect(wrapper.find(CircularProgress).length).toBe(0);
-        expect(wrapper.find(Folder).length).toBe(0);
-        expect(wrapper.find(FolderOpen).length).toBe(0);
+        expect(wrapper.find(FolderIcon).length).toBe(0);
+        expect(wrapper.find(FolderOpenIcon).length).toBe(0);
         expect(wrapper.find('li')).toHaveLength(0);
         const alert = wrapper.find(AdminOnlyAlert);
         expect(alert).toHaveLength(1);
@@ -102,8 +100,8 @@ describe('FetchFold', () => {
 
     it('should not render if count is 0', () => {
         const wrapper = shallow(<FetchFold {...defaultProps} count={0} />);
-        expect(wrapper.find(Folder).length).toBe(0);
-        expect(wrapper.find(FolderOpen).length).toBe(0);
+        expect(wrapper.find(FolderIcon).length).toBe(0);
+        expect(wrapper.find(FolderOpenIcon).length).toBe(0);
         expect(wrapper.find(AdminOnlyAlert)).toHaveLength(0);
         expect(wrapper.find('p')).toHaveLength(0);
     });

--- a/src/app/js/formats/list/InputList.js
+++ b/src/app/js/formats/list/InputList.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Field } from 'redux-form';
-import IconButton from 'material-ui/IconButton';
-import ActionDeleteIcon from 'material-ui/svg-icons/action/delete';
-import ActionAddIcon from 'material-ui/svg-icons/content/add';
-import RaisedButton from 'material-ui/RaisedButton';
 import classnames from 'classnames';
 import memoize from 'lodash.memoize';
+import { Field } from 'redux-form';
+import IconButton from 'material-ui/IconButton';
+import RaisedButton from 'material-ui/RaisedButton';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
 
 import { polyglot as polyglotPropTypes } from '../../propTypes';
 import stylesToClassname from '../../lib/stylesToClassName';
@@ -80,7 +80,7 @@ class InputList extends Component {
                             tooltip={polyglot.t('remove')}
                             onClick={this.removeValue(index)}
                         >
-                            <ActionDeleteIcon />
+                            <FontAwesomeIcon icon={faTrash} />
                         </IconButton>
                     </div>
                 ))}
@@ -89,7 +89,7 @@ class InputList extends Component {
                     tooltip={polyglot.t('add')}
                     onClick={this.addValue}
                 >
-                    <ActionAddIcon />
+                    <FontAwesomeIcon icon={faPlus} />
                 </IconButton>
             </div>
         );

--- a/src/app/js/formats/sparql/SparqlRequest.js
+++ b/src/app/js/formats/sparql/SparqlRequest.js
@@ -4,6 +4,9 @@ import { connect } from 'react-redux';
 import translate from 'redux-polyglot/translate';
 import compose from 'recompose/compose';
 import URL from 'url';
+import TextField from 'material-ui/TextField';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faLink } from '@fortawesome/free-solid-svg-icons';
 
 import {
     field as fieldPropTypes,
@@ -12,8 +15,7 @@ import {
 import { fromFormat } from '../../public/selectors';
 import { loadFormatData } from '../../formats/reducer';
 import Loading from '../../lib/components/Loading';
-import LinkIcon from 'material-ui/svg-icons/content/link';
-import TextField from 'material-ui/TextField';
+
 import { isURL } from '../../../../common/uris.js';
 import Link from '../../lib/components/Link';
 
@@ -133,7 +135,8 @@ export default url => FormatView => {
             if (!sparql.hiddenInfo) {
                 return (
                     <div>
-                        <LinkIcon
+                        <FontAwesomeIcon
+                            icon={faLink}
                             style={
                                 isURL(requestText)
                                     ? styles.pointer

--- a/src/app/js/formats/sparql/SparqlTextField/SparqlAdmin.js
+++ b/src/app/js/formats/sparql/SparqlTextField/SparqlAdmin.js
@@ -2,9 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import translate from 'redux-polyglot/translate';
 import TextField from 'material-ui/TextField';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlus, faTimes } from '@fortawesome/free-solid-svg-icons';
+
 import config from '../../../../../../config.json';
-import ContentAdd from 'material-ui/svg-icons/content/add';
-import ContentClear from 'material-ui/svg-icons/content/clear';
 import SelectFormat from '../../SelectFormat';
 
 import { polyglot as polyglotPropTypes } from '../../../propTypes';
@@ -299,7 +300,10 @@ class SparqlTextFieldAdmin extends Component {
                         }}
                         style={styles.pointer}
                     >
-                        <ContentAdd style={{ verticalAlign: 'sub' }} />
+                        <FontAwesomeIcon
+                            icon={faPlus}
+                            style={{ verticalAlign: 'sub' }}
+                        />
                         {polyglot.t('sparql_add_subformat')}
                     </div>
                     {sparql.subformat.map((result, key) => {
@@ -311,7 +315,8 @@ class SparqlTextFieldAdmin extends Component {
                                     key % 2 == 1 ? styles.color1 : styles.color2
                                 }
                             >
-                                <ContentClear
+                                <FontAwesomeIcon
+                                    icon={faTimes}
                                     onClick={() => {
                                         this.removeSubformat({ key });
                                     }}

--- a/src/app/js/formats/trello-timeline/TrelloTimelineView.js
+++ b/src/app/js/formats/trello-timeline/TrelloTimelineView.js
@@ -1,34 +1,68 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Timeline, TimelineEvent } from 'react-event-timeline/dist';
-import {
-    ActionDateRange,
-    ActionAlarm,
-    ActionBookmark,
-    ActionRecordVoiceOver,
-    ActionTrendingUp,
-} from 'material-ui/svg-icons';
 import { milestones } from 'inist-roadmap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+    faCalendarAlt,
+    faClock,
+    faBookmark,
+    faPhoneVolume,
+    faBullseye,
+} from '@fortawesome/free-solid-svg-icons';
+
+const smallIcon = {
+    width: 18,
+    height: 18,
+};
+
 import { field as fieldPropTypes } from '../../propTypes';
 import Link from '../../lib/components/Link';
 
 function getIconFromLabel(labels) {
-    const smallIcon = {
-        width: 18,
-        height: 18,
-    };
     if (labels.indexOf('sprint-review') !== -1) {
-        return <ActionAlarm iconStyle={smallIcon} style={smallIcon} />;
-    } else if (labels.indexOf('communication') !== -1) {
         return (
-            <ActionRecordVoiceOver iconStyle={smallIcon} style={smallIcon} />
+            <FontAwesomeIcon
+                icon={faClock}
+                iconStyle={smallIcon}
+                style={smallIcon}
+            />
         );
-    } else if (labels.indexOf('objectif') !== -1) {
-        return <ActionTrendingUp iconStyle={smallIcon} style={smallIcon} />;
-    } else if (labels.indexOf('reunion') !== -1) {
-        return <ActionDateRange iconStyle={smallIcon} style={smallIcon} />;
     }
-    return <ActionBookmark iconStyle={smallIcon} style={smallIcon} />;
+    if (labels.indexOf('communication') !== -1) {
+        return (
+            <FontAwesomeIcon
+                icon={faPhoneVolume}
+                iconStyle={smallIcon}
+                style={smallIcon}
+            />
+        );
+    }
+    if (labels.indexOf('objectif') !== -1) {
+        return (
+            <FontAwesomeIcon
+                icon={faBullseye}
+                iconStyle={smallIcon}
+                style={smallIcon}
+            />
+        );
+    }
+    if (labels.indexOf('reunion') !== -1) {
+        return (
+            <FontAwesomeIcon
+                icon={faCalendarAlt}
+                iconStyle={smallIcon}
+                style={smallIcon}
+            />
+        );
+    }
+    return (
+        <FontAwesomeIcon
+            icon={faBookmark}
+            iconStyle={smallIcon}
+            style={smallIcon}
+        />
+    );
 }
 
 const SeeMoreStyle = {

--- a/src/app/js/lib/components/ButtonWithDialog.js
+++ b/src/app/js/lib/components/ButtonWithDialog.js
@@ -17,7 +17,6 @@ export const PureButtonWithDialog = ({
     handleOpen,
     open,
     show,
-    style,
     dialog,
     className,
     label,
@@ -45,7 +44,7 @@ export const PureButtonWithDialog = ({
     }
 
     return (
-        <span style={style}>
+        <>
             {openButton}
             <Dialog
                 title={label}
@@ -61,7 +60,7 @@ export const PureButtonWithDialog = ({
             >
                 {dialog}
             </Dialog>
-        </span>
+        </>
     );
 };
 
@@ -71,7 +70,6 @@ PureButtonWithDialog.propTypes = {
     p: polyglotPropTypes.isRequired,
     open: PropTypes.bool,
     show: PropTypes.bool,
-    style: PropTypes.object,
     dialog: PropTypes.node.isRequired,
     label: PropTypes.string.isRequired,
     icon: PropTypes.node,

--- a/src/app/js/lib/components/ButtonWithDialogForm.js
+++ b/src/app/js/lib/components/ButtonWithDialogForm.js
@@ -103,6 +103,10 @@ PureButtonWithDialogForm.defaultProps = {
     icon: null,
     show: true,
     open: false,
+    buttonStyle: {
+        width: '40px',
+        height: '40px',
+    },
 };
 
 PureButtonWithDialogForm.propTypes = {

--- a/src/app/js/lib/components/ButtonWithStatus.js
+++ b/src/app/js/lib/components/ButtonWithStatus.js
@@ -4,14 +4,30 @@ import { lightGreenA400, red400 } from 'material-ui/styles/colors';
 import CircularProgress from 'material-ui/CircularProgress';
 import FlatButton from 'material-ui/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+    faCheck,
+    faExclamationTriangle,
+} from '@fortawesome/free-solid-svg-icons';
 
-import Warning from 'material-ui/svg-icons/alert/warning';
-import Success from 'material-ui/svg-icons/action/done';
+export const WarningIcon = props => (
+    <FontAwesomeIcon icon={faExclamationTriangle} color={red400} {...props} />
+);
+
+export const SuccessIcon = props => (
+    <FontAwesomeIcon icon={faCheck} color={lightGreenA400} {...props} />
+);
 
 const getIcon = (error, loading, success) => {
-    if (loading) return <CircularProgress size={20} />;
-    if (error) return <Warning color={red400} />;
-    if (success) return <Success color={lightGreenA400} />;
+    if (loading) {
+        return <CircularProgress size={20} />;
+    }
+    if (error) {
+        return <WarningIcon />;
+    }
+    if (success) {
+        return <SuccessIcon />;
+    }
     return null;
 };
 

--- a/src/app/js/lib/components/ButtonWithStatus.spec.js
+++ b/src/app/js/lib/components/ButtonWithStatus.spec.js
@@ -1,13 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { lightGreenA400, red400 } from 'material-ui/styles/colors';
 import CircularProgress from 'material-ui/CircularProgress';
 import FlatButton from 'material-ui/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
-import Warning from 'material-ui/svg-icons/alert/warning';
-import Success from 'material-ui/svg-icons/action/done';
 
-import ButtonWithStatus from './ButtonWithStatus';
+import ButtonWithStatus, { WarningIcon, SuccessIcon } from './ButtonWithStatus';
 
 describe('<ButtonWithStatus />', () => {
     describe('<ButtonWithStatus raised={false} />', () => {
@@ -33,16 +30,14 @@ describe('<ButtonWithStatus />', () => {
             const wrapper = shallow(<ButtonWithStatus label="Foo" error />);
             const button = wrapper.find(FlatButton);
 
-            expect(button.prop('icon')).toEqual(<Warning color={red400} />);
+            expect(button.prop('icon')).toEqual(<WarningIcon />);
         });
 
         it('should render a FlatButton with a Success icon when it has success', () => {
             const wrapper = shallow(<ButtonWithStatus label="Foo" success />);
             const button = wrapper.find(FlatButton);
 
-            expect(button.prop('icon')).toEqual(
-                <Success color={lightGreenA400} />,
-            );
+            expect(button.prop('icon')).toEqual(<SuccessIcon />);
         });
     });
     describe('<ButtonWithStatus raised={true} />', () => {
@@ -72,7 +67,7 @@ describe('<ButtonWithStatus />', () => {
             );
             const button = wrapper.find(RaisedButton);
 
-            expect(button.prop('icon')).toEqual(<Warning color={red400} />);
+            expect(button.prop('icon')).toEqual(<WarningIcon />);
         });
 
         it('should render a RaisedButton with a Success icon when it has success', () => {
@@ -81,9 +76,7 @@ describe('<ButtonWithStatus />', () => {
             );
             const button = wrapper.find(RaisedButton);
 
-            expect(button.prop('icon')).toEqual(
-                <Success color={lightGreenA400} />,
-            );
+            expect(button.prop('icon')).toEqual(<SuccessIcon />);
         });
     });
 });

--- a/src/app/js/lib/components/Drawer.js
+++ b/src/app/js/lib/components/Drawer.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import Drawer from 'material-ui/Drawer';
 import IconButton from 'material-ui/IconButton';
 import FlatButton from 'material-ui/FlatButton';
-import CloseIcon from 'material-ui/svg-icons/content/clear';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
 const styles = {
     container: {
@@ -41,7 +42,7 @@ class LodexDrawer extends Component {
                                 style={styles.close}
                                 onClick={this.close}
                             >
-                                <CloseIcon />
+                                <FontAwesomeIcon icon={faTimes} />
                             </IconButton>
                             {children}
                         </div>

--- a/src/app/js/lib/components/Pagination.js
+++ b/src/app/js/lib/components/Pagination.js
@@ -1,7 +1,5 @@
-/*
-Taken from https://raw.githubusercontent.com/ENDiGo/pagination-material-ui
-Could not use it from npm at the time as it has not been compiled correctly
-*/
+// Taken from https://raw.githubusercontent.com/ENDiGo/pagination-@material-ui/core
+// Could not use it from npm at the time as it has not been compiled correctly
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -9,9 +7,11 @@ import IconButton from 'material-ui/IconButton';
 import MenuItem from 'material-ui/MenuItem';
 import SelectField from 'material-ui/SelectField';
 import TextField from 'material-ui/TextField';
-
-import ChevronLeft from 'material-ui/svg-icons/navigation/chevron-left';
-import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+    faChevronLeft,
+    faChevronRight,
+} from '@fortawesome/free-solid-svg-icons';
 
 const styles = {
     container: {
@@ -151,13 +151,13 @@ class Pagination extends Component {
                     disabled={currentPage === 0}
                     onClick={this.handlePreviousPageClick}
                 >
-                    <ChevronLeft />
+                    <FontAwesomeIcon icon={faChevronLeft} />
                 </IconButton>
                 <IconButton
                     disabled={currentPage === count - 1}
                     onClick={this.handleNextPageClick}
                 >
-                    <ChevronRight />
+                    <FontAwesomeIcon icon={faChevronRight} />
                 </IconButton>
             </div>
         );

--- a/src/app/js/lib/components/Pagination.js
+++ b/src/app/js/lib/components/Pagination.js
@@ -40,6 +40,10 @@ const styles = {
     underline: {
         display: 'none',
     },
+    icon: {
+        width: '20px',
+        height: '20px',
+    },
 };
 
 const texts = {
@@ -150,12 +154,14 @@ class Pagination extends Component {
                 <IconButton
                     disabled={currentPage === 0}
                     onClick={this.handlePreviousPageClick}
+                    iconStyle={styles.icon}
                 >
                     <FontAwesomeIcon icon={faChevronLeft} />
                 </IconButton>
                 <IconButton
                     disabled={currentPage === count - 1}
                     onClick={this.handleNextPageClick}
+                    iconStyle={styles.icon}
                 >
                     <FontAwesomeIcon icon={faChevronRight} />
                 </IconButton>

--- a/src/app/js/lib/components/SortButton.js
+++ b/src/app/js/lib/components/SortButton.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import FlatButton from 'material-ui/FlatButton';
-import ArrowUp from 'material-ui/svg-icons/navigation/arrow-upward';
 import withHandlers from 'recompose/withHandlers';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowUp } from '@fortawesome/free-solid-svg-icons';
+
 import { isLongText, getShortText } from '../../lib/longTexts';
 
 const styles = {
@@ -26,7 +28,8 @@ const SortButton = ({ name, label, sortBy, sortDir, sort }) => (
         label={isLongText(label) ? getShortText(label) : label}
         icon={
             sortBy === name && (
-                <ArrowUp
+                <FontAwesomeIcon
+                    icon={faArrowUp}
                     style={Object.assign(
                         {},
                         styles.iconSortBy,

--- a/src/app/js/public/Property/ModerateButton.js
+++ b/src/app/js/public/Property/ModerateButton.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import IconButton from 'material-ui/IconButton';
-import RejectedIcon from 'material-ui/svg-icons/content/clear';
-import ProposedIcon from 'material-ui/svg-icons/content/remove';
-import ValidatedIcon from 'material-ui/svg-icons/action/done';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import translate from 'redux-polyglot/translate';
@@ -14,6 +11,8 @@ import {
     grey500,
 } from 'material-ui/styles/colors';
 import classnames from 'classnames';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCheck, faTimes, faMinus } from '@fortawesome/free-solid-svg-icons';
 
 import propositionStatus from '../../../../common/propositionStatus';
 import { polyglot as polyglotPropTypes } from '../../propTypes';
@@ -21,9 +20,9 @@ import { fromResource } from '../selectors';
 import { fromUser } from '../../sharedSelectors';
 
 const icons = {
-    PROPOSED: ProposedIcon,
-    VALIDATED: ValidatedIcon,
-    REJECTED: RejectedIcon,
+    PROPOSED: <FontAwesomeIcon icon={faMinus} />,
+    VALIDATED: <FontAwesomeIcon icon={faCheck} />,
+    REJECTED: <FontAwesomeIcon icon={faTimes} />,
 };
 
 const colors = {

--- a/src/app/js/public/dataset/UriColumn.js
+++ b/src/app/js/public/dataset/UriColumn.js
@@ -18,7 +18,15 @@ const UriColumn = ({ column, resource, indice }) => (
             labelPosition="after"
             label={indice}
             containerElement={<Link to={getResourceUri(resource)} />}
-            icon={<FontAwesomeIcon icon={faChevronRight} />}
+            icon={
+                <FontAwesomeIcon
+                    icon={faChevronRight}
+                    style={{
+                        width: '20px',
+                        height: '20px',
+                    }}
+                />
+            }
         />
     </TableRowColumn>
 );

--- a/src/app/js/public/dataset/UriColumn.js
+++ b/src/app/js/public/dataset/UriColumn.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { TableRowColumn } from 'material-ui/Table';
 import FlatButton from 'material-ui/FlatButton';
-import RightIcon from 'material-ui/svg-icons/hardware/keyboard-arrow-right';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 
 import { field as fieldPropTypes } from '../../propTypes';
 import { getResourceUri } from '../../../../common/uris';
@@ -17,7 +18,7 @@ const UriColumn = ({ column, resource, indice }) => (
             labelPosition="after"
             label={indice}
             containerElement={<Link to={getResourceUri(resource)} />}
-            icon={<RightIcon />}
+            icon={<FontAwesomeIcon icon={faChevronRight} />}
         />
     </TableRowColumn>
 );

--- a/src/app/js/public/graph/GraphLink.js
+++ b/src/app/js/public/graph/GraphLink.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import translate from 'redux-polyglot/translate';
 import { Card, CardMedia, CardActions } from 'material-ui/Card';
 import FlatButton from 'material-ui/FlatButton';
-import Forward from 'material-ui/svg-icons/content/forward';
-import translate from 'redux-polyglot/translate';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowRight } from '@fortawesome/free-solid-svg-icons';
 
 import { polyglot as polyglotPropTypes } from '../../propTypes';
 import Link from '../../lib/components/Link';
@@ -41,7 +42,9 @@ const GraphLink = ({ link, children, p: polyglot }) => (
                 to={link}
                 label={polyglot.t('view_details')}
                 labelPosition="before"
-                icon={<Forward style={styles.icon} />}
+                icon={
+                    <FontAwesomeIcon icon={faArrowRight} style={styles.icon} />
+                }
             />
         </CardActions>
     </Card>

--- a/src/app/js/public/resource/CreateResource.js
+++ b/src/app/js/public/resource/CreateResource.js
@@ -3,7 +3,8 @@ import { connect } from 'react-redux';
 import translate from 'redux-polyglot/translate';
 import compose from 'recompose/compose';
 import FloatingActionButton from 'material-ui/FloatingActionButton';
-import ContentAdd from 'material-ui/svg-icons/content/add';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
 
 import { fromResource } from '../selectors';
 import CreateResourceForm from './CreateResourceForm';
@@ -21,6 +22,11 @@ const styles = {
         bottom: 100,
         right: 40,
     },
+    icon: {
+        color: 'white',
+        height: 56,
+        lineHeight: 56,
+    },
 };
 
 const CreateResource = ({ handleOpen, p, ...props }) => (
@@ -37,7 +43,7 @@ const CreateResource = ({ handleOpen, p, ...props }) => (
                 style={styles.button}
                 title={p.t('create_resource')}
             >
-                <ContentAdd />
+                <FontAwesomeIcon icon={faPlus} style={styles.icon} />
             </FloatingActionButton>
         }
     />

--- a/src/app/js/public/resource/CreateResource.js
+++ b/src/app/js/public/resource/CreateResource.js
@@ -19,13 +19,13 @@ import { fromUser } from '../../sharedSelectors';
 const styles = {
     button: {
         position: 'fixed',
-        bottom: 100,
-        right: 40,
+        bottom: '100px',
+        right: '40px',
     },
     icon: {
         color: 'white',
-        height: 56,
-        lineHeight: 56,
+        width: '20px',
+        height: '20px',
     },
 };
 

--- a/src/app/js/public/resource/Resource.js
+++ b/src/app/js/public/resource/Resource.js
@@ -5,12 +5,13 @@ import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import { withRouter } from 'react-router-dom';
 import translate from 'redux-polyglot/translate';
-import HomeIcon from 'material-ui/svg-icons/action/home';
-import { CardText, CardActions } from 'material-ui/Card';
-import FlatButton from 'material-ui/FlatButton';
 import { Swipeable } from 'react-swipeable';
 import get from 'lodash.get';
 import isEqual from 'lodash.isequal';
+import { CardText, CardActions } from 'material-ui/Card';
+import FlatButton from 'material-ui/FlatButton';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faHome } from '@fortawesome/free-solid-svg-icons';
 
 import { fromResource, fromSearch } from '../selectors';
 import { fromFields, fromCharacteristic } from '../../sharedSelectors';
@@ -103,7 +104,7 @@ export class ResourceComponent extends Component {
                 className="btn-back-to-list"
                 containerElement={<Link to="/graph" />}
                 label={backToListLabel}
-                icon={<HomeIcon />}
+                icon={<FontAwesomeIcon icon={faHome} />}
             />
         );
 

--- a/src/app/js/public/resource/SelectVersion.js
+++ b/src/app/js/public/resource/SelectVersion.js
@@ -8,7 +8,8 @@ import { connect } from 'react-redux';
 import moment from 'moment';
 import translate from 'redux-polyglot/translate';
 import compose from 'recompose/compose';
-import ArrowDown from 'material-ui/svg-icons/hardware/keyboard-arrow-down';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
 
 import { polyglot as polyglotPropTypes } from '../../propTypes';
 import { selectVersion } from '../resource';
@@ -73,7 +74,7 @@ export class SelectVersionComponent extends Component {
                     label={format(versions[selectedVersion], selectedVersion)}
                     labelPosition="before"
                     onClick={this.handleClick}
-                    icon={<ArrowDown />}
+                    icon={<FontAwesomeIcon icon={faChevronDown} />}
                 />
                 <Popover
                     open={showMenu}


### PR DESCRIPTION
[Trello Card #15](https://trello.com/c/68tUnjZA/15-upgrade-mui)

We use both `material-ui` and `font-awesome` icons. But as there are major breaking changes in newer versions of `material-ui` icons, it's better to keep only `font-awesome` at the moment.

Refs. https://github.com/Inist-CNRS/lodex/pull/1045

## Todo

- [x] Replace material-ui icons by font-awesome icons
- [x] Fix breaking changes

## Screenshots

![Sélection_002](https://user-images.githubusercontent.com/5584839/71731979-67a9ef80-2e46-11ea-8ddf-f309432626e3.png)

![Sélection_003](https://user-images.githubusercontent.com/5584839/71731986-6aa4e000-2e46-11ea-88e8-676015f60eed.png)
