### PR TITLE
2460 load data on annotation

### DIFF
--- a/src/app/js/admin/Appbar/AppBar.js
+++ b/src/app/js/admin/Appbar/AppBar.js
@@ -7,7 +7,7 @@ import AspectRatioIcon from '@mui/icons-material/AspectRatio';
 
 import PublicationButton from '../publish/PublicationButton';
 import { fromFields, fromUser } from '../../sharedSelectors';
-import { fromParsing, fromPublication } from '../selectors';
+import { fromPublication } from '../selectors';
 import SidebarToggleButton from './SidebarToggleButton';
 import Menu from './Menu';
 import GoToPublicationButton from './GoToPublicationButton';

--- a/src/app/js/admin/Data.js
+++ b/src/app/js/admin/Data.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import { Switch, Route, useRouteMatch, Redirect } from 'react-router';
-import { connect } from 'react-redux';
-import withInitialData from './withInitialData';
 
 import { DataRoute } from './DataRoute';
 import { DataAddRoute } from './DataAddRoute';
@@ -45,7 +43,4 @@ const DataComponent = () => {
     );
 };
 
-const mapStateToProps = () => ({
-    withInitialData,
-});
-export const Data = connect(mapStateToProps)(DataComponent);
+export const Data = DataComponent;

--- a/src/app/js/admin/annotations/AnnotationItem.js
+++ b/src/app/js/admin/annotations/AnnotationItem.js
@@ -211,4 +211,4 @@ export const AnnotationItem = () => {
     );
 };
 
-export default withInitialData(AnnotationItem);
+export default withInitialData(AnnotationItem, true);

--- a/src/app/js/admin/annotations/AnnotationItem.js
+++ b/src/app/js/admin/annotations/AnnotationItem.js
@@ -11,6 +11,7 @@ import Loading from '../../lib/components/Loading';
 import { AnnotationForm } from './AnnotationForm';
 import { AnnotationValue } from './AnnotationValue';
 import { useGetAnnotation } from './useGetAnnotation';
+import withInitialData from '../withInitialData';
 
 const tenant = sessionStorage.getItem('lodex-tenant') || DEFAULT_TENANT;
 
@@ -209,3 +210,5 @@ export const AnnotationItem = () => {
         </Stack>
     );
 };
+
+export default withInitialData(AnnotationItem);

--- a/src/app/js/admin/annotations/AnnotationList.js
+++ b/src/app/js/admin/annotations/AnnotationList.js
@@ -344,4 +344,4 @@ export const AnnotationList = () => {
     );
 };
 
-export default withInitialData(AnnotationList);
+export default withInitialData(AnnotationList, true);

--- a/src/app/js/admin/annotations/AnnotationList.js
+++ b/src/app/js/admin/annotations/AnnotationList.js
@@ -17,6 +17,7 @@ import { AnnotationStatus } from './AnnotationStatus';
 import { ResourceTitleCell } from './ResourceTitleCell';
 import { ResourceUriCell } from './ResourceUriCell';
 import { useGetAnnotations } from './useGetAnnotations';
+import withInitialData from '../withInitialData';
 
 const AnnotationListToolBar = () => {
     const { translate } = useTranslate();
@@ -342,3 +343,5 @@ export const AnnotationList = () => {
         />
     );
 };
+
+export default withInitialData(AnnotationList);

