### PR TITLE
Fix exporting columns with special characters

### DIFF
--- a/src/app/js/user/index.js
+++ b/src/app/js/user/index.js
@@ -409,7 +409,7 @@ export const getGetDatasetColumnsRequest = (state) => {
 
 export const getDeleteManyDatasetRowRequest = (state, ids) => {
     return getRequest(state, {
-        url: `/api/dataset/batch-delete-id?ids=${ids.join(',')}`,
+        url: `/api/dataset/batch-delete-id?ids=${encodeURIComponent(ids.join(','))}`,
         method: 'DELETE',
     });
 };
@@ -419,7 +419,11 @@ export const getDeleteFilteredDatasetRowRequest = (
     { columnField, operatorValue, value },
 ) => {
     return getRequest(state, {
-        url: `/api/dataset/batch-delete-filter?filterBy=${columnField}&filterOperator=${operatorValue}&filterValue=${value}`,
+        url: `/api/dataset/batch-delete-filter?filterBy=${encodeURIComponent(
+            columnField,
+        )}&filterOperator=${encodeURIComponent(
+            operatorValue,
+        )}&filterValue=${encodeURIComponent(value)}`,
         method: 'DELETE',
     });
 };
@@ -432,7 +436,7 @@ export const getClearDatasetRequest = (state) =>
 
 export const getDumpDatasetRequest = (state, fields) =>
     getRequest(state, {
-        url: '/api/dump?fields=' + fields.join(','),
+        url: `/api/dump?fields=${encodeURIComponent(fields.join(','))}`,
         method: 'GET',
     });
 

--- a/src/app/js/user/index.spec.js
+++ b/src/app/js/user/index.spec.js
@@ -101,7 +101,34 @@ describe('user reducer', () => {
                 'field3',
             ]);
             expect(result).toEqual({
-                url: '/api/dump?fields=field1,field2,field3',
+                url: '/api/dump?fields=field1%2Cfield2%2Cfield3',
+                method: 'GET',
+                credentials: 'same-origin',
+                body: undefined,
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                    Authorization: 'Bearer token',
+                    Cookie: undefined,
+                },
+            });
+        });
+
+        it('should escape special characters in field names', () => {
+            const result = getDumpDatasetRequest({ token: 'token' }, [
+                'field & cie',
+                'another field',
+                '== field ==',
+                'field/with/slash',
+                'field?with?question',
+                'field+with+plus',
+                'field,with,comma',
+                'field%with%percent',
+                'field#with#hash',
+            ]);
+            console.log(result.url);
+            expect(result).toEqual({
+                url: '/api/dump?fields=field%20%26%20cie%2Canother%20field%2C%3D%3D%20field%20%3D%3D%2Cfield%2Fwith%2Fslash%2Cfield%3Fwith%3Fquestion%2Cfield%2Bwith%2Bplus%2Cfield%2Cwith%2Ccomma%2Cfield%25with%25percent%2Cfield%23with%23hash',
                 method: 'GET',
                 credentials: 'same-origin',
                 body: undefined,


### PR DESCRIPTION
Fixes #2842 

The dump dataset request URL builder didn't escape URL characters (like '&', '/', '=', '%', '?', etc.) properly. This adds `encodeURIComponent` in the dump dataset request builder, but also in a few other request builders where it might be a problem too.