### PR TITLE
fix CSV and TSV exporters

### DIFF
--- a/src/app/js/lib/fetch.js
+++ b/src/app/js/lib/fetch.js
@@ -59,6 +59,10 @@ export default ({ url, ...config }, mode = 'json') => {
                             'extended-nquads-compressed': 'gzip',
                             kbart: 'tsv',
                             raw: 'json',
+                            'csv-full': 'csv',
+                            'csv': 'csv',
+                            'tsv-full': 'tsv',
+                            'tsv': 'tsv',
                         };
                         filename = `export.${
                             exportExtent[exportType]
@@ -94,6 +98,10 @@ export default ({ url, ...config }, mode = 'json') => {
                             'extended-nquads-compressed': 'gzip',
                             kbart: 'tsv',
                             raw: 'json',
+                            'csv-full': 'csv',
+                            'csv': 'csv',
+                            'tsv-full': 'tsv',
+                            'tsv': 'tsv',
                         };
                         filename = `export.${
                             exportExtent[exportType]

--- a/workers/exporters/tsv-full.ini
+++ b/workers/exporters/tsv-full.ini
@@ -22,9 +22,6 @@ value = get('fields').map('label')
 path = connectionStringURI
 value = get('connectionStringURI')
 
-path = isHidden
-value = get('fields').filter({ 'display': false }).map('name')
-
 [LodexRunQuery]
 [greater]
 path = total
@@ -38,7 +35,7 @@ than = 1
 connectionStringURI = env('connectionStringURI')
 
 [exchange]
-value = self().omit(env('isHidden'))
+value = self()
 
 [keyMapping]
 from = env('from')


### PR DESCRIPTION
- Removed an unnecessary line from `csv-full.ini`
- Fix hidden files in `tsv-full.ini`
- Updated `fetch` mapping to add `csv-full` and `tsv-full` so that exports use correct `.csv` and `.tsv` extensions insetad of `.csv-full`

fixes #2831 