### PR TITLE
Fix for Dockerfile smell DL3059

### DIFF
--- a/Dockerfile.spec
+++ b/Dockerfile.spec
@@ -18,9 +18,8 @@ WORKDIR /app
 ARG node_env="production"
 ENV NODE_ENV=$node_env
 
-RUN cp -n ./config/production-dist.js ./config/production.js
-
-RUN npm run build
+RUN cp -n ./config/production-dist.js ./config/production.js \
+    && npm run build
 
 EXPOSE 3000
 CMD ["npm", "start"]


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile.spec" contains the best practice violation [DL3059](https://github.com/hadolint/hadolint/wiki/DL3059) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3059 occurs if there are multiple consecutive RUN instructions. Each RUN will correspond to a layer of the final Docker image, thus is recommended to compact them to reduce the number of layers for the final image.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, The consecutive RUN instructions have been chained until a comment or a different instruction appears.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance
