### PR TITLE
enable an unused reducer

### DIFF
--- a/config.json
+++ b/config.json
@@ -19,6 +19,7 @@
         "distinct-alpha-3-ISO639-from",
         "distinct-by-field",
         "distinct-by",
+        "ventilate-by",
         "distinct-ISO3166-1-alpha2-from",
         "distinct-ISO3166-1-alpha3-from",
         "distribute-by-date",

--- a/packages/ezsLodex/src/reducers/ventilate.js
+++ b/packages/ezsLodex/src/reducers/ventilate.js
@@ -29,12 +29,21 @@ module.exports.reduce = function (key, values) {
 };
 
 module.exports.finalize = function finalize(key, value) {
-    return value;
+    var vector = JSON.parse(key);
+    var obj = {
+        source: vector[0],
+        target: vector[1],
+        weight: value,
+    }
+    return obj;
 };
 
 module.exports.fieldname = function (name) {
     if (name === 'value') {
-        return 'value';
+        return 'value.weight';
+    }
+    if (name === 'label') {
+        return 'value.source';
     }
     return '_id';
 };

--- a/src/app/custom/routines/routines-catalog.json
+++ b/src/app/custom/routines/routines-catalog.json
@@ -84,6 +84,15 @@
         ]
     },
     {
+        "id": "r-ventilate-by",
+        "url": "/api/run/ventilate-by/",
+        "doc": "https://www.lodex.fr/docs/documentation/principales-fonctionnalites-disponibles/les-routines-et-graphes/les-routines/#ventilate-by",
+        "recommendedWith": [
+            "Network",
+            "HeatMap"
+        ]
+    },
+    {
         "id": "r-distinct-by-field",
         "url": "/api/run/distinct-by-field/",
         "doc": "https://www.lodex.fr/docs/documentation/principales-fonctionnalites-disponibles/les-routines-et-graphes/les-routines/#distinct-by-field",

--- a/src/app/custom/translations.tsv
+++ b/src/app/custom/translations.tsv
@@ -897,6 +897,8 @@
 "r-distinct-alpha-3-ISO639-from_description"	"Transforms the ISO 3 codes of the languages of the represented field into verbalised headings."	"Transforme les codes ISO 3 des langues du champ représenté en intitulés verbalisés."
 "r-distinct-by_title"	"distinct-by"	"distinct-by"
 "r-distinct-by_description"	"Counts, for each element of the represented field (identifier), the number of times this element appears."	"Compte, pour chaque élément du champ représenté (identifiant), le nombre de fois où cet élément apparaît."
+"r-ventilate-by_title"	"ventilate-by"	"ventilate-by"
+"r-ventilate-by_description"	"Counts, for multiple elements (source) and multiple values (target), the number of times each same element and same value appears"	"Compte, pour plusieurs éléments (source) et pour plusieurs valeurs (target), le nombre de fois où chaque même élément et même valeur apparaîent."
 "r-group-and-sum-with_title"	"group-and-sum-with"	"group-and-sum-with"
 "r-group-and-sum-with_description"	"Adds, for each element of the represented field (identifier), all the values of the corresponding second field (value)."	"Ajoute, pour chaque élément du champ représenté (identifiant), toutes les valeurs du deuxième champ (valeur) correspondant."
 "r-distinct-by-field_title"	"distinct-by-field"	"distinct-by-field"

--- a/workers/routines/ventilate-by.ini
+++ b/workers/routines/ventilate-by.ini
@@ -1,0 +1,37 @@
+# Reduce to distinct values from one or more fields
+
+prepend = delegate?file=../worker.ini
+mimeType = application/json
+label = distinct
+
+[use]
+plugin = basics
+plugin = lodex
+
+[buildContext]
+connectionStringURI = get('connectionStringURI')
+
+[env]
+path = fields
+value = get('fields').keyBy('name').mapValues('label')
+;    .map(item => _.pick(item, ['name', 'label']);
+[LodexReduceQuery]
+reducer = ventilate
+
+[replace]
+path = source
+value = env('fields').get(self.value.source)
+
+path = target
+value = get('value.target')
+
+path = weight
+value = get('value.weight')
+
+path = total
+value = get('total')
+
+[LodexOutput]
+indent = true
+extract = total
+

--- a/workers/routines/ventilate-by.ini
+++ b/workers/routines/ventilate-by.ini
@@ -2,7 +2,7 @@
 
 prepend = delegate?file=../worker.ini
 mimeType = application/json
-label = distinct
+label = ventilate
 
 [use]
 plugin = basics
@@ -14,7 +14,7 @@ connectionStringURI = get('connectionStringURI')
 [env]
 path = fields
 value = get('fields').keyBy('name').mapValues('label')
-;    .map(item => _.pick(item, ['name', 'label']);
+
 [LodexReduceQuery]
 reducer = ventilate
 


### PR DESCRIPTION
Routine permettant de faire un "distinct-by" sur plusieurs champs. 
Cette routine évite de faire de concaténation de champs via des enrichissements et des dé-concaténation en vega.
![image](https://github.com/user-attachments/assets/b37f3ffa-2092-4cfe-8497-cd0c856d4974)

Lodex savait déjà faire ce type de traitement, mais il n'y avait pas la routine adaptée.

Cela plaide pour la fonctionnalité permettant de créer des routines "custom" cf. https://github.com/Inist-CNRS/lodex/issues/2584#issuecomment-2694530739