### PR TITLE
Fix data import by URL link

### DIFF
--- a/src/api/controller/api/upload.js
+++ b/src/api/controller/api/upload.js
@@ -177,7 +177,7 @@ export const uploadUrl = async ctx => {
     const { url, parserName } = ctx.request.body;
     const [extension] = url.match(/[^.]*$/);
 
-    const parseStream = ctx.getParser(
+    const parseStream = await ctx.getParser(
         !parserName || parserName === 'automatic' ? extension : parserName,
     );
 


### PR DESCRIPTION
## Trello card [#2](https://trello.com/c/FYlCpmA1)

Data import with "Importer depuis une URL lead to an error 500 server side

## Solution

The function to parse file is a Promise and have to be resolved before to be executed

After fix, loading is ok:

![image](https://user-images.githubusercontent.com/39904906/95765770-9a74f400-0cb2-11eb-8438-3d300bd69d21.png)

