### PR TITLE
Update json-openalex.ini

### DIFF
--- a/workers/loaders/json-openalex.ini
+++ b/workers/loaders/json-openalex.ini
@@ -12,6 +12,13 @@ ezs = false
 [JSONParse]
 separator = results.*
 
+[assign]
+path=abstract
+value = get("abstract_inverted_index").flatMap((values, key) => values.map(value => [value, key])).sort((a, b) => a[0] - b[0]).map(item => item[1]).join(' ')
+
+[exchange]
+value = omit("abstract_inverted_index")
+
 # Ensures that each object contains an identification key (required by lodex)
 [swing]
 test = pick(['URI', 'uri']).pickBy(_.identity).isEmpty()


### PR DESCRIPTION
Processing of "abstract_inverted_index" to resolve the issue of "." in keys (not accepted by Mongo) and reconstruct the abstract in text format