### PR TITLE
Feat: gestion des notes (skos:note) ; Fix: typo

### DIFF
--- a/workers/exporters/ris.ini
+++ b/workers/exporters/ris.ini
@@ -9,10 +9,10 @@ plugin = lodex
 
 [env]
 path = source
-value = fix('http://purl.org/ontology/bibo/authorList', 'http://purl.org/ontology/bibo/abstract', 'http://purl.org/dc/terms/title', 'https://data.istex.fr/ontology/istex#publicationTitle', 'http://purl.org/dc/terms/publisher', 'http://purl.org/dc/terms/language', 'http://purl.org/dc/terms/issued', 'http://purl.org/ontology/bibo/doi', 'http://purl.org/dc/terms/subject', 'https://data.istex.fr/ontology/istex#contentType', 'https://data.istex.fr/ontology/istex#accessURL')
+value = fix('http://purl.org/ontology/bibo/authorList', 'http://purl.org/ontology/bibo/abstract', 'http://purl.org/dc/terms/title', 'https://data.istex.fr/ontology/istex#publicationTitle', 'http://purl.org/dc/terms/publisher', 'http://purl.org/dc/terms/language', 'http://purl.org/dc/terms/issued', 'http://purl.org/ontology/bibo/doi', 'http://purl.org/dc/terms/subject', 'https://data.istex.fr/ontology/istex#contentType', 'https://data.istex.fr/ontology/istex#accessURL', 'http://www.w3.org/2004/02/skos/core#note')
 
 path = target
-value = fix('AU', 'AB', 'TI', 'T2', 'ED', 'LA', 'PY', 'DO', 'KW', 'M3', 'L2')
+value = fix('AU', 'AB', 'TI', 'T2', 'ED', 'LA', 'PY', 'DO', 'KW', 'M3', 'L2', 'N1')
 
 [buildContext]
 connectionStringURI = get('connectionStringURI')
@@ -53,4 +53,4 @@ value = self() \
 
 [ungroup] 
 
-# TODO : TY could be different of "JOUR"
+# TODO : TY could be different of "GENERIC"


### PR DESCRIPTION
Cette PR ajoute une note  `N1` à l'export RIS. 

Les données labellisées avec une propriété `skos:note` sont mappées dans le champ RIS `N1`.