### PR TITLE
Export RIS : Ajout des types de document

### DIFF
--- a/workers/exporters/ris.ini
+++ b/workers/exporters/ris.ini
@@ -9,10 +9,10 @@ plugin = lodex
 
 [env]
 path = source
-value = fix('http://purl.org/ontology/bibo/authorList', 'http://purl.org/ontology/bibo/abstract', 'http://purl.org/dc/terms/title', 'https://data.istex.fr/ontology/istex#publicationTitle', 'http://purl.org/dc/terms/publisher', 'http://purl.org/dc/terms/language', 'http://purl.org/dc/terms/issued', 'http://purl.org/ontology/bibo/doi', 'http://purl.org/dc/terms/subject', 'https://data.istex.fr/ontology/istex#contentType', 'https://data.istex.fr/ontology/istex#accessURL', 'http://www.w3.org/2004/02/skos/core#note')
+value = fix('http://purl.org/ontology/bibo/authorList', 'http://purl.org/ontology/bibo/abstract', 'http://purl.org/dc/terms/title', 'https://data.istex.fr/ontology/istex#publicationTitle', 'http://purl.org/dc/terms/publisher', 'http://purl.org/dc/terms/language', 'http://purl.org/dc/terms/issued', 'http://purl.org/ontology/bibo/doi', 'http://purl.org/dc/terms/subject', 'https://data.istex.fr/ontology/istex#contentType', 'https://data.istex.fr/ontology/istex#accessURL', 'http://www.w3.org/2004/02/skos/core#note', 'http://purl.org/ontology/bibo/volume', 'http://purl.org/ontology/bibo/issue', 'http://purl.org/ontology/bibo/pageStart', 'http://purl.org/ontology/bibo/pageEnd')
 
 path = target
-value = fix('AU', 'AB', 'TI', 'T2', 'ED', 'LA', 'PY', 'DO', 'KW', 'M3', 'L2', 'N1')
+value = fix('AU', 'AB', 'TI', 'T2', 'ED', 'LA', 'PY', 'DO', 'KW', 'M3', 'L2', 'N1', 'VL', 'IS', 'SP', 'EP')
 
 [buildContext]
 connectionStringURI = get('connectionStringURI')

--- a/workers/exporters/ris.ini
+++ b/workers/exporters/ris.ini
@@ -8,21 +8,37 @@ plugin = basics
 plugin = lodex
 
 [env]
-path = source
-value = fix('http://purl.org/ontology/bibo/authorList', 'http://purl.org/ontology/bibo/abstract', 'http://purl.org/dc/terms/title', 'https://data.istex.fr/ontology/istex#publicationTitle', 'http://purl.org/dc/terms/publisher', 'http://purl.org/dc/terms/language', 'http://purl.org/dc/terms/issued', 'http://purl.org/ontology/bibo/doi', 'http://purl.org/dc/terms/subject', 'https://data.istex.fr/ontology/istex#contentType', 'https://data.istex.fr/ontology/istex#accessURL', 'http://www.w3.org/2004/02/skos/core#note', 'http://purl.org/ontology/bibo/volume', 'http://purl.org/ontology/bibo/issue', 'http://purl.org/ontology/bibo/pageStart', 'http://purl.org/ontology/bibo/pageEnd')
-
-path = target
-value = fix('AU', 'AB', 'TI', 'T2', 'ED', 'LA', 'PY', 'DO', 'KW', 'M3', 'L2', 'N1', 'VL', 'IS', 'SP', 'EP')
+path = scheme-to-ris-tag
+value = fix({ \
+    'http://purl.org/dc/elements/1.1/type': 'TY', \
+    'http://purl.org/ontology/bibo/authorList': 'AU', \
+    'http://purl.org/ontology/bibo/abstract': 'AB', \
+    'http://purl.org/dc/terms/title': 'TI', \
+    'https://data.istex.fr/ontology/istex#publicationTitle': 'T2', \
+    'http://purl.org/dc/terms/publisher': 'ED', \
+    'http://purl.org/dc/terms/language': 'LA', \
+    'http://purl.org/dc/terms/issued': 'PY', \
+    'http://purl.org/ontology/bibo/doi': 'DO', \
+    'http://purl.org/dc/terms/subject':'KW', \
+    'https://data.istex.fr/ontology/istex#contentType': 'M3', \
+    'https://data.istex.fr/ontology/istex#accessURL': 'L2', \
+    'http://www.w3.org/2004/02/skos/core#note': 'N1', \
+    'http://purl.org/ontology/bibo/volume': 'VL', \
+    'http://purl.org/ontology/bibo/issue': 'IS', \
+    'http://purl.org/ontology/bibo/pageStart': 'SP', \
+    'http://purl.org/ontology/bibo/pageEnd': 'EP', \
+    'http://purl.org/ontology/bibo/isbn': 'SN', \
+    'http://purl.org/ontology/bibo/issn': 'SN' \
+})
 
 [buildContext]
 connectionStringURI = get('connectionStringURI')
 
 [env]
-path = from
-value = get('fields').map('name')
-
-path = to
-value = get('fields').map('scheme')
+path = names-to-tag
+value = get('fields') \
+    .filter(object => _.has(object, 'scheme')) \
+    .reduce((acc, elem) => {acc[elem['name']] = env('scheme-to-ris-tag')[elem['scheme']]; return acc }, {})
 
 [LodexRunQuery]
 
@@ -33,24 +49,16 @@ than = 1
 [filterVersions]
 [filterContributions]
 
-[keyMapping]
-from = env('from')
-to = env('to')
-
-[keyMapping]
-from = env('source')
-to = env('target').map(i => i.concat('  -'))
-
 [exchange]
 value = self() \
-    .map((value, key) => [key, value]) \
-    .filter(item => String(item[0]).includes('-')) \
-    .filter(item => item[1]) \
-    .flatMap(item => _.castArray(item[1]).map(elem => item[0].concat(' ').concat(elem.trim()))) \
-    .unshift("TY  - GENERIC") \
+    .mapKeys((value, key) => { return env('names-to-tag')[key]}) \
+    .omit(undefined) \
+    .update('TY', (n) => { return n ? n : 'GENERIC'}) \
+    .toPairs() \
+    .sortBy([([key, value]) => { return key != 'TY'}]) \
+    .flatMap(([key, value]) => _.chain(value).castArray().compact().value().map(elem => key.concat('  - ').concat(elem.trim()))) \
     .concat(["ER  -"]) \
-    .join("\n").concat("\n\n")
+    .join("\n") \
+    .concat("\n\n")
 
 [ungroup] 
-
-# TODO : TY could be different of "GENERIC"


### PR DESCRIPTION
**Export des types de document**

Cette pull request permet d'exporter les types de document grâce à l'attribut sémantique `dc:type`.

La ressource ayant un attribut `dc:type` doit contenir l'une des valeurs de la [spécification RIS](https://en.wikipedia.org/wiki/RIS_(file_format)#Type_of_reference)

En cas d'absence d'attribut dc:type le document est considéré comme `GENERIC`

**Ajout des ISSN et ISBN**

Cette PR supporte les ISSN et ISBN grâce aux attributs `bibo:issn` et `bibo:isbn`.

**Modification du code**

Le code s'appuie sur deux mapping : 
1. `scheme-to-ris-tag` qui permet d'établir la correspondance entre attributs sémantiques et le champ RIS correspondant
2. `names-to-tag` qui permet de faire la correspondance entre les champs Lodex et les tags RIS.

Les mappings utilisent des objets pour éviter des erreurs d'appariement. L'utilisation des objets a nécessité de modifier la section [exchange] du code.
