### PR TITLE
Upgrade query-openalex by adding IntDisplayNames object

### DIFF
--- a/workers/loaders/query-openalex.ini
+++ b/workers/loaders/query-openalex.ini
@@ -106,6 +106,9 @@ value = get('doi').replace("https://doi.org/","").toLower()
 path = inist_is_oa
 value = get("open_access.is_oa").replace(false,"Non").replace(true,"Oui")
 
+path = inist_oa_status
+value = get("open_access.oa_status").capitalize()
+
 path = inist_keywords
 value = get('keywords').map('display_name')
 
@@ -122,9 +125,6 @@ value = get('authorships').flatMap("institutions").map("display_name").uniq()
 path = source
 value = get("primary_location.source.display_name")
 
-path = inist_oa_status
-value = get("apc_list.value").replace(/^(?!0$).*$/,"").replace(/^0$/,"diamond").concat(self.open_access.oa_status).compact().reduce((acc, v) => {if (v === "diamond") {return ["diamond"]} {return acc}},)
-
 path = is_retracted
 value = get("is_retracted").replace(false,"Non").replace(true,"Oui")
 
@@ -137,6 +137,7 @@ value = get("biblio.volume")
 path = inist_issue
 value = get("biblio.issue")
 
+# On récupère ici les 4 niveaux de classification, via Template strings on préfixe les valeurs de chaque niveau par un nombre correspondant à sa place hiérarchique. Nécéssaire pour créer un arbre hiérarchique.
 path = inist_classification
 value = get("topics").map(item => `1 - ${item.domain.display_name}@2 - ${item.field.display_name}@3 - ${item.subfield.display_name}@4 - ${item.display_name}`).map(item=>item.split("@"))
 
@@ -152,8 +153,21 @@ value = get("topics").map("subfield.display_name")
 path = inist_topics
 value = get("topics").map("display_name")
 
+path = inist_iso2
+value = get("authorships").flatMap("countries").uniq()
+
+# On récupère ici un code langue, auquel on applique un constructeur Javascript, qui verbalise et traduit le code. "fr" devient "français".
+path = inist_langues
+value = get("language").thru(d => new Intl.DisplayNames(['FR'], { type: 'language'}).of(d))
+
+[assign]
+#On récupère des tableaux de codes Iso2, on enlève le code de la France. Puis on teste chaque tableau, s'il n'est pas vide on remplace par "Oui" (il y a d'autres pays donc collaboration), sinon par "Non".
 path = inist_collaborations_internationales
-value = get("authorships").flatMap("countries").uniq().pull("FR").thru(arr=>!_.isEmpty(arr)).replace("true","Oui").replace("false","Non")
+value = get("inist_iso2").pull("FR").thru(arr=>!_.isEmpty(arr)).replace("true","Oui").replace("false","Non")
+
+# On récupère ici un code Iso2, auquel on applique un constructeur Javascript, qui verbalise et traduit le code. "FRA" devient "France".
+path = inist_pays
+value = get("inist_iso2").map(d => new Intl.DisplayNames(['FR'], { type: 'region'}).of(d))
 
 
 # On récupère un tableau d'objets, puis on itère sur chaque objet avec un template string pour en faire une chaîne de caractères.
@@ -226,7 +240,7 @@ value = get("abstract_inverted_index").flatMap((values, key) => {return values.m
 
 #[F]
 [exchange]
-value = omit(["topics","concepts","grants","datasets","versions","is_authors_truncated","inist_filtered_raw_affiliation_strings","inist_filtered_and_tested_raw_affiliation_strings","doi","biblio","abstract_inverted_index","indexed_in","display_name","inist_publisher_only","inist_xor_publisher","publication_date","countries_distinct_count","institutions_distinct_count","corresponding_author_ids","corresponding_institution_ids","has_fulltext","fulltext_origin","cited_by_percentile_year","is_paratext","primary_topic","keywords","locations_count","referenced_works","related_works","ngrams_url","cited_by_api_url","created_date","updated_date","sustainable_development_goals"])
+value = omit(["fwci","language","topics","concepts","grants","datasets","versions","is_authors_truncated","inist_filtered_raw_affiliation_strings","inist_filtered_and_tested_raw_affiliation_strings","doi","biblio","abstract_inverted_index","indexed_in","display_name","inist_publisher_only","inist_xor_publisher","publication_date","countries_distinct_count","institutions_distinct_count","corresponding_author_ids","corresponding_institution_ids","has_fulltext","fulltext_origin","cited_by_percentile_year","is_paratext","primary_topic","keywords","locations_count","referenced_works","related_works","ngrams_url","cited_by_api_url","created_date","updated_date","sustainable_development_goals"])
 
 # }}}
 


### PR DESCRIPTION
Addition of functions using the IntDisplayNames object constructor to verbalize and translate ISO 2 and 3 codes instead of using much slower mapping-tools. The script is more concise, more readable, and has a significantly faster execution speed.