### PR TITLE
fix: dbName was wrong for numeric second part

### DIFF
--- a/config/production-dist.js
+++ b/config/production-dist.js
@@ -5,8 +5,8 @@ const getMongoConfig = () => {
 
     const defaultConfig = {
         dbName: String(process.env.EZMASTER_TECHNICAL_NAME).replace(
-            /(-[0-9]+)$/,
-            '',
+            /(-[^-]*)-[0-9]+$/,
+            '$1',
         ),
     };
 


### PR DESCRIPTION
bla-1 gave bla instead of bla-1.

With an `EZMASTER_TECHNICAL_NAME` having only a number in the second part, and no third part, instead of ignoring only **3rd part**, `dbName` ignores the **last part** containing only a number.

Unfortunately, the second part can contain only a number, while the third part is absent.

`example-1` yields the same `dbName` as `example-2`, though we want only `canonical-example-1` and `canonical-example-2` share the same `dbName`.

We did not anticipate an `EZMASTER_TECHNICAL_NAME` having so few parts (with an entirely numeric last one).