### PR TITLE
Display field id in the preview

### DIFF
--- a/src/app/js/admin/preview/ExcerptHeader.js
+++ b/src/app/js/admin/preview/ExcerptHeader.js
@@ -22,6 +22,17 @@ const getStyle = memoize(field =>
         : null,
 );
 
+const titleStyle = {
+    titleBlock: {
+        display: 'flex',
+        flexDirection: 'column',
+    },
+    titleId: {
+        fontWeight: 'lighter',
+        fontStyle: 'italic',
+    },
+};
+
 const ensureTextIsShort = text =>
     isLongText(text) ? getShortText(text) : text;
 
@@ -50,7 +61,12 @@ const ExcerptHeaderComponent = ({
     p: polyglot,
 }) => (
     <div style={getStyle(field)}>
-        {ensureTextIsShort(field.label || field.name)}
+        <p style={titleStyle.titleBlock}>
+            <span>{ensureTextIsShort(field.label)}</span>
+            <span style={titleStyle.titleId}>
+                ( {ensureTextIsShort(field.name)} )
+            </span>
+        </p>
         {completedField && (
             <div className={`completes_${getFieldClassName(completedField)}`}>
                 {polyglot.t('completes_field_X', {

--- a/src/app/js/admin/preview/publication/PublicationPreview.js
+++ b/src/app/js/admin/preview/publication/PublicationPreview.js
@@ -18,7 +18,7 @@ const styles = {
     container: {
         position: 'relative',
         display: 'flex',
-        maxHeight: 600,
+        maxHeight: 610,
     },
     content: {
         overflow: 'auto',


### PR DESCRIPTION
## Issue 

Dans le modèle avant publication, page ressources, lorsque j'ajoute un nouveau champ qui est de nature "graphique", j'indique la routine à utiliser dans la partie "valeur arbitraire".
Pour pouvoir compléter cette routine avec l'identifiant du champ sur lequel elle doit travailler, je dois suivre les étapes :
1) publier les données
2) dans le modèle publié, copier l'identifiant du champ "mots-clés auteur"
3) coller cet identifiant dans le graphique "publications similaires" via le crayon pour compléter la routine
=> impossible, le crayon n'est pas disponible (car c'est un champ ressource, on n'est pas censé modifier la valeur ) warning
3 bis) du coup, dans les données publiées : rechercher un document susceptible d'afficher un asterplot sur les mots-clés d'auteur, et quand ce doc est trouvé, coller l'identifiant du champ mots-clés auteur dans le crayon dispo pour le champ du graphique correspondant

=> est-il possible de simplifier ce processus ? (cf 12.0.4_ajout-asterplot.gif)

## Solution 

Displaying the id will allow, when creating a new graphic, to know what id to set in the routine string, whitout needing to publish the data.

![image](https://user-images.githubusercontent.com/39904906/100379003-7841f600-3014-11eb-95d6-7b0086d16573.png)
