### PR TITLE
Fix(enrichment): Debounce the number of calls to preview when filling advanced rule input

### DIFF
--- a/cypress/e2e/phase_2/enrichment.cy.js
+++ b/cypress/e2e/phase_2/enrichment.cy.js
@@ -9,6 +9,8 @@ describe('Enrichment', () => {
 
     describe('Advanced enrichment', () => {
         it('should add an advanced enrichment', () => {
+            cy.intercept('POST', '/api/enrichment/preview').as('preview');
+
             menu.openAdvancedDrawer();
             menu.goToAdminDashboard();
             cy.wait(300);
@@ -16,7 +18,12 @@ describe('Enrichment', () => {
             datasetImportPage.addFile('dataset/simple.csv');
             enrichmentFormPage.openEnrichment();
             cy.wait(300);
+
             enrichmentFormPage.fillAdvancedEnrichment();
+            // We test here that we do not spam preview when filling the advanced rule input
+            cy.get('@preview.all').then((interceptions) => {
+                expect(interceptions).to.have.length(2);
+            });
             enrichmentFormPage.updateNameEnrichment();
             enrichmentFormPage.runEnrichment();
             adminNavigation.goToData();

--- a/src/app/js/admin/enrichment/EnrichmentForm.js
+++ b/src/app/js/admin/enrichment/EnrichmentForm.js
@@ -6,7 +6,7 @@ import FormSourceCodeField from '../../lib/components/FormSourceCodeField';
 import EnrichmentLogsDialogComponent from './EnrichmentLogsDialog';
 import translate from 'redux-polyglot/translate';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import PropTypes from 'prop-types';
+import PropTypes, { func } from 'prop-types';
 import SubressourceFieldAutoComplete from '../subresource/SubressourceFieldAutoComplete';
 
 import { launchEnrichment, loadEnrichments } from '.';
@@ -364,7 +364,8 @@ export const EnrichmentForm = ({
     }, []);
 
     useEffect(() => {
-        handleSourcePreview(formValues);
+        const timeout = setTimeout(() => handleSourcePreview(formValues), 500);
+        return () => clearTimeout(timeout);
     }, [formValues?.rule, formValues?.sourceColumn, formValues?.subPath]);
 
     return (

--- a/src/app/js/admin/enrichment/EnrichmentForm.js
+++ b/src/app/js/admin/enrichment/EnrichmentForm.js
@@ -6,7 +6,7 @@ import FormSourceCodeField from '../../lib/components/FormSourceCodeField';
 import EnrichmentLogsDialogComponent from './EnrichmentLogsDialog';
 import translate from 'redux-polyglot/translate';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import PropTypes, { func } from 'prop-types';
+import PropTypes from 'prop-types';
 import SubressourceFieldAutoComplete from '../subresource/SubressourceFieldAutoComplete';
 
 import { launchEnrichment, loadEnrichments } from '.';


### PR DESCRIPTION
# Problem

Everytime user changes the advanced rule input, a call to the preview API is made

# Solution

Debounce form values watcher

Closes #2203 