### PR TITLE
Fix the creation of an enrichment when the source is a number

### DIFF
--- a/src/api/services/enrichment/enrichment.js
+++ b/src/api/services/enrichment/enrichment.js
@@ -12,7 +12,13 @@ export const createEnrichmentRule = async ctx => {
     }
 
     const excerpt = await ctx.dataset.getExcerpt();
-    const sourceData = excerpt[0][enrichment.sourceColumn];
+    let sourceData;
+    for (let line of excerpt) {
+        if (line[enrichment.sourceColumn]) {
+            sourceData = line[enrichment.sourceColumn];
+            break;
+        }
+    }
     let data;
     try {
         data = JSON.parse(sourceData);
@@ -31,7 +37,10 @@ export const createEnrichmentRule = async ctx => {
 const isDirectPath = sourceData => {
     return (
         typeof sourceData === 'string' ||
-        (Array.isArray(sourceData) && typeof sourceData[0] === 'string')
+        typeof sourceData === 'number' ||
+        (Array.isArray(sourceData) &&
+            (typeof sourceData[0] === 'string' ||
+                typeof sourceData === 'number'))
     );
 };
 

--- a/src/api/services/enrichment/enrichment.js
+++ b/src/api/services/enrichment/enrichment.js
@@ -12,13 +12,9 @@ export const createEnrichmentRule = async ctx => {
     }
 
     const excerpt = await ctx.dataset.getExcerpt();
-    let sourceData;
-    for (let line of excerpt) {
-        if (line[enrichment.sourceColumn]) {
-            sourceData = line[enrichment.sourceColumn];
-            break;
-        }
-    }
+    const sourceData = excerpt.find(line => !!line[enrichment.sourceColumn])[
+        enrichment.sourceColumn
+    ];
     let data;
     try {
         data = JSON.parse(sourceData);
@@ -34,13 +30,14 @@ export const createEnrichmentRule = async ctx => {
     };
 };
 
+const isBasicType = sourceData => {
+    return typeof sourceData === 'string' || typeof sourceData === 'number';
+};
+
 const isDirectPath = sourceData => {
     return (
-        typeof sourceData === 'string' ||
-        typeof sourceData === 'number' ||
-        (Array.isArray(sourceData) &&
-            (typeof sourceData[0] === 'string' ||
-                typeof sourceData === 'number'))
+        isBasicType(sourceData) ||
+        (Array.isArray(sourceData) && isBasicType(sourceData[0]))
     );
 };
 


### PR DESCRIPTION
## [Trello card](https://trello.com/c/xk8a3EYV/87-enrichissement-ini-vide)

- [ ] We check that the line used is not empty. And we now take into account the number types