### PR TITLE
Feat: keep hidden resources on re-publishing

### DIFF
--- a/src/api/controller/api/publishedDataset.js
+++ b/src/api/controller/api/publishedDataset.js
@@ -93,13 +93,13 @@ export const getRemovedPage = async ctx => {
 
 export const removeResource = async ctx => {
     const { uri, reason } = ctx.request.body;
-    const date = new Date();
+    const removedAt = new Date();
     ctx.hiddenResource.create({
         uri,
         reason,
-        date,
+        removedAt,
     });
-    ctx.body = await ctx.publishedDataset.hide(uri, reason, date);
+    ctx.body = await ctx.publishedDataset.hide(uri, reason, removedAt);
 };
 
 export const restoreResource = async ctx => {

--- a/src/api/controller/api/publishedDataset.js
+++ b/src/api/controller/api/publishedDataset.js
@@ -94,7 +94,7 @@ export const getRemovedPage = async ctx => {
 export const removeResource = async ctx => {
     const { uri, reason } = ctx.request.body;
     const removedAt = ctx.request.body.removedAt ?? new Date();
-    ctx.hiddenResource.create({
+    await ctx.hiddenResource.create({
         uri,
         reason,
         removedAt,
@@ -104,7 +104,7 @@ export const removeResource = async ctx => {
 
 export const restoreResource = async ctx => {
     const { uri } = ctx.request.body;
-    ctx.hiddenResource.deleteByUri(uri);
+    await ctx.hiddenResource.deleteByUri(uri);
     ctx.body = await ctx.publishedDataset.restore(uri);
 };
 

--- a/src/api/controller/api/publishedDataset.js
+++ b/src/api/controller/api/publishedDataset.js
@@ -104,6 +104,7 @@ export const removeResource = async ctx => {
 
 export const restoreResource = async ctx => {
     const { uri } = ctx.request.body;
+    ctx.hiddenResource.deleteByUri(uri);
     ctx.body = await ctx.publishedDataset.restore(uri);
 };
 

--- a/src/api/controller/api/publishedDataset.js
+++ b/src/api/controller/api/publishedDataset.js
@@ -93,8 +93,13 @@ export const getRemovedPage = async ctx => {
 
 export const removeResource = async ctx => {
     const { uri, reason } = ctx.request.body;
-
-    ctx.body = await ctx.publishedDataset.hide(uri, reason);
+    const date = new Date();
+    ctx.hiddenResource.create({
+        uri,
+        reason,
+        date,
+    });
+    ctx.body = await ctx.publishedDataset.hide(uri, reason, date);
 };
 
 export const restoreResource = async ctx => {

--- a/src/api/controller/api/publishedDataset.js
+++ b/src/api/controller/api/publishedDataset.js
@@ -93,7 +93,7 @@ export const getRemovedPage = async ctx => {
 
 export const removeResource = async ctx => {
     const { uri, reason } = ctx.request.body;
-    const removedAt = new Date();
+    const removedAt = ctx.request.body.removedAt ?? new Date();
     ctx.hiddenResource.create({
         uri,
         reason,

--- a/src/api/controller/api/publishedDataset.spec.js
+++ b/src/api/controller/api/publishedDataset.spec.js
@@ -317,6 +317,12 @@ describe('publishedDataset', () => {
                 'the reason',
                 date,
             );
+
+            expect(ctx.hiddenResource.create).toHaveBeenCalledWith({
+                uri: 'the uri',
+                reason: 'the reason',
+                removedAt: date,
+            });
         });
 
         it('should return the result', async () => {

--- a/src/api/controller/api/publishedDataset.spec.js
+++ b/src/api/controller/api/publishedDataset.spec.js
@@ -358,6 +358,10 @@ describe('publishedDataset', () => {
             expect(ctx.publishedDataset.restore).toHaveBeenCalledWith(
                 'the uri',
             );
+
+            expect(ctx.hiddenResource.deleteByUri).toHaveBeenCalledWith(
+                'the uri',
+            );
         });
 
         it('should return the result', async () => {

--- a/src/api/controller/api/publishedDataset.spec.js
+++ b/src/api/controller/api/publishedDataset.spec.js
@@ -285,6 +285,7 @@ describe('publishedDataset', () => {
     });
 
     describe('removeResource', () => {
+        const date = new Date();
         const ctx = {
             publishedDataset: {
                 hide: jest
@@ -295,7 +296,16 @@ describe('publishedDataset', () => {
                 body: {
                     uri: 'the uri',
                     reason: 'the reason',
+                    removedAt: date,
                 },
+            },
+            hiddenResource: {
+                create: jest.fn().mockImplementation(() => ({
+                    _id: '65ba559de49f0fc00f4581ba',
+                    uri: 'uid:/0R4JCK4F',
+                    reason: 'Reason',
+                    removedAt: date,
+                })),
             },
         };
 
@@ -305,6 +315,7 @@ describe('publishedDataset', () => {
             expect(ctx.publishedDataset.hide).toHaveBeenCalledWith(
                 'the uri',
                 'the reason',
+                date,
             );
         });
 
@@ -326,6 +337,12 @@ describe('publishedDataset', () => {
                 body: {
                     uri: 'the uri',
                 },
+            },
+            hiddenResource: {
+                deleteByUri: jest.fn().mockImplementation(() => ({
+                    acknowledged: true,
+                    deletedCount: 1,
+                })),
             },
         };
 

--- a/src/api/models/hiddenResource.js
+++ b/src/api/models/hiddenResource.js
@@ -9,8 +9,12 @@ export default async db => {
 
     collection.create = async data => {
         const { insertedId } = await collection.insertOne(data);
-        return collection.findOne({ _id: insertedId });
+        return collection.findOne({
+            _id: insertedId,
+        });
     };
+
+    collection.deleteByUri = async uri => collection.deleteOne({ uri });
 
     collection.delete = async id =>
         collection.remove({ _id: new ObjectID(id) });

--- a/src/api/models/hiddenResource.js
+++ b/src/api/models/hiddenResource.js
@@ -6,6 +6,7 @@ export default async db => {
     await collection.createIndex({ uri: 1 }, { unique: true });
 
     collection.findAll = async () => collection.find({}).toArray();
+    collection.findOneByUri = async uri => collection.findOne({ uri });
 
     collection.create = async data => {
         const { insertedId } = await collection.insertOne(data);

--- a/src/api/models/hiddenResource.js
+++ b/src/api/models/hiddenResource.js
@@ -1,0 +1,21 @@
+import { ObjectID } from 'mongodb';
+import { castIdsFactory } from './utils';
+
+export default async db => {
+    const collection = db.collection('hiddenResource');
+    await collection.createIndex({ uri: 1 }, { unique: true });
+
+    collection.findAll = async () => collection.find({}).toArray();
+
+    collection.create = async data => {
+        const { insertedId } = await collection.insertOne(data);
+        return collection.findOne({ _id: insertedId });
+    };
+
+    collection.delete = async id =>
+        collection.remove({ _id: new ObjectID(id) });
+
+    collection.castIds = castIdsFactory(collection);
+
+    return collection;
+};

--- a/src/api/services/publishDocuments.js
+++ b/src/api/services/publishDocuments.js
@@ -22,6 +22,7 @@ export const versionTransformerDecorator = (
     );
 
     return {
+        ...hiddenResource,
         uri: doc.uri,
         subresourceId,
         versions: [
@@ -30,7 +31,6 @@ export const versionTransformerDecorator = (
                 publicationDate,
             },
         ],
-        ...hiddenResource,
     };
 };
 

--- a/src/api/services/publishDocuments.js
+++ b/src/api/services/publishDocuments.js
@@ -17,7 +17,7 @@ export const versionTransformerDecorator = (
     hiddenResources = null,
 ) => async (document, _, __, publicationDate = new Date()) => {
     const doc = await transformDocument(document);
-    const hiddenResource = hiddenResources.find(
+    const hiddenResource = hiddenResources?.find(
         hidden => hidden.uri === doc.uri,
     );
 

--- a/src/api/services/publishDocuments.spec.js
+++ b/src/api/services/publishDocuments.spec.js
@@ -46,7 +46,7 @@ const getCtx = ({ subresources } = {}) => ({
         insertBatch: 'publishedDataset.insertBatch()',
     },
     hiddenResource: {
-        findAll: jest.fn().mockImplementation(() => null),
+        findAll: jest.fn().mockImplementation(() => []),
     },
     job,
 });
@@ -101,7 +101,7 @@ describe('publishDocuments', () => {
             expect(versionTransformerDecorator).toHaveBeenCalledWith(
                 'transformDocument()',
                 null,
-                null,
+                [],
             );
         });
 

--- a/src/api/services/publishDocuments.spec.js
+++ b/src/api/services/publishDocuments.spec.js
@@ -227,6 +227,50 @@ describe('publishDocuments', () => {
 
             expect(transform).toHaveBeenCalledWith(doc);
         });
+
+        it('should add hiddenResource to document if it exists', async () => {
+            const transform = jest.fn().mockImplementation(() => ({
+                uri: 'uid:/09P2JFN2',
+                transformed: 'data',
+            }));
+            const doc = {
+                _id: 'id',
+                uri: 'uri',
+                data: 'value',
+            };
+            const date = new Date();
+            const hiddenResource = [
+                {
+                    uri: 'uid:/09P2JFN2',
+                    reason: 'reason',
+                    removedAt: date,
+                },
+                {
+                    uri: 'uid:/0R4JCK4F',
+                    reason: 'reason',
+                    removedAt: date,
+                },
+            ];
+
+            expect(
+                await versionTransformerDecorator(
+                    transform,
+                    null,
+                    hiddenResource,
+                )(doc, null, null, date),
+            ).toEqual({
+                uri: 'uid:/09P2JFN2',
+                subresourceId: null,
+                removedAt: date,
+                reason: 'reason',
+                versions: [
+                    {
+                        transformed: 'data',
+                        publicationDate: date,
+                    },
+                ],
+            });
+        });
     });
 
     describe('getFieldsFromSubresourceFields', () => {

--- a/src/api/services/publishDocuments.spec.js
+++ b/src/api/services/publishDocuments.spec.js
@@ -242,12 +242,12 @@ describe('publishDocuments', () => {
             const hiddenResource = [
                 {
                     uri: 'uid:/09P2JFN2',
-                    reason: 'reason',
+                    reason: 'because',
                     removedAt: date,
                 },
                 {
                     uri: 'uid:/0R4JCK4F',
-                    reason: 'reason',
+                    reason: 'why not',
                     removedAt: date,
                 },
             ];
@@ -262,7 +262,7 @@ describe('publishDocuments', () => {
                 uri: 'uid:/09P2JFN2',
                 subresourceId: null,
                 removedAt: date,
-                reason: 'reason',
+                reason: 'because',
                 versions: [
                     {
                         transformed: 'data',

--- a/src/api/services/publishDocuments.spec.js
+++ b/src/api/services/publishDocuments.spec.js
@@ -45,6 +45,9 @@ const getCtx = ({ subresources } = {}) => ({
     publishedDataset: {
         insertBatch: 'publishedDataset.insertBatch()',
     },
+    hiddenResource: {
+        findAll: jest.fn().mockImplementation(() => null),
+    },
     job,
 });
 
@@ -97,6 +100,8 @@ describe('publishDocuments', () => {
         it('should call versionTransformerDecorator with transformDocument', () => {
             expect(versionTransformerDecorator).toHaveBeenCalledWith(
                 'transformDocument()',
+                null,
+                null,
             );
         });
 

--- a/src/api/services/repositoryMiddleware.js
+++ b/src/api/services/repositoryMiddleware.js
@@ -9,6 +9,7 @@ import precomputed from '../models/precomputed';
 import mongoClient from './mongoClient';
 import tenant from '../models/tenant';
 import configTenant from '../models/configTenant';
+import hiddenResource from '../models/hiddenResource';
 
 export const mongoClientFactory = mongoClientImpl => async (ctx, next) => {
     ctx.db = await mongoClientImpl(ctx.tenant);
@@ -21,6 +22,7 @@ export const mongoClientFactory = mongoClientImpl => async (ctx, next) => {
     ctx.publishedDataset = await publishedDataset(ctx.db);
     ctx.publishedFacet = await publishedFacet(ctx.db);
     ctx.configTenantCollection = await configTenant(ctx.db);
+    ctx.hiddenResource = await hiddenResource(ctx.db);
 
     await next();
 };

--- a/src/api/services/repositoryMiddleware.spec.js
+++ b/src/api/services/repositoryMiddleware.spec.js
@@ -25,6 +25,7 @@ describe('mongoClient middleware', () => {
             'publishedDataset',
             'publishedFacet',
             'configTenantCollection',
+            'hiddenResource',
         ]);
     });
 });


### PR DESCRIPTION
## Problem
Unpublishing data results in the loss of previously hidden resources, which is annoying because users have to hide the resources again after another publication.

## Solution
Keep hidden resources and apply them during re-publishing