--- a/src/app/js/admin/configTenant/index.js
+++ b/src/app/js/admin/configTenant/index.js
@@ -10,13 +10,18 @@ export const loadConfigTenantSuccess = createAction(LOAD_CONFIG_TENANT_SUCCESS);
 
 export const initialState = {
     error: null,
+    initialized: false,
     loading: false,
     configTenant: {},
 };
 
 export default handleActions(
     {
-        LOAD_CONFIG_TENANT: (state) => ({ ...state, loading: true }),
+        LOAD_CONFIG_TENANT: (state) => ({
+            ...state,
+            loading: true,
+            initialized: true,
+        }),
         LOAD_CONFIG_TENANT_ERROR: (state, { payload: error }) => ({
             ...state,
             error,
@@ -32,6 +37,7 @@ export default handleActions(
 );
 
 export const isLoading = (state) => state.loading;
+export const isInitialized = (state) => state.initialized;
 export const configTenant = (state) => state.configTenant;
 export const isEnableAutoPublication = (state) =>
     state.configTenant?.enableAutoPublication;
@@ -39,6 +45,7 @@ export const getError = (state) => state.error;
 
 export const selectors = {
     isLoading,
+    isInitialized,
     getError,
     configTenant,
     isEnableAutoPublication,

--- a/src/app/js/admin/enrichment/index.js
+++ b/src/app/js/admin/enrichment/index.js
@@ -29,6 +29,7 @@ export const launchAllEnrichmentError = createAction(
 
 export const initialState = {
     error: null,
+    initialized: false,
     loading: false,
     dataPreviewLoading: false,
     enrichments: [],
@@ -40,6 +41,7 @@ export default handleActions(
         LOAD_ENRICHMENTS: (state) => ({
             ...state,
             isLoadEnrichmentsPending: true,
+            initialized: true,
         }),
         LOAD_ENRICHMENTS_ERROR: (state, { payload: error }) => ({
             ...state,
@@ -69,12 +71,14 @@ export default handleActions(
 );
 
 export const isDataPreviewLoading = (state) => state.dataPreviewLoading;
+export const isInitialized = (state) => state.initialized;
 export const enrichments = (state) => state.enrichments;
 export const dataPreviewEnrichment = (state) => state.dataPreviewEnrichment;
 export const getError = (state) => state.error;
 
 export const selectors = {
     isDataPreviewLoading,
+    isInitialized,
     enrichments,
     dataPreviewEnrichment,
     getError,

--- a/src/app/js/admin/index.js
+++ b/src/app/js/admin/index.js
@@ -20,7 +20,7 @@ import getLocale from '../../../common/getLocale';
 import App from './App';
 import PrivateRoute from './PrivateRoute';
 import { Display } from './Display';
-import { AnnotationList } from './annotations/AnnotationList';
+import AnnotationList from './annotations/AnnotationList';
 import { Data } from './Data';
 import { frFR as frFRDatagrid, enUS as enUSDatagrid } from '@mui/x-data-grid';
 import { frFR, enUS } from '@mui/material/locale';
@@ -31,7 +31,7 @@ import defaultTheme from '../../custom/themes/default/defaultTheme';
 import { Router } from 'react-router-dom';
 import { I18N } from '../i18n/I18NContext';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { AnnotationItem } from './annotations/AnnotationItem';
+import AnnotationItem from './annotations/AnnotationItem';
 
 const localesMUI = new Map([
     ['fr', { ...frFR, ...frFRDatagrid }],

--- a/src/app/js/admin/parsing/index.js
+++ b/src/app/js/admin/parsing/index.js
@@ -16,6 +16,7 @@ export const defaultState = {
     error: false,
     excerptLines: [],
     precomputed: [],
+    initialized: false,
     loading: false,
     parsing: false,
     allowUpload: true,
@@ -30,6 +31,7 @@ export default handleActions(
             ...state,
             allowUpload: false,
             loading: true,
+            initialized: true,
         }),
         LOAD_PARSING_RESULT_ERROR: (state, { payload }) => ({
             ...state,
@@ -78,6 +80,7 @@ export const hasUploadedFile = ({ totalLoadedLines }) => !!totalLoadedLines;
 export const canUpload = ({ allowUpload }) => !!allowUpload;
 
 export const isParsingLoading = ({ loading }) => loading;
+export const isInitialized = ({ initialized }) => initialized;
 
 export const getTotalLoadedLines = ({ totalLoadedLines }) => totalLoadedLines;
 
@@ -89,6 +92,7 @@ export const selectors = {
     hasUploadedFile,
     canUpload,
     isParsingLoading,
+    isInitialized,
     getTotalLoadedLines,
     showAddFromColumn: getshowAddFromColumn,
 };

--- a/src/app/js/admin/precomputed/index.js
+++ b/src/app/js/admin/precomputed/index.js
@@ -12,6 +12,7 @@ export const launchPrecomputed = createAction(LAUNCH_PRECOMPUTED);
 
 export const initialState = {
     error: null,
+    initialized: false,
     loading: false,
     dataPreviewLoading: false,
     precomputed: [],
@@ -20,7 +21,11 @@ export const initialState = {
 
 export default handleActions(
     {
-        LOAD_PRECOMPUTED: (state) => ({ ...state, loading: true }),
+        LOAD_PRECOMPUTED: (state) => ({
+            ...state,
+            loading: true,
+            initialized: true,
+        }),
         LOAD_PRECOMPUTED_ERROR: (state, { payload: error }) => ({
             ...state,
             error,
@@ -37,6 +42,7 @@ export default handleActions(
 
 export const isDataPreviewLoading = (state) => state.dataPreviewLoading;
 export const isLoading = (state) => state.loading;
+export const isInitialized = (state) => state.initialized;
 export const precomputed = (state) => state.precomputed;
 export const dataPreviewPrecomputed = (state) => state.dataPreviewPrecomputed;
 export const getError = (state) => state.error;
@@ -44,6 +50,7 @@ export const getError = (state) => state.error;
 export const selectors = {
     isDataPreviewLoading,
     isLoading,
+    isInitialized,
     precomputed,
     dataPreviewPrecomputed,
     getError,

--- a/src/app/js/admin/publication/index.js
+++ b/src/app/js/admin/publication/index.js
@@ -16,6 +16,7 @@ export const publicationCleared = createAction(PUBLICATION_CLEARED);
 export const selectField = createAction(SELECT_FIELD);
 
 export const defaultState = {
+    initialized: false,
     loading: false,
     fields: [],
     published: false,
@@ -25,6 +26,7 @@ export default handleActions(
     {
         LOAD_PUBLICATION: (state) => ({
             ...state,
+            initialized: true,
             error: null,
             loading: true,
         }),
@@ -57,8 +59,10 @@ export default handleActions(
 
 export const hasPublishedDataset = ({ published }) => published;
 export const isPublicationLoading = ({ loading }) => loading;
+export const isInitialized = ({ initialized }) => initialized;
 
 export const selectors = {
     hasPublishedDataset,
     isPublicationLoading,
+    isInitialized,
 };

--- a/src/app/js/admin/subresource/index.js
+++ b/src/app/js/admin/subresource/index.js
@@ -24,13 +24,18 @@ export const deleteSubresource = createAction(DELETE_SUBRESOURCE);
 
 export const initialState = {
     error: null,
+    initialized: false,
     loading: false,
     subresources: [],
 };
 
 export default handleActions(
     {
-        LOAD_SUBRESOURCES: (state) => ({ ...state, loading: true }),
+        LOAD_SUBRESOURCES: (state) => ({
+            ...state,
+            loading: true,
+            initialized: true,
+        }),
         LOAD_SUBRESOURCES_ERROR: (state, { payload: error }) => ({
             ...state,
             error,
@@ -60,9 +65,11 @@ export default handleActions(
 );
 
 export const isLoading = (state) => state.loading;
+export const isInitialized = (state) => state.initialized;
 export const getSubresources = (state) => state.subresources;
 
 export const selectors = {
     isLoading,
     getSubresources,
+    isInitialized,
 };

--- a/src/app/js/admin/withInitialData.spec.js
+++ b/src/app/js/admin/withInitialData.spec.js
@@ -7,18 +7,22 @@ import { AdminComponent } from './Admin';
 
 describe('withInitialData HOC', () => {
     const Component = withInitialDataHoc(AdminComponent);
+    let defaultProps;
 
-    const defaultProps = {
-        hasUploadedFile: true,
-        loadParsingResult: jest.fn(),
-        loadPublication: jest.fn(),
-        loadSubresources: jest.fn(),
-        loadEnrichments: jest.fn(),
-        loadPrecomputed: jest.fn(),
-        loadConfigTenant: jest.fn(),
-        p: { t: () => {} },
-        isLoading: false,
-    };
+    beforeEach(() => {
+        defaultProps = {
+            hasUploadedFile: true,
+            loadParsingResult: jest.fn(),
+            loadPublication: jest.fn(),
+            loadSubresources: jest.fn(),
+            loadEnrichments: jest.fn(),
+            loadPrecomputed: jest.fn(),
+            loadConfigTenant: jest.fn(),
+            p: { t: () => {} },
+            isLoading: false,
+            initialized: false,
+        };
+    });
 
     it('should call loadParsingResult on mount', () => {
         shallow(<Component {...defaultProps} />);
@@ -29,6 +33,30 @@ describe('withInitialData HOC', () => {
         expect(defaultProps.loadEnrichments).toHaveBeenCalled();
         expect(defaultProps.loadPrecomputed).toHaveBeenCalled();
         expect(defaultProps.loadConfigTenant).toHaveBeenCalled();
+    });
+
+    it('should call loadParsingResult on mount when onlyLoadIfNotInitialized is true and isInitialized is false', () => {
+        const Component = withInitialDataHoc(AdminComponent, true);
+        shallow(<Component {...defaultProps} isInitialized={false} />);
+        expect(defaultProps.loadParsingResult).toHaveBeenCalled();
+        expect(defaultProps.loadParsingResult).toHaveBeenCalled();
+        expect(defaultProps.loadPublication).toHaveBeenCalled();
+        expect(defaultProps.loadSubresources).toHaveBeenCalled();
+        expect(defaultProps.loadEnrichments).toHaveBeenCalled();
+        expect(defaultProps.loadPrecomputed).toHaveBeenCalled();
+        expect(defaultProps.loadConfigTenant).toHaveBeenCalled();
+    });
+
+    it('should not load any data on mount when onlyLoadIfNotInitialized is true and isInitialized is true', () => {
+        const Component = withInitialDataHoc(AdminComponent, true);
+        shallow(<Component {...defaultProps} isInitialized={true} />);
+        expect(defaultProps.loadParsingResult).not.toHaveBeenCalled();
+        expect(defaultProps.loadParsingResult).not.toHaveBeenCalled();
+        expect(defaultProps.loadPublication).not.toHaveBeenCalled();
+        expect(defaultProps.loadSubresources).not.toHaveBeenCalled();
+        expect(defaultProps.loadEnrichments).not.toHaveBeenCalled();
+        expect(defaultProps.loadPrecomputed).not.toHaveBeenCalled();
+        expect(defaultProps.loadConfigTenant).not.toHaveBeenCalled();
     });
 
     it('should render AdminComponent when isLoading is false', () => {
@@ -51,168 +79,209 @@ describe('withInitialData HOC', () => {
                 mapStateToProps({
                     parsing: {
                         loading: false,
+                        initialized: false,
                     },
                     publication: {
                         loading: false,
+                        initialized: false,
                     },
                     subresource: {
                         loading: false,
+                        initialized: false,
                     },
                     precomputed: {
                         loading: false,
+                        initialized: false,
                     },
                     configTenant: {
                         loading: false,
+                        initialized: false,
                     },
                     enrichment: {
                         loading: false,
                     },
                 }),
-            ).toStrictEqual({ isLoading: false });
+            ).toStrictEqual({ isLoading: false, isInitialized: false });
         });
         it('should return isLoading true if parsing.loading is true', () => {
             expect(
                 mapStateToProps({
                     parsing: {
                         loading: true,
+                        initialized: false,
                     },
                     publication: {
                         loading: false,
+                        initialized: false,
                     },
                     subresource: {
                         loading: false,
+                        initialized: false,
                     },
                     precomputed: {
                         loading: false,
+                        initialized: false,
                     },
                     configTenant: {
                         loading: false,
+                        initialized: false,
                     },
                     enrichment: {
                         loading: false,
+                        initialized: false,
                     },
                 }),
-            ).toStrictEqual({ isLoading: true });
+            ).toStrictEqual({ isLoading: true, isInitialized: false });
         });
         it('should return isLoading true if publication.loading is true', () => {
             expect(
                 mapStateToProps({
                     parsing: {
                         loading: false,
+                        initialized: false,
                     },
                     publication: {
                         loading: true,
+                        initialized: false,
                     },
                     subresource: {
                         loading: false,
+                        initialized: false,
                     },
                     precomputed: {
                         loading: false,
+                        initialized: false,
                     },
                     configTenant: {
                         loading: false,
+                        initialized: false,
                     },
                     enrichment: {
                         loading: false,
+                        initialized: false,
                     },
                 }),
-            ).toStrictEqual({ isLoading: true });
+            ).toStrictEqual({ isLoading: true, isInitialized: false });
         });
         it('should return isLoading true if subresource.loading is true', () => {
             expect(
                 mapStateToProps({
                     parsing: {
                         loading: false,
+                        initialized: false,
                     },
                     publication: {
                         loading: false,
+                        initialized: false,
                     },
                     subresource: {
                         loading: true,
+                        initialized: false,
                     },
                     precomputed: {
                         loading: false,
+                        initialized: false,
                     },
                     configTenant: {
                         loading: false,
+                        initialized: false,
                     },
                     enrichment: {
                         loading: false,
+                        initialized: false,
                     },
                 }),
-            ).toStrictEqual({ isLoading: true });
+            ).toStrictEqual({ isLoading: true, isInitialized: false });
         });
         it('should return isLoading true if precomputed.loading is true', () => {
             expect(
                 mapStateToProps({
                     parsing: {
                         loading: false,
+                        initialized: false,
                     },
                     publication: {
                         loading: false,
+                        initialized: false,
                     },
                     subresource: {
                         loading: false,
+                        initialized: false,
                     },
                     precomputed: {
                         loading: true,
+                        initialized: false,
                     },
                     configTenant: {
                         loading: false,
+                        initialized: false,
                     },
                     enrichment: {
                         loading: false,
+                        initialized: false,
                     },
                 }),
-            ).toStrictEqual({ isLoading: true });
+            ).toStrictEqual({ isLoading: true, isInitialized: false });
         });
         it('should return isLoading true if configTenant.loading is true', () => {
             expect(
                 mapStateToProps({
                     parsing: {
                         loading: false,
+                        initialized: false,
                     },
                     publication: {
                         loading: false,
+                        initialized: false,
                     },
                     subresource: {
                         loading: false,
+                        initialized: false,
                     },
                     precomputed: {
                         loading: false,
+                        initialized: false,
                     },
                     configTenant: {
                         loading: true,
+                        initialized: false,
                     },
                     enrichment: {
                         loading: false,
+                        initialized: false,
                     },
                 }),
-            ).toStrictEqual({ isLoading: true });
+            ).toStrictEqual({ isLoading: true, isInitialized: false });
         });
         it('should return isLoading false even if enrichment.loading is true', () => {
             expect(
                 mapStateToProps({
                     parsing: {
                         loading: false,
+                        initialized: false,
                     },
                     publication: {
                         loading: false,
+                        initialized: false,
                     },
                     subresource: {
                         loading: false,
+                        initialized: false,
                     },
                     precomputed: {
                         loading: false,
+                        initialized: false,
                     },
                     configTenant: {
                         loading: false,
+                        initialized: false,
                     },
                     enrichment: {
                         loading: true,
+                        initialized: false,
                     },
                 }),
-            ).toStrictEqual({ isLoading: false });
+            ).toStrictEqual({ isLoading: false, isInitialized: false });
         });
     });
 });


### PR DESCRIPTION
Load initial data on annotation pages, if data have not been already loaded
closes #2460 

- [x] add initialized props to loaded data reducer, ad set it to true on first load
- [x] update withInitialData to take a onlyLoadIfNotInitialized optional argument (default false)
- [x] use withInitialData with AnnotationList and AnnotationItem
- [x] add test
