### PR TITLE
fix(language): handle null values to avoid erros

### DIFF
--- a/workers/loaders/query-openalex.ini
+++ b/workers/loaders/query-openalex.ini
@@ -140,7 +140,7 @@ value = get("authorships").flatMap("countries").uniq()
 
 ; On récupère ici un code langue, auquel on applique un constructeur Javascript, qui verbalise et traduit le code. "fr" devient "français".
 path = language
-value = get("language").thru(d => new Intl.DisplayNames(['FR'], { type: 'language'}).of(d))
+value = get("language").thru(d => d ? new Intl.DisplayNames(['FR'], { type: 'language'}).of(d) : 'n/a')
 
 [assign]
 ;On récupère des tableaux de codes Iso2, on enlève le code de la France. Puis on teste chaque tableau, s'il n'est pas vide on remplace par "Oui" (il y a d'autres pays donc collaboration), sinon par "Non".


### PR DESCRIPTION
Records may now have "language" set to null, causing a Error when using Intl.DisplayNames. Added a check to return a default value ("n/a") if "language" is null