### PR TITLE
Graph - Fix responsive design of facets items

### DIFF
--- a/src/app/js/public/facet/FacetItem.js
+++ b/src/app/js/public/facet/FacetItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import { ListItem } from 'material-ui/List';
 import { connect } from 'react-redux';
 
@@ -17,11 +18,15 @@ const styles = {
 
 const onClick = (openFacet, field) => () => openFacet({ name: field.name });
 
-const FacetItem = ({ isOpen, field, total, page }) => (
+const FacetItem = ({ className, isOpen, field, total, page }) => (
     <FacetActionsContext.Consumer>
         {({ openFacet }) => (
             <ListItem
-                className={`facet-item facet-${getFieldClassName(field)}`}
+                className={classnames(
+                    className,
+                    'facet-item',
+                    `facet-${getFieldClassName(field)}`,
+                )}
                 nestedListStyle={styles.nested}
                 key={field.name}
                 primaryText={`${field.label} ${total ? `(${total})` : ''}`}
@@ -42,6 +47,7 @@ const FacetItem = ({ isOpen, field, total, page }) => (
 );
 
 FacetItem.propTypes = {
+    className: PropTypes.string,
     isOpen: PropTypes.bool.isRequired,
     field: fieldPropType.isRequired,
     total: PropTypes.number,

--- a/src/app/js/public/facet/FacetList.js
+++ b/src/app/js/public/facet/FacetList.js
@@ -35,6 +35,15 @@ const styles = stylesToClassname(
             height: '100%',
             maxHeight: '10000px',
         },
+        listItem: {
+            height: '0px',
+            '@media (min-width: 992px)': {
+                height: '100%',
+            },
+        },
+        listItemOpen: {
+            height: '100%',
+        },
     },
     'facets',
 );
@@ -75,6 +84,9 @@ const FacetList = ({
                         key={`${page}-${field.name}`}
                         field={field}
                         page={page}
+                        className={classnames(styles.listItem, {
+                            [styles.listItemOpen]: open,
+                        })}
                     />
                 ))}
             </FacetActionsContext.Provider>


### PR DESCRIPTION
[Trello Card #116](https://trello.com/c/RQmSfejd/116-am%C3%A9liorer-laffichage-de-la-page-graphe-sur-mobile)

Introduced by https://github.com/Inist-CNRS/lodex/pull/1047 and https://github.com/Inist-CNRS/lodex/pull/1055

On Mobile: 
- Facets Items broke the Graph Interactions

## Todo

- [x] Fix Facets Items which broke the graphs interactions when hidden

## Screenshots

![Peek 07-01-2020 10-49](https://user-images.githubusercontent.com/5584839/71885862-84427200-313b-11ea-90f6-0419d9759d0f.gif)
