### PR TITLE
fix(precomputed): Fix field setting when precomputed data doesn't exists

### DIFF
--- a/src/app/js/fields/sourceValue/SourceValuePrecomputed.js
+++ b/src/app/js/fields/sourceValue/SourceValuePrecomputed.js
@@ -30,6 +30,7 @@ const SourceValuePrecomputed = ({
         });
 
         if (
+            !precomputedSelected.data ||
             precomputedSelected.data.length === 0 ||
             precomputedSelected.status !== 'FINISHED'
         ) {


### PR DESCRIPTION
![image](https://github.com/Inist-CNRS/lodex/assets/39904906/f2640093-dcc9-411e-afcf-85b7529c1a03)
