### PR TITLE
Prevent syntax error in customized loaders

### DIFF
--- a/workers/loaders/tar-gz.ini
+++ b/workers/loaders/tar-gz.ini
@@ -114,9 +114,7 @@ value = get('serie.issue')
 ; exemple : "1 - science", "2 - zoology", "2 - evolutionary biology"
 ; et on veut un objet Nom-Classification-outil pour chaque tag 2
 path = Catégories WoS
-value = get('categories.wos')\
-        .filter((cat) => cat.startsWith('2 - '))\
-		.map(function createCat(nom) { return { Nom: nom, Classification: _.get(self, 'categories.wos.0'), Outils:  ['multicat'] } })
+value = get('categories.wos').filter((cat) => cat.startsWith('2 - ')).map(function createCat(nom) { return { Nom: nom, Classification: _.get(self, 'categories.wos.0'), Outils:  ['multicat'] } })
 
 ; Scopus : des groupes sémantiques successifs de 3 éléments, du plus générique (tag1) au plus spécifique (tag 3), groupes non séparés entre eux --> chunk
 path = Catégories Scopus

--- a/workers/loaders/zip.ini
+++ b/workers/loaders/zip.ini
@@ -110,9 +110,7 @@ value = get('serie.issue')
 ; exemple : "1 - science", "2 - zoology", "2 - evolutionary biology"
 ; et on veut un objet Nom-Classification-outil pour chaque tag 2
 path = Catégories WoS
-value = get('categories.wos')\
-        .filter((cat) => cat.startsWith('2 - '))\
-		.map(function createCat(nom) { return { Nom: nom, Classification: _.get(self, 'categories.wos.0'), Outils:  ['multicat'] } })
+value = get('categories.wos').filter((cat) => cat.startsWith('2 - ')).map(function createCat(nom) { return { Nom: nom, Classification: _.get(self, 'categories.wos.0'), Outils:  ['multicat'] } })
 
 ; Scopus : des groupes sémantiques successifs de 3 éléments, du plus générique (tag1) au plus spécifique (tag 3), groupes non séparés entre eux --> chunk
 path = Catégories Scopus


### PR DESCRIPTION
When using loaders with ezs multiline statements in customized loader and modifying it, a syntax error happens.

![image](https://github.com/Inist-CNRS/lodex/assets/595509/7a39f11f-170a-4e28-9aad-6fc5b5a075a9)

https://github.com/Inist-CNRS/lodex/blob/b68414f31f667cd6e3d3b795dc283b3019823569/workers/loaders/zip.ini#L113-L115

I think that ace editor modifies its content on change (something like converting LF line returns to CR LF).