### PR TITLE
Fix(data): Set page to 1 when filtering data

### DIFF
--- a/cypress/e2e/phase_1/publication.cy.js
+++ b/cypress/e2e/phase_1/publication.cy.js
@@ -181,6 +181,37 @@ describe('Dataset Publication', () => {
                 ['"2"', '"Alain"', '"Chabat"', 'true'].join(''),
             );
         });
+
+        it('should return to first page when filtering rows', () => {
+            menu.openAdvancedDrawer();
+            menu.goToAdminDashboard();
+            cy.wait(300);
+            datasetImportPage.importDataset(
+                'dataset/twoPagesForFilterTests.json',
+            );
+
+            cy.get('[data-testid="KeyboardArrowRightIcon"]').click();
+
+            cy.get(
+                '[role=columnheader][data-field=firstName] [aria-label=Menu]',
+                {
+                    timeout: 500,
+                },
+            ).click({ force: true });
+
+            cy.wait(100);
+            cy.get('[role=menu] :nth-child(4)').click({ force: true });
+            cy.focused().type('Helga');
+
+            cy.get('.MuiTablePagination-displayedRows', {
+                timeout: 3000,
+            }).contains('1–1 of 1');
+
+            cy.get('[data-rowindex=0]', { timeout: 3000 }).should(
+                'contains.text',
+                ['"2"', '"Helga"', '"Rowe"'].join(''),
+            );
+        });
     });
 
     describe('Transformers upsert', () => {
@@ -191,9 +222,7 @@ describe('Dataset Publication', () => {
             datasetImportPage.importModel('model/simple.json');
 
             adminNavigation.goToDisplay();
-            cy.get('.sidebar')
-                .contains('Main resource')
-                .click();
+            cy.get('.sidebar').contains('Main resource').click();
 
             cy.contains('New field').click();
             cy.get('.wizard', { timeout: 10000 }).should('be.visible');
@@ -224,9 +253,7 @@ describe('Dataset Publication', () => {
             datasetImportPage.importModel('model/simple.json');
 
             adminNavigation.goToDisplay();
-            cy.get('.sidebar')
-                .contains('Main resource')
-                .click();
+            cy.get('.sidebar').contains('Main resource').click();
 
             cy.contains('New field').click();
             cy.get('.wizard', { timeout: 10000 }).should('be.visible');
@@ -250,15 +277,11 @@ describe('Dataset Publication', () => {
 
             cy.contains('Existing Column(s)').click();
             cy.get('[data-testid="source-value-from-columns"]').click();
-            cy.get('[role="listbox"]')
-                .contains('Column 1')
-                .click();
+            cy.get('[role="listbox"]').contains('Column 1').click();
             cy.contains('UPPERCASE').should('be.visible');
 
             cy.get('[data-testid="source-value-from-columns"]').click();
-            cy.get('[role="listbox"]')
-                .contains('Column 2')
-                .click();
+            cy.get('[role="listbox"]').contains('Column 2').click();
             cy.contains('UPPERCASE').should('be.visible');
 
             cy.get('.btn-save').click();
@@ -272,9 +295,7 @@ describe('Dataset Publication', () => {
             datasetImportPage.importModel('model/simple.json');
 
             adminNavigation.goToDisplay();
-            cy.get('.sidebar')
-                .contains('Main resource')
-                .click();
+            cy.get('.sidebar').contains('Main resource').click();
 
             cy.contains('New field').click();
             cy.get('.wizard', { timeout: 10000 }).should('be.visible');
@@ -325,9 +346,7 @@ describe('Dataset Publication', () => {
             menu.goToAdminDashboard();
             datasetImportPage.importDataset('dataset/simple.csv');
             adminNavigation.goToDisplay();
-            cy.get('.sidebar')
-                .contains('Main resource')
-                .click();
+            cy.get('.sidebar').contains('Main resource').click();
 
             datasetImportPage.addColumn('Column 1');
             cy.get('.btn-publish button', { timeout: 300 }).should(
@@ -341,9 +360,7 @@ describe('Dataset Publication', () => {
             datasetImportPage.importDataset('dataset/simple.csv');
             adminNavigation.goToDisplay();
 
-            cy.get('.sidebar')
-                .contains('Main resource')
-                .click();
+            cy.get('.sidebar').contains('Main resource').click();
 
             datasetImportPage.addColumn('Column 1');
 
@@ -367,9 +384,7 @@ describe('Dataset Publication', () => {
             datasetImportPage.importModel('model/concat.json');
 
             adminNavigation.goToDisplay();
-            cy.get('.sidebar')
-                .contains('Main resource')
-                .click();
+            cy.get('.sidebar').contains('Main resource').click();
 
             cy.contains('button', 'Published data').click();
 
@@ -471,11 +486,9 @@ describe('Dataset Publication', () => {
             datasetImportPage.publish();
             adminNavigation.goToResourcePage();
             cy.wait(2000);
-            cy.get('[aria-label="Title"]', { timeout: 3000 })
-                .eq(0)
-                .click({
-                    force: true,
-                });
+            cy.get('[aria-label="Title"]', { timeout: 3000 }).eq(0).click({
+                force: true,
+            });
             cy.get('.btn-save').click();
 
             cy.get('[aria-label="job-progress"]', { timeout: 3000 }).should(
@@ -492,11 +505,9 @@ describe('Dataset Publication', () => {
             datasetImportPage.publish();
             adminNavigation.goToResourcePage();
             cy.wait(2000);
-            cy.get('[aria-label="Title"]', { timeout: 3000 })
-                .eq(0)
-                .click({
-                    force: true,
-                });
+            cy.get('[aria-label="Title"]', { timeout: 3000 }).eq(0).click({
+                force: true,
+            });
             cy.contains('Remove').click({ force: true });
             cy.contains('Accept').click({ force: true });
 

--- a/cypress/fixtures/dataset/twoPagesForFilterTests.json
+++ b/cypress/fixtures/dataset/twoPagesForFilterTests.json
@@ -1,0 +1,202 @@
+[
+    {
+        "uri": 1,
+        "firstName": "Dolly",
+        "lastName": "Konopelski"
+    },
+    {
+        "uri": 2,
+        "firstName": "Helga",
+        "lastName": "Rowe"
+    },
+    {
+        "uri": 3,
+        "firstName": "Golda",
+        "lastName": "Walter"
+    },
+    {
+        "uri": 4,
+        "firstName": "Marielle",
+        "lastName": "Hayes"
+    },
+    {
+        "uri": 5,
+        "firstName": "Madisen",
+        "lastName": "Rutherford"
+    },
+    {
+        "uri": 6,
+        "firstName": "Soledad",
+        "lastName": "Lesch"
+    },
+    {
+        "uri": 7,
+        "firstName": "Francesca",
+        "lastName": "Parker"
+    },
+    {
+        "uri": 8,
+        "firstName": "Sandy",
+        "lastName": "Larkin"
+    },
+    {
+        "uri": 9,
+        "firstName": "Vern",
+        "lastName": "Swaniawski"
+    },
+    {
+        "uri": 10,
+        "firstName": "Jayde",
+        "lastName": "Witting"
+    },
+    {
+        "uri": 11,
+        "firstName": "Hudson",
+        "lastName": "McLaughlin"
+    },
+    {
+        "uri": 12,
+        "firstName": "Lindsay",
+        "lastName": "Ullrich"
+    },
+    {
+        "uri": 13,
+        "firstName": "Keely",
+        "lastName": "Cole"
+    },
+    {
+        "uri": 14,
+        "firstName": "Boris",
+        "lastName": "Pacocha"
+    },
+    {
+        "uri": 15,
+        "firstName": "Kaelyn",
+        "lastName": "Schinner"
+    },
+    {
+        "uri": 16,
+        "firstName": "Emie",
+        "lastName": "Leannon"
+    },
+    {
+        "uri": 17,
+        "firstName": "Rex",
+        "lastName": "Cummings"
+    },
+    {
+        "uri": 18,
+        "firstName": "Keira",
+        "lastName": "Bartell"
+    },
+    {
+        "uri": 19,
+        "firstName": "Nathan",
+        "lastName": "Rempel"
+    },
+    {
+        "uri": 20,
+        "firstName": "Dandre",
+        "lastName": "Kub"
+    },
+    {
+        "uri": 21,
+        "firstName": "Jacey",
+        "lastName": "Kautzer-Rolfson"
+    },
+    {
+        "uri": 22,
+        "firstName": "Zane",
+        "lastName": "Turcotte"
+    },
+    {
+        "uri": 23,
+        "firstName": "Guido",
+        "lastName": "Schuppe"
+    },
+    {
+        "uri": 24,
+        "firstName": "Ellie",
+        "lastName": "Cummings-Gutkowski"
+    },
+    {
+        "uri": 25,
+        "firstName": "Pasquale",
+        "lastName": "Nicolas"
+    },
+    {
+        "uri": 26,
+        "firstName": "Newell",
+        "lastName": "Feeney"
+    },
+    {
+        "uri": 27,
+        "firstName": "Kiarra",
+        "lastName": "VonRueden"
+    },
+    {
+        "uri": 28,
+        "firstName": "Kelley",
+        "lastName": "Moen"
+    },
+    {
+        "uri": 29,
+        "firstName": "Travis",
+        "lastName": "Romaguera"
+    },
+    {
+        "uri": 30,
+        "firstName": "Demario",
+        "lastName": "O'Hara"
+    },
+    {
+        "uri": 31,
+        "firstName": "Lester",
+        "lastName": "Hermiston"
+    },
+    {
+        "uri": 32,
+        "firstName": "Onie",
+        "lastName": "Cummings"
+    },
+    {
+        "uri": 33,
+        "firstName": "Lenna",
+        "lastName": "Labadie-Schuppe"
+    },
+    {
+        "uri": 34,
+        "firstName": "Nicklaus",
+        "lastName": "King"
+    },
+    {
+        "uri": 35,
+        "firstName": "Aylin",
+        "lastName": "Fahey"
+    },
+    {
+        "uri": 36,
+        "firstName": "Cornelius",
+        "lastName": "Ebert"
+    },
+    {
+        "uri": 37,
+        "firstName": "Madelynn",
+        "lastName": "Boyer"
+    },
+    {
+        "uri": 38,
+        "firstName": "Jedediah",
+        "lastName": "Graham"
+    },
+    {
+        "uri": 39,
+        "firstName": "Kayla",
+        "lastName": "Thiel-Brakus"
+    },
+    {
+        "uri": 40,
+        "firstName": "Werner",
+        "lastName": "Muller"
+    }
+]

--- a/src/app/js/admin/parsing/ParsingResult.js
+++ b/src/app/js/admin/parsing/ParsingResult.js
@@ -321,6 +321,7 @@ export const ParsingResultComponent = (props) => {
         }
         const { columnField, operatorValue, value } = filterModel.items[0];
         setFilter({ columnField, operatorValue, value });
+        setSkip(0);
     };
 
     const handleCellClick = (params) => {


### PR DESCRIPTION
# Problem

When a user filters data from another page than the first one and that there are less results than the page size: The user does not see the results

# Expected Behavior

The user sees the filtered results

# Solution

Set skip state to `0` when applying filters

Closes #2274