### PR TITLE
Fix precompute when ws is failure

### DIFF
--- a/src/api/controller/webhook.js
+++ b/src/api/controller/webhook.js
@@ -26,7 +26,6 @@ export const getComputedWebserviceData = async ctx => {
             ctx,
             tenant,
             precomputedId,
-            callId,
             jobId,
             type,
             message,


### PR DESCRIPTION
Another little fix to avoid somes internal errors and ensure the page reload, when the webservice answers with a failure