### PR TITLE
corrected typo breaking function

### DIFF
--- a/workers/loaders/query-openalex.ini
+++ b/workers/loaders/query-openalex.ini
@@ -62,7 +62,7 @@ value = env('query').thru(string => string.match(/i\d+/)).toUpper()
 
 ; On retire les notices non pertinentes en raison d'erreurs d'affiliations d'OpenAlex.
 ; Exemple pour le laboratoire GANIL
-; [A] On récupère dans un premier temps les adresses originales qu'OpenALex a identifié comme relevant du laboratoire requêté.
+;[A] On récupère dans un premier temps les adresses originales qu'OpenALex a identifié comme relevant du laboratoire requêté.
 [assign]
 path = filtered_raw_affiliation_strings
 value = get("authorships").filter(obj => obj.institutions.some(obj => obj.id === `https://openalex.org/${self.lodexStamp.queryIdentifier}`)).flatMap(obj => obj.raw_affiliation_strings)
@@ -72,9 +72,9 @@ value = get("authorships").filter(obj => obj.institutions.some(obj => obj.id ===
 ;path = filtered_and_tested_raw_affiliation_strings
 ;value = get("filtered_raw_affiliation_strings").some(item => /ganil/i.test(item) || /grand acc.*national.*ions.*lour/i.test(item) || /Large heavy ion Nat.*acc.*/i.test(item))
 
-; [C] Enfin on supprime les notices non pertinentes.
+;[C] Enfin on supprime les notices non pertinentes.
 ;[remove]
-;test = get("inist_filtered_and_tested_raw_affiliation_strings").isEqual(false)
+;test = get("filtered_and_tested_raw_affiliation_strings").isEqual(false)
 ; }}}
 
 [assign]
@@ -172,7 +172,7 @@ path = is_hal
 value = get("locations").map("landing_page_url").compact().some(item=>(/[^a-zA-Z0-9]hal[^a-zA-Z0-9]/).test(item)).thru(bool=>bool === false ?"Non" : "Oui")
 
 ; On récupère le champ qui indique dans quelles bases bibliographiques sont indexés les "works".
-; On concatène le champ "inist_is_hal", on retire les "Non" et transforme les "Oui" en "hal".
+; On concatène le champ "is_hal", on retire les "Non" et transforme les "Oui" en "hal".
 [assign]
 path = indexed_in_hal_enriched
 value = get("indexed_in").concat(self.is_hal).pull("Non").map(item=>item === "Oui" ? "hal" : item).sort()


### PR DESCRIPTION
remove an old prefix in "remove" instruction 