### PR TITLE
Remove warning cause by d3

### DIFF
--- a/src/app/webpack.config.babel.js
+++ b/src/app/webpack.config.babel.js
@@ -19,6 +19,11 @@ const translations = require('../api/services/translations');
 
 module.exports = {
     mode: isDevelopment ? 'development' : 'production',
+    ignoreWarnings: [
+        {
+            module: /d3/,
+        },
+    ],
     entry: {
         index: resolve(__dirname, './js/public/index.js'),
         'admin/index': resolve(__dirname, './js/admin/index.js'),


### PR DESCRIPTION
Webpack displays a warning caused by D3, specifically its export of the `map` function from both `d3-collection` and `d3-array`. While non-blocking, this warning does not cause any issues.

We can observe this warning because webpack can now detect potential issues more effectively.

https://www.npmjs.com/package/d3/v/5.16.0?activeTab=code
https://github.com/Inist-CNRS/lodex/actions/runs/6771946023/job/18403452128#step:4:282