### PR TITLE
Allow loaders to known the used filename/urlname and the parser name

### DIFF
--- a/src/api/services/import.js
+++ b/src/api/services/import.js
@@ -52,6 +52,9 @@ export const startImport = async ctx => {
         };
         let parseStream;
         if (customLoader) {
+            loaderEnvironment.parser = loaderEnvironment.parser.concat(
+                '/custom',
+            );
             parseStream = await ctx.getCustomLoader(
                 customLoader,
                 loaderEnvironment,

--- a/src/api/services/import.spec.js
+++ b/src/api/services/import.spec.js
@@ -39,7 +39,10 @@ describe('import', () => {
         });
 
         it('should have called getLoader with extension', async () => {
-            expect(ctx.getLoader).toHaveBeenCalledWith('csv');
+            expect(ctx.getLoader).toHaveBeenCalledWith('csv', {
+                parser: 'csv',
+                source: 'upload/filename.csv',
+            });
         });
 
         it('should have called mergeChunks', async () => {
@@ -116,7 +119,10 @@ describe('import', () => {
         });
 
         it('should have called getCustomLoader with custom', async () => {
-            expect(ctx.getCustomLoader).toHaveBeenCalledWith('custom');
+            expect(ctx.getCustomLoader).toHaveBeenCalledWith('custom', {
+                parser: 'csv/custom',
+                source: 'upload/filename.csv'
+            });
         });
 
         it('should have called mergeChunks', async () => {
@@ -192,7 +198,10 @@ describe('import', () => {
         });
 
         it('should have called getLoader with extension', async () => {
-            expect(ctx.getLoader).toHaveBeenCalledWith('csv');
+            expect(ctx.getLoader).toHaveBeenCalledWith('csv', {
+                parser: 'csv',
+                source: 'http://host/file.name.csv'
+            });
         });
 
         it('should have called getStreamFromUrl', async () => {


### PR DESCRIPTION
Following an internal discussion, and to avoid developments that go beyond the scope of this intervention.