### PR TITLE
Fix: Should not allow to create multiple subresources with the same path

### DIFF
--- a/src/app/custom/translations.tsv
+++ b/src/app/custom/translations.tsv
@@ -1059,3 +1059,4 @@
 "format_default_params"	"Display parameters"	"Paramètres d'affichage"
 "format_sub_format_params"	"Sub-format parameters"	"Paramètres du sous-format"
 "format_without_params"	"This format has no parameters"	"Ce format n'a pas de paramètres"
+"subresource_path_validation_error"	"A subresource with this path already exists"	"Une sous-ressource avec ce chemin existe déjà"

--- a/src/app/js/admin/subresource/AddSubresource.js
+++ b/src/app/js/admin/subresource/AddSubresource.js
@@ -9,6 +9,7 @@ import SubresourceForm from './SubresourceForm';
 
 const mapStateToProps = state => ({
     pathSelected: formValueSelector('SUBRESOURCE_ADD_FORM')(state, 'path'),
+    subresources: state.subresource.subresources,
 });
 
 export const AddSubresource = compose(

--- a/src/app/js/admin/subresource/EditSubresourceForm.js
+++ b/src/app/js/admin/subresource/EditSubresourceForm.js
@@ -21,6 +21,7 @@ export const EditSubresourceForm = compose(
             initialValues: s.subresource.subresources.find(
                 sr => sr._id === match.params.subresourceId,
             ),
+            subresources: s.subresource.subresources,
         }),
         {
             updateSubresource: updateSubresourceAction,

--- a/src/app/js/admin/subresource/SubresourceForm.js
+++ b/src/app/js/admin/subresource/SubresourceForm.js
@@ -65,6 +65,7 @@ const SubresourceFormComponent = ({
     pathSelected,
     change,
     subresources,
+    invalid,
 }) => {
     const optionsIdentifier = useMemo(() => {
         const firstExcerptLine = excerptLines[0]?.[pathSelected] || [];
@@ -173,7 +174,7 @@ const SubresourceFormComponent = ({
                             variant="contained"
                             color="primary"
                             type="submit"
-                            disabled={pristine || submitting}
+                            disabled={pristine || submitting || invalid}
                         >
                             {polyglot.t('save')}
                         </Button>

--- a/src/app/js/admin/subresource/SubresourceForm.js
+++ b/src/app/js/admin/subresource/SubresourceForm.js
@@ -79,7 +79,7 @@ const SubresourceFormComponent = ({
     const validatePath = useCallback(
         path =>
             path && subresources.map(sr => sr.path).includes(path)
-                ? 'A subresource with this path already exists'
+                ? polyglot.t('subresource_path_validation_error')
                 : undefined,
         [subresources],
     );

--- a/src/app/js/admin/subresource/SubresourceForm.js
+++ b/src/app/js/admin/subresource/SubresourceForm.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import compose from 'recompose/compose';
 import translate from 'redux-polyglot/translate';
 import { propTypes as reduxFormPropTypes, Field } from 'redux-form';
@@ -64,6 +64,7 @@ const SubresourceFormComponent = ({
     excerptLines,
     pathSelected,
     change,
+    subresources,
 }) => {
     const optionsIdentifier = useMemo(() => {
         const firstExcerptLine = excerptLines[0]?.[pathSelected] || [];
@@ -74,6 +75,14 @@ const SubresourceFormComponent = ({
     const handleCancel = () => {
         history.push('/display/document/subresource');
     };
+
+    const validatePath = useCallback(
+        path =>
+            path && subresources.map(sr => sr.path).includes(path)
+                ? 'A subresource with this path already exists'
+                : undefined,
+        [subresources],
+    );
 
     return (
         <Box sx={{ background: 'primary', padding: '20px' }}>
@@ -113,6 +122,7 @@ const SubresourceFormComponent = ({
                         clearIdentifier={() => {
                             change('identifier', '');
                         }}
+                        validate={validatePath}
                     />
 
                     <Field

--- a/src/app/js/admin/subresource/SubressourceFieldAutoComplete.js
+++ b/src/app/js/admin/subresource/SubressourceFieldAutoComplete.js
@@ -9,12 +9,14 @@ const SubressourceFieldAutoComplete = ({
     hint,
     meta: { touched, error },
     clearIdentifier,
+    error: rootError,
     ...props
 }) => {
+    const finalError = rootError || (touched && error) || undefined;
     return (
-        <FormControl fullWidth>
+        <FormControl fullWidth error={!!finalError}>
             <Autocomplete
-                error={touched ? error : undefined}
+                error={finalError}
                 {...input}
                 onChange={(event, newValue, reason) => {
                     if (reason === 'clear') {
@@ -24,7 +26,7 @@ const SubressourceFieldAutoComplete = ({
                 }}
                 {...props}
             />
-            <FormHelperText>{hint}</FormHelperText>
+            <FormHelperText>{finalError || hint}</FormHelperText>
         </FormControl>
     );
 };


### PR DESCRIPTION
### Problem

Creating multiple subresources with the same path causes a bug later, when selecting the subresource in a subresource field, because they are identified by their `path`, and hence multiple items will appear as selected.

### Solution

Long term: probably rethink the subresource model, and use a unique identifier to identify them and store them.

Short term: prevent creation of subresources with the same path by adding a client-side validation.
This is what this PR does.

![2024-01-30_18-22](https://github.com/Inist-CNRS/lodex/assets/14542336/d2489da1-bd35-4e12-a06b-aab677625fb0)
