### PR TITLE
2600: restore style for enriched column and errored header

### DIFF
--- a/src/app/js/admin/parsing/ParsingResult.js
+++ b/src/app/js/admin/parsing/ParsingResult.js
@@ -207,6 +207,7 @@ export const ParsingResultComponent = (props) => {
 
             return res;
         };
+
         return getColumnsToShow(
             columns,
             showEnrichmentColumns,
@@ -461,6 +462,10 @@ export const ParsingResultComponent = (props) => {
                 components={{
                     Footer: CustomFooter,
                     Toolbar: CustomToolbar,
+                }}
+                sx={{
+                    ['& .error-header']: styles.errorHeader,
+                    ['& .enriched-column']: styles.enrichedColumn,
                 }}
             />
             <Drawer


### PR DESCRIPTION
closes #2600 

I inadvertently removed the style for the enriched and errored column when I removed the deleted column.
This PR restore those styles