### PR TITLE
Not show unvisible fields

### DIFF
--- a/src/app/js/fields/selectors.js
+++ b/src/app/js/fields/selectors.js
@@ -127,7 +127,7 @@ const getRootCollectionFields = createSelector(
     getCollectionFieldsExceptComposite,
     allFields =>
         allFields
-            .filter(f => f.display || f.contribution)
+            .filter(f => f.display)
             .filter(
                 f =>
                     (f.scope === SCOPE_COLLECTION ||


### PR DESCRIPTION
If field is "display:false, it should never be visible in published data

## Before

![image](https://user-images.githubusercontent.com/39904906/108984353-1aaf5b00-7690-11eb-9856-e20a44447888.png)


## After

![image](https://user-images.githubusercontent.com/39904906/108984123-dde36400-768f-11eb-88db-2ce715f19b04.png)
