### PR TITLE
Fix: FieldComposedOf should also display fields with no label in the options

### DIFF
--- a/src/app/js/fields/FieldComposedOf.js
+++ b/src/app/js/fields/FieldComposedOf.js
@@ -59,22 +59,20 @@ const FieldComposedOf = ({
                         label={polyglot.t('fields_composed_of')}
                     />
                 )}
-                renderOption={(props, option) =>
-                    !!option.label && (
-                        <MenuItem
-                            sx={{
-                                '&.MuiAutocomplete-option': {
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'space-between',
-                                },
-                            }}
-                            {...props}
-                        >
-                            <FieldRepresentation field={option} />
-                        </MenuItem>
-                    )
-                }
+                renderOption={(props, option) => (
+                    <MenuItem
+                        sx={{
+                            '&.MuiAutocomplete-option': {
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'space-between',
+                            },
+                        }}
+                        {...props}
+                    >
+                        <FieldRepresentation field={option} />
+                    </MenuItem>
+                )}
                 onChange={handleChange}
             />
         </Box>


### PR DESCRIPTION
**Problem**

There is no way to select fields with an empty label as composed field, as they are not included in the options.

**Solution**

Also include in the options fields with an empty label.

![2024-01-29_14-11](https://github.com/Inist-CNRS/lodex/assets/14542336/17f9aa4b-ee2d-42dc-a0c4-57ca7f250bf1)
