### PR TITLE
2172: fix transformer validation

### DIFF
--- a/src/common/validateFields.js
+++ b/src/common/validateFields.js
@@ -67,7 +67,12 @@ export const validateTransformers = (field, isContribution) => {
         isValid: true,
     };
 
-    if (isContribution || field.scope === SCOPE_GRAPHIC || field.composedOf) {
+    if (
+        isContribution ||
+        field.scope === SCOPE_GRAPHIC ||
+        field.internalScopes?.includes(SCOPE_GRAPHIC) ||
+        field.composedOf
+    ) {
         return result;
     }
 

--- a/src/common/validateFields.spec.js
+++ b/src/common/validateFields.spec.js
@@ -311,6 +311,44 @@ describe('validateField', () => {
                 error: 'required',
             });
         });
+
+        it('should return valid result if no transformers and scope is graphic', () => {
+            expect(
+                validateTransformers({
+                    scope: SCOPE_GRAPHIC,
+                }),
+            ).toEqual({
+                name: 'transformers',
+                isValid: true,
+            });
+        });
+
+        it('should return valid result if no transformers and internalScopes include graphic', () => {
+            expect(
+                validateTransformers({
+                    internalScopes: [SCOPE_DOCUMENT, SCOPE_GRAPHIC],
+                }),
+            ).toEqual({
+                name: 'transformers',
+                isValid: true,
+            });
+        });
+
+        it('should return valid result if no transformers and isContribution is true', () => {
+            expect(validateTransformers({}, true)).toEqual({
+                name: 'transformers',
+                isValid: true,
+            });
+        });
+
+        it('should return valid result if no transformers and composedOf is set', () => {
+            expect(
+                validateTransformers({ composedOf: ['field1', 'field2'] }),
+            ).toEqual({
+                name: 'transformers',
+                isValid: true,
+            });
+        });
     });
 
     describe('validateTransformer', () => {


### PR DESCRIPTION
fix [2172](https://github.com/orgs/Inist-CNRS/projects/2/views/1?pane=issue&itemId=83457315&issue=Inist-CNRS%7Clodex%7C2172)

update transformer validation to accept no transformer when internalScopes includes graphic scope