### PR TITLE
Use wildcard to list index keys

### DIFF
--- a/cypress/support/datasetImportPage.js
+++ b/cypress/support/datasetImportPage.js
@@ -99,6 +99,7 @@ export const setOperationTypeInWizard = (value = 'DEFAULT') => {
 
 export const publish = () => {
     cy.get('.btn-publish button').click();
+    cy.wait(500);
     adminNavigation.goToData();
     cy.get('.data-published').should('be.visible');
 };

--- a/src/api/models/publishedDataset.js
+++ b/src/api/models/publishedDataset.js
@@ -399,24 +399,18 @@ export default async db => {
             return;
         }
 
-        const textIndex = fields.reduce(
-            (acc, name) => ({
-                ...acc,
-                [`versions.${name}`]: 'text',
-            }),
-            {},
-        );
-
         try {
-            await collection.createIndex(textIndex, {
-                name: 'match_index',
-            });
-        } catch (error) {
             await collection.dropIndex('match_index');
-            await collection.createIndex(textIndex, {
-                name: 'match_index',
-            });
+        } catch (error) {
+            //Needed for old indexes
         }
+
+        await collection.createIndex(
+            { '$**': 'text' },
+            {
+                name: 'match_index',
+            },
+        );
     };
 
     return collection;


### PR DESCRIPTION
The createIndex function in mongodb dont accept "Index keys" document too heavy
When there was more than 85 searchable fields in the model, it failed.

https://trello.com/c/luYMwqcO