### PR TITLE
Add other selection for subressource column

### DIFF
--- a/src/app/custom/translations.tsv
+++ b/src/app/custom/translations.tsv
@@ -603,3 +603,4 @@
 "facet_tooltip"	"From facet"	"Depuis une facette"
 "chart_tooltip"	"From chart"	"Depuis un graphique"
 "other_column"	"Other column"	"Autre nom de colonne"
+"other"	"Other"	"Autre"

--- a/src/app/custom/translations.tsv
+++ b/src/app/custom/translations.tsv
@@ -602,3 +602,4 @@
 "subRessource_tooltip"	"From subresource"	"Depuis une sous-ressource"
 "facet_tooltip"	"From facet"	"Depuis une facette"
 "chart_tooltip"	"From chart"	"Depuis un graphique"
+"other_column"	"Other column"	"Autre nom de colonne"

--- a/src/app/js/fields/wizard/SelectSubresourceField.js
+++ b/src/app/js/fields/wizard/SelectSubresourceField.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
     Select,
@@ -32,17 +32,28 @@ export const SelectSubresourceFieldComponent = ({
     label,
     id,
 }) => {
-    const [isOtherColumn, setIsOtherColumn] = useState(false);
-
-    useEffect(() => {
+    const checkIsOtherColumn = column => {
         if (column) {
-            if (datasetFields.includes(column) && column !== 'Autre') {
-                setIsOtherColumn(false);
+            if (
+                datasetFields.includes(column) &&
+                column !== polyglot.t('other')
+            ) {
+                return false;
             } else {
-                setIsOtherColumn(true);
+                return true;
             }
         }
-    }, [column]);
+        return false;
+    };
+
+    const [isOtherColumn, setIsOtherColumn] = useState(
+        checkIsOtherColumn(column),
+    );
+
+    const checkIsOtherColumnAndHandleChange = column => {
+        setIsOtherColumn(checkIsOtherColumn(column));
+        handleChange(column);
+    };
 
     return (
         <>
@@ -50,10 +61,12 @@ export const SelectSubresourceFieldComponent = ({
                 <InputLabel>{polyglot.t(label)}</InputLabel>
                 <Select
                     id={id}
-                    onChange={e => handleChange(e.target.value)}
+                    onChange={e =>
+                        checkIsOtherColumnAndHandleChange(e.target.value)
+                    }
                     style={styles.select}
                     labelId="select-subresource-input-label"
-                    value={isOtherColumn ? 'Autre' : column}
+                    value={isOtherColumn ? polyglot.t('other') : column}
                 >
                     {datasetFields.map(datasetField => (
                         <MenuItem
@@ -67,13 +80,18 @@ export const SelectSubresourceFieldComponent = ({
                 </Select>
             </FormControl>
             {isOtherColumn && (
-                <TextField
-                    label={polyglot.t('other_column')}
-                    onChange={e => handleChange(e.target.value)}
-                    style={styles.input}
-                    type="text"
-                    value={column}
-                />
+                <FormControl
+                    id="select-subresource-other-input-label"
+                    fullWidth
+                >
+                    <TextField
+                        label={polyglot.t('other_column')}
+                        onChange={e => handleChange(e.target.value)}
+                        style={styles.input}
+                        type="text"
+                        value={column}
+                    />
+                </FormControl>
             )}
         </>
     );
@@ -112,7 +130,7 @@ export const mapStateToProps = (state, { subresourceUri }) => {
                     ? subresourceData[0]
                     : subresourceData) || {},
             ),
-            ...['Autre'],
+            ...[state.polyglot.phrases['other']],
         ],
     };
 };

--- a/src/app/js/fields/wizard/SelectSubresourceField.js
+++ b/src/app/js/fields/wizard/SelectSubresourceField.js
@@ -1,6 +1,12 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Select, MenuItem, FormControl, InputLabel } from '@material-ui/core';
+import {
+    Select,
+    MenuItem,
+    FormControl,
+    InputLabel,
+    TextField,
+} from '@material-ui/core';
 import translate from 'redux-polyglot/translate';
 import compose from 'recompose/compose';
 import { connect } from 'react-redux';
@@ -13,6 +19,9 @@ const styles = {
     select: {
         width: '100%',
     },
+    input: {
+        marginTop: '10px',
+    },
 };
 
 export const SelectSubresourceFieldComponent = ({
@@ -22,28 +31,53 @@ export const SelectSubresourceFieldComponent = ({
     column,
     label,
     id,
-}) => (
-    <FormControl id="select-subresource-input-label" fullWidth>
-        <InputLabel>{polyglot.t(label)}</InputLabel>
-        <Select
-            id={id}
-            onChange={e => handleChange(e.target.value)}
-            style={styles.select}
-            labelId="select-subresource-input-label"
-            value={column}
-        >
-            {datasetFields.map(datasetField => (
-                <MenuItem
-                    key={`id_${datasetField}`}
-                    className={`column-${datasetField}`}
-                    value={datasetField}
+}) => {
+    const [isOtherColumn, setIsOtherColumn] = useState(false);
+
+    useEffect(() => {
+        if (column) {
+            if (datasetFields.includes(column) && column !== 'Autre') {
+                setIsOtherColumn(false);
+            } else {
+                setIsOtherColumn(true);
+            }
+        }
+    }, [column]);
+
+    return (
+        <>
+            <FormControl id="select-subresource-input-label" fullWidth>
+                <InputLabel>{polyglot.t(label)}</InputLabel>
+                <Select
+                    id={id}
+                    onChange={e => handleChange(e.target.value)}
+                    style={styles.select}
+                    labelId="select-subresource-input-label"
+                    value={isOtherColumn ? 'Autre' : column}
                 >
-                    {datasetField}
-                </MenuItem>
-            ))}
-        </Select>
-    </FormControl>
-);
+                    {datasetFields.map(datasetField => (
+                        <MenuItem
+                            key={`id_${datasetField}`}
+                            className={`column-${datasetField}`}
+                            value={datasetField}
+                        >
+                            {datasetField}
+                        </MenuItem>
+                    ))}
+                </Select>
+            </FormControl>
+            {isOtherColumn && (
+                <TextField
+                    label={polyglot.t('other_column')}
+                    onChange={e => handleChange(e.target.value)}
+                    style={styles.input}
+                    type="text"
+                    value={column}
+                />
+            )}
+        </>
+    );
+};
 
 SelectSubresourceFieldComponent.propTypes = {
     datasetFields: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -72,11 +106,14 @@ export const mapStateToProps = (state, { subresourceUri }) => {
     const subresourceData = parseValue(firstParsedLine[subresource.path] || '');
 
     return {
-        datasetFields: Object.keys(
-            (Array.isArray(subresourceData)
-                ? subresourceData[0]
-                : subresourceData) || {},
-        ),
+        datasetFields: [
+            ...Object.keys(
+                (Array.isArray(subresourceData)
+                    ? subresourceData[0]
+                    : subresourceData) || {},
+            ),
+            ...['Autre'],
+        ],
     };
 };
 

--- a/src/app/js/fields/wizard/SelectSubresourceField.spec.js
+++ b/src/app/js/fields/wizard/SelectSubresourceField.spec.js
@@ -10,10 +10,11 @@ describe('SelectSubresourceField', () => {
                 parsing: {
                     excerptLines: [{ columnPath: '{"cov": "fefe"}' }],
                 },
+                polyglot: { phrases: { other: 'Other' } },
             };
 
             expect(mapStateToProps(state, { subresourceUri: 'foo' })).toEqual({
-                datasetFields: ['cov', 'Autre'],
+                datasetFields: ['cov', 'Other'],
             });
         });
 
@@ -27,10 +28,11 @@ describe('SelectSubresourceField', () => {
                         { columnPath: '[{"bar": "bade"}, {"cov": "fefe"}]' },
                     ],
                 },
+                polyglot: { phrases: { other: 'Other' } },
             };
 
             expect(mapStateToProps(state, { subresourceUri: 'foo' })).toEqual({
-                datasetFields: ['bar', 'Autre'],
+                datasetFields: ['bar', 'Other'],
             });
         });
     });

--- a/src/app/js/fields/wizard/SelectSubresourceField.spec.js
+++ b/src/app/js/fields/wizard/SelectSubresourceField.spec.js
@@ -13,7 +13,7 @@ describe('SelectSubresourceField', () => {
             };
 
             expect(mapStateToProps(state, { subresourceUri: 'foo' })).toEqual({
-                datasetFields: ['cov'],
+                datasetFields: ['cov', 'Autre'],
             });
         });
 
@@ -30,7 +30,7 @@ describe('SelectSubresourceField', () => {
             };
 
             expect(mapStateToProps(state, { subresourceUri: 'foo' })).toEqual({
-                datasetFields: ['bar'],
+                datasetFields: ['bar', 'Autre'],
             });
         });
     });


### PR DESCRIPTION
## [Trello card](https://trello.com/c/6r0588Ow/92-cr%C3%A9ation-nouveau-champ-liste-des-colonnes-pour-choisir-la-valeur-dun-champ)

- [x] Add Other field for subressource column selection. 

First iteration. I know that the hard value "Autre" is not great, but it is the only solution that came to mind in a simple way

## Screenshot

![image](https://user-images.githubusercontent.com/18294269/144455589-dbb242fc-73e1-4bfd-817d-259014d2a00c.png)
