### PR TITLE
fix(export): exclude chart and home fields from csv-full and tsv-full…

### DIFF
--- a/workers/exporters/csv-full.ini
+++ b/workers/exporters/csv-full.ini
@@ -12,7 +12,6 @@ plugin = analytics
 [buildContext]
 connectionStringURI = get('connectionStringURI')
 
-; remplace les identifiants de champ par le label du champ (ex: X2ED devient Titre)
 [env]
 path = from
 value = get('fields').map('name')
@@ -20,11 +19,14 @@ value = get('fields').map('name')
 path = to
 value = get('fields').map('label')
 
+path = resourceFields
+value = get('fields').filter(f => f.scope === 'collection' || f.scope === 'document').map('name')
+
 path = connectionStringURI
 value = get('connectionStringURI')
 
-
 [LodexRunQuery]
+
 [greater]
 path = total
 than = 1
@@ -32,12 +34,11 @@ than = 1
 [filterVersions]
 [filterContributions]
 
-; ajoute à chaque ligne les champs de type Dataset
 [injectDatasetFields?singleton]
 connectionStringURI = env('connectionStringURI')
 
 [exchange]
-value = self()
+value = self().pick(env('resourceFields'))
 
 [keyMapping]
 from = env('from')

--- a/workers/exporters/tsv-full.ini
+++ b/workers/exporters/tsv-full.ini
@@ -11,7 +11,7 @@ plugin = analytics
 [buildContext]
 connectionStringURI = get('connectionStringURI')
 
-; remplace les identifiants de champ par le label du champ (ex: X2ED devient Titre)
+
 [env]
 path = from
 value = get('fields').map('name')
@@ -19,10 +19,14 @@ value = get('fields').map('name')
 path = to
 value = get('fields').map('label')
 
+path = resourceFields
+value = get('fields').filter(f => f.scope === 'collection' || f.scope === 'document').map('name')
+
 path = connectionStringURI
 value = get('connectionStringURI')
 
 [LodexRunQuery]
+
 [greater]
 path = total
 than = 1
@@ -30,12 +34,11 @@ than = 1
 [filterVersions]
 [filterContributions]
 
-; ajoute à chaque ligne les champs de type Dataset
 [injectDatasetFields?singleton]
 connectionStringURI = env('connectionStringURI')
 
 [exchange]
-value = self()
+value = self().pick(env('resourceFields'))
 
 [keyMapping]
 from = env('from')


### PR DESCRIPTION
La précédente PR récupérait bien les champs "invisibles" mais également tous les autre **fields** comme home ou chart, ce qui n'avait aucune utilité. 

Ceux ci sont désormais exclus de l'export, on récupère bien les champs de la ressource principale qu'ils soient visibles ou non, et rien d'autre désormais.

testé en local