### PR TITLE
Export RIS : mappage des URLs dans le champ UR

### DIFF
--- a/workers/exporters/ris.ini
+++ b/workers/exporters/ris.ini
@@ -21,7 +21,7 @@ value = fix({ \
     'http://purl.org/ontology/bibo/doi': 'DO', \
     'http://purl.org/dc/terms/subject':'KW', \
     'https://data.istex.fr/ontology/istex#contentType': 'M3', \
-    'https://data.istex.fr/ontology/istex#accessURL': 'L2', \
+    'https://data.istex.fr/ontology/istex#accessURL': 'UR', \
     'http://www.w3.org/2004/02/skos/core#note': 'N1', \
     'http://purl.org/ontology/bibo/volume': 'VL', \
     'http://purl.org/ontology/bibo/issue': 'IS', \


### PR DESCRIPTION
Cette PR modifie le mapping RIS pour exporter les URLs des documents dans le champ `UR` afin qu'elles soient mieux prise en compte par Zotero.

Anciens comportement  :

![image](https://github.com/Inist-CNRS/lodex/assets/60341438/01cf74d7-949f-481c-8d25-264809afc979)

Les URLs sont copiées en note

Nouveau comportement :

![image](https://github.com/Inist-CNRS/lodex/assets/60341438/d88b36a7-e9ed-422f-b14e-0c76462430c6)
Les URLs sont sont importées dans le champ `URL`

fix #2069 