### PR TITLE
modify french translation of remove

### DIFF
--- a/src/app/custom/translations.tsv
+++ b/src/app/custom/translations.tsv
@@ -138,7 +138,7 @@
 "transformers"	"Operations"	"Opérations"
 "fieldname_copied_clipboard"	"Field name was copied to clipboard"	"Le nom de champ a été copié dans le presse papier"
 "add"	"add"	"ajout"
-"remove"	"remove"	"enlever"
+"remove"	"remove"	"supprimer"
 "select_a_field"	"Select a field"	"Sélectionner un champ"
 "select_a_format"	"Apply a format"	"Appliquer un format"
 "language"	"Language"	"Langue"


### PR DESCRIPTION
Just an modification of the french translation of remove which was "enlever", and is "supprimer" now.
![Capture d’écran 2023-01-30 à 16 15 23](https://user-images.githubusercontent.com/17042642/215516786-71d8f0af-916b-4358-82a0-f8e4456e81db.png)
