### PR TITLE
Graph - Fix responsive design of facets

### DIFF
--- a/src/app/js/public/facet/FacetList.js
+++ b/src/app/js/public/facet/FacetList.js
@@ -19,10 +19,12 @@ const styles = stylesToClassname(
         list: {
             opacity: '0',
             maxHeight: '0px',
+            height: '0px',
             padding: '0px !important',
             transition: 'max-height 300ms ease-in-out, opacity 600ms ease',
             '@media (min-width: 992px)': {
                 opacity: '1',
+                height: '100%',
                 maxHeight: '10000px',
                 minWidth: '300px',
                 flex: 1,
@@ -30,6 +32,7 @@ const styles = stylesToClassname(
         },
         listOpen: {
             opacity: '1',
+            height: '100%',
             maxHeight: '10000px',
         },
     },

--- a/src/app/js/public/search/Search.js
+++ b/src/app/js/public/search/Search.js
@@ -207,7 +207,10 @@ class Search extends Component {
         return (
             <div className={classnames(className, styles.container)}>
                 <div className={styles.header}>
-                    <SearchSearchBar withFacets={withFacets} />
+                    <SearchSearchBar
+                        withFacets={withFacets}
+                        onToggleFacets={this.handleToggleFacets}
+                    />
                     <div className={styles.advanced}>
                         {(everythingIsOk || noResults) && <SearchStats />}
                     </div>


### PR DESCRIPTION
[Trello Card #116](https://trello.com/c/RQmSfejd/116-am%C3%A9liorer-laffichage-de-la-page-graphe-sur-mobile)

Introduced by https://github.com/Inist-CNRS/lodex/pull/1047

On Mobile: 
- Facets are always hidden in the Search Drawer
- Facets are still clickable, even if they are hidden

## Todo

- [x] Fix toggle facets in SearchBar
- [x] Fix Facets which are still clickable when hidden

## Screenshots

![Peek 07-01-2020 10-49](https://user-images.githubusercontent.com/5584839/71885862-84427200-313b-11ea-90f6-0419d9759d0f.gif)
