### PR TITLE
Fix(facet): Reset facet page when filtering facets by name

### DIFF
--- a/cypress/e2e/phase_3/search.cy.js
+++ b/cypress/e2e/phase_3/search.cy.js
@@ -3,19 +3,18 @@ import * as menu from '../../support/menu';
 import * as datasetImportPage from '../../support/datasetImportPage';
 import * as searchDrawer from '../../support/searchDrawer';
 
-const initSearchDataset = (
-    dataset = 'dataset/book_summary.csv',
-    model = 'model/book_summary.json',
-) => () => {
-    teardown();
-    menu.openAdvancedDrawer();
-    menu.goToAdminDashboard();
+const initSearchDataset =
+    (dataset = 'dataset/book_summary.csv', model = 'model/book_summary.json') =>
+    () => {
+        teardown();
+        menu.openAdvancedDrawer();
+        menu.goToAdminDashboard();
 
-    datasetImportPage.importDataset(dataset);
-    datasetImportPage.importModel(model);
-    datasetImportPage.publish();
-    datasetImportPage.goToPublishedResources();
-};
+        datasetImportPage.importDataset(dataset);
+        datasetImportPage.importModel(model);
+        datasetImportPage.publish();
+        datasetImportPage.goToPublishedResources();
+    };
 
 describe('Search', () => {
     describe('Basics', () => {
@@ -24,7 +23,7 @@ describe('Search', () => {
         it('should have the right information in the search results', () => {
             menu.openSearchDrawer();
             searchDrawer.checkResultsCount(10);
-            searchDrawer.checkMoreResultsCount(10, 12);
+            searchDrawer.checkMoreResultsCount(10, 13);
         });
 
         it('should export the dataset', () => {
@@ -56,24 +55,24 @@ describe('Search', () => {
         it('should be able to load more search results several times', () => {
             menu.openSearchDrawer();
 
-            searchDrawer.checkStatsCount(12, 12);
+            searchDrawer.checkStatsCount(13, 13);
             searchDrawer.checkResultsCount(10);
-            searchDrawer.checkMoreResultsCount(10, 12);
+            searchDrawer.checkMoreResultsCount(10, 13);
 
             searchDrawer.loadMore(); // Call load more for the first time
 
-            searchDrawer.checkResultsCount(12);
+            searchDrawer.checkResultsCount(13);
             searchDrawer.checkMoreResultsNotExist();
 
             searchDrawer.search('bezoar');
             searchDrawer.clearSearch();
 
             searchDrawer.checkResultsCount(10);
-            searchDrawer.checkMoreResultsCount(10, 12);
+            searchDrawer.checkMoreResultsCount(10, 13);
 
             searchDrawer.loadMore(); // Call load more for the second time
 
-            searchDrawer.checkResultsCount(12);
+            searchDrawer.checkResultsCount(13);
             searchDrawer.checkMoreResultsNotExist();
         });
 
@@ -115,7 +114,7 @@ describe('Search', () => {
         it.skip('should sort result by pertinence', () => {
             menu.openSearchDrawer();
             searchDrawer.search('medicine');
-            searchDrawer.checkStatsCount(2, 12);
+            searchDrawer.checkStatsCount(2, 13);
             searchDrawer.checkResultsCount(2);
 
             searchDrawer.checkResultList([
@@ -153,6 +152,15 @@ describe('Search', () => {
 
             searchDrawer.clearFacet('2014');
             searchDrawer.checkResultsCount(10);
+        });
+
+        it('should allow to filter search results by multiple facets', () => {
+            menu.openSearchDrawer();
+            searchDrawer.getFacet('Première mise en ligne en').click();
+            cy.wait(500);
+            cy.get('[data-testid="ChevronRightIcon"]').click();
+
+            searchDrawer.filterFacet('Première mise en ligne en', '1926');
         });
 
         it.skip('should allow to sort facet', () => {

--- a/cypress/fixtures/dataset/book_summary.csv
+++ b/cypress/fixtures/dataset/book_summary.csv
@@ -11,3 +11,4 @@ BMJ (Clinical research ed.)	0959-8138	1468-5833	1988			2013			http://www.bmj.com
 BMJ case reports		1757-790X	2008			2013			http://casereports.bmj.com/content/by/year		casereports		fulltext		BMJ	serial								P
 BMJ quality & safety (Print)	2044-5415	2044-5423	2011	20	1	2014			http://qualitysafety.bmj.com/content/by/year		qualitysafety		fulltext		BMJ	serial								P
 BMJ supportive & palliative care	2045-435X	2045-4368	2011			2013			http://spcare.bmj.com/content/by/year		spcare		fulltext		BMJ	serial								P
+Nature & Science	2089-875X	2089-8754	1996			1998			http://spcare.bmj.com/content/by/year		spcare		fulltext		BMJ	serial								P

--- a/cypress/support/searchDrawer.js
+++ b/cypress/support/searchDrawer.js
@@ -1,10 +1,8 @@
 export const searchInput = () =>
     cy.get('.search .search-searchbar input[type="text"]');
 
-export const search = value => {
-    cy.get('.search .search-searchbar')
-        .scrollIntoView()
-        .should('be.visible');
+export const search = (value) => {
+    cy.get('.search .search-searchbar').scrollIntoView().should('be.visible');
     searchInput().type(value);
     cy.wait(500); // Wait for the debounce
 };
@@ -12,18 +10,19 @@ export const search = value => {
 export const clearSearch = () =>
     cy.get('.search .search-searchbar button.searchbar-clear').click();
 
-export const findSearchResultByTitle = value =>
+export const findSearchResultByTitle = (value) =>
     cy
         .get('.search .search-result-title')
         .contains(value)
         .should('be.visible')
         .parent();
 
-export const checkResultList = titles => {
+export const checkResultList = (titles) => {
     titles.forEach((title, index) => {
         cy.get(
-            `.search .search-result-link:nth-child(${index +
-                1}) .search-result-title`,
+            `.search .search-result-link:nth-child(${
+                index + 1
+            }) .search-result-title`,
         )
             .contains(title)
             .scrollIntoView()
@@ -32,9 +31,7 @@ export const checkResultList = titles => {
 };
 
 export const loadMore = () => {
-    cy.get('.search .load-more button')
-        .scrollIntoView()
-        .click();
+    cy.get('.search .load-more button').scrollIntoView().click();
 };
 
 export const waitForLoading = () => {
@@ -44,7 +41,7 @@ export const waitForLoading = () => {
     cy.get('.search .load-more .search-loading').should('not.exist');
 };
 
-export const getFacetsOrder = facets => {
+export const getFacetsOrder = (facets) => {
     facets.forEach((name, index) => {
         cy.get(`.search .search-facets > li:nth-child(${index + 1})`)
             .contains(name)
@@ -52,19 +49,14 @@ export const getFacetsOrder = facets => {
     });
 };
 
-export const getFacet = name =>
+export const getFacet = (name) =>
     cy.get('.search .search-facets .facet-item').contains('span', name);
 
 export const getFacetItem = (name, value) =>
-    getFacet(name)
-        .parent()
-        .contains('span', value)
-        .parent();
+    getFacet(name).parent().contains('span', value).parent();
 
-export const getFacetExcludeItem = name =>
-    getFacet(name)
-        .next()
-        .find('.facet-value-list .exclude-facet');
+export const getFacetExcludeItem = (name) =>
+    getFacet(name).next().find('.facet-value-list .exclude-facet');
 
 export const setFacet = (name, value) => {
     getFacet(name).click();
@@ -72,7 +64,7 @@ export const setFacet = (name, value) => {
     waitForLoading();
 };
 
-export const clearFacet = value => {
+export const clearFacet = (value) => {
     cy.get('.search .applied-facet-container')
         .contains(value)
         .parent()
@@ -83,22 +75,20 @@ export const clearFacet = value => {
 };
 
 export const checkFacetsItem = (name, facets) => {
-    const facetValueItems = getFacet(name)
-        .next()
-        .find('.facet-value-item');
+    const facetValueItems = getFacet(name).next().find('.facet-value-item');
 
     facetValueItems.each((facetValueItem, index) => {
-        cy.wrap(facetValueItem)
-            .contains('span', facets[index])
-            .should('exist');
+        cy.wrap(facetValueItem).contains('span', facets[index]).should('exist');
     });
 };
 
 export const sortFacet = (name, sortName) => {
-    getFacet(name)
-        .get(`.sort_${sortName}`)
-        .first()
-        .click();
+    getFacet(name).get(`.sort_${sortName}`).first().click();
+    cy.wait(1000);
+};
+
+export const filterFacet = (name, filter) => {
+    getFacet(name).get(`input[placeholder$="${name}"`).type(filter);
     cy.wait(1000);
 };
 
@@ -123,11 +113,11 @@ export const checkStatsCount = (current, count) => {
         .should('be.visible');
 };
 
-export const checkResultsCount = count => {
+export const checkResultsCount = (count) => {
     cy.get('.search .search-result').should('have.length', count);
 };
 
-export const goToResourceNumber = nb => {
+export const goToResourceNumber = (nb) => {
     cy.get(
         `.search .search-result-list-container > a:nth-child(${nb}) .search-result`,
     ).click();

--- a/src/app/js/public/facet/FacetValueList.js
+++ b/src/app/js/public/facet/FacetValueList.js
@@ -43,15 +43,14 @@ const onPageChange =
             filter,
         });
 
-const onFilterChange =
-    (changeFacetValue, name, currentPage, perPage) => (e) => {
-        changeFacetValue({
-            name,
-            currentPage,
-            perPage,
-            filter: e.target.value,
-        });
-    };
+const onFilterChange = (changeFacetValue, name, perPage) => (e) => {
+    changeFacetValue({
+        name,
+        currentPage: 0,
+        perPage,
+        filter: e.target.value,
+    });
+};
 
 const onInvertChange = (invertFacet, name) => (_, inverted) =>
     invertFacet({ name, inverted });
@@ -95,12 +94,7 @@ export const FacetValueList = ({
                 placeholder={polyglot.t('filter_value', { field: label })}
                 value={filter}
                 fullWidth
-                onChange={onFilterChange(
-                    changeFacetValue,
-                    name,
-                    currentPage,
-                    perPage,
-                )}
+                onChange={onFilterChange(changeFacetValue, name, perPage)}
                 variant="standard"
             />
             <div>


### PR DESCRIPTION
# Problem

When filtering facets by name, the facet page is not reset, causing to display an empty list when there is results

# Solution

Reset page when filtering facets by name

Closes #2130 

https://github.com/user-attachments/assets/bf4ad017-8c55-4fc2-9918-e730b32232e8

