### PR TITLE
Fix vega graph aspect ratio when no image format is provided

### DIFF
--- a/src/app/js/formats/utils/components/admin/AspectRatioSelector.js
+++ b/src/app/js/formats/utils/components/admin/AspectRatioSelector.js
@@ -11,9 +11,15 @@ const AspectRatioSelector = ({ value, onChange, p }) => {
     const aspectRatios = useMemo(() => {
         return ASPECT_RATIOS.map((ratio) => {
             if (ratio === ASPECT_RATIO_NONE) {
-                return p.t('aspect_ratio_none');
+                return {
+                    id: ASPECT_RATIO_NONE,
+                    label: p.t('aspect_ratio_none'),
+                };
             }
-            return ratio;
+            return {
+                id: ratio,
+                label: ratio,
+            };
         });
     }, []);
 
@@ -30,9 +36,9 @@ const AspectRatioSelector = ({ value, onChange, p }) => {
             onChange={handleAspectRatio}
             value={aspectRatio}
         >
-            {aspectRatios.map((aspectRatio) => (
+            {aspectRatios.map(({ id: aspectRatio, label }) => (
                 <MenuItem key={aspectRatio} value={aspectRatio}>
-                    {aspectRatio}
+                    {label}
                 </MenuItem>
             ))}
         </TextField>

--- a/src/app/js/formats/utils/components/vega-lite-component/VegaLiteComponent.js
+++ b/src/app/js/formats/utils/components/vega-lite-component/VegaLiteComponent.js
@@ -58,76 +58,45 @@ function CustomActionVegaLite({
             throw new Error('Invalid data injection type');
     }
 
+    const vegaGraphElement = (
+        <Vega
+            style={
+                aspectRatio === ASPECT_RATIO_NONE
+                    ? {
+                          width: '100%',
+                          aspectRatio:
+                              // If no height is provided when the spec height is set to container,
+                              // the graph height is very small. As a workaround we set a default aspect ratio of 2/1.
+                              specHeight === 'container' ? '2 / 1' : undefined,
+                      }
+                    : { width: '100%', aspectRatio }
+            }
+            spec={deepClone(specWithData)}
+            actions={actions}
+            mode="vega-lite"
+            i18n={{
+                SVG_ACTION: polyglot.t('vega_export_svg'),
+                PNG_ACTION: polyglot.t('vega_export_png'),
+                CLICK_TO_VIEW_ACTIONS: polyglot.t('vega_click_to_view_actions'),
+                COMPILED_ACTION: polyglot.t('vega_compiled_action'),
+                EDITOR_ACTION: polyglot.t('vega_editor_action'),
+                SOURCE_ACTION: polyglot.t('vega_source_action'),
+            }}
+        />
+    );
+
     return (
         <>
             <style>{'#vg-tooltip-element {z-index:99999}'}</style>
             {disableZoom ? (
-                <div ref={graphParentRef}>
-                    <Vega
-                        style={
-                            aspectRatio === ASPECT_RATIO_NONE
-                                ? {
-                                      width: '100%',
-                                      aspectRatio:
-                                          // If no height is provided when the spec height is set to container,
-                                          // the graph height is very small. As a workaround we set a default aspect ratio of 2/1.
-                                          specHeight === 'container'
-                                              ? '2 / 1'
-                                              : undefined,
-                                  }
-                                : { width: '100%', aspectRatio }
-                        }
-                        spec={deepClone(specWithData)}
-                        actions={actions}
-                        mode="vega-lite"
-                        i18n={{
-                            SVG_ACTION: polyglot.t('vega_export_svg'),
-                            PNG_ACTION: polyglot.t('vega_export_png'),
-                            CLICK_TO_VIEW_ACTIONS: polyglot.t(
-                                'vega_click_to_view_actions',
-                            ),
-                            COMPILED_ACTION: polyglot.t('vega_compiled_action'),
-                            EDITOR_ACTION: polyglot.t('vega_editor_action'),
-                            SOURCE_ACTION: polyglot.t('vega_source_action'),
-                        }}
-                    />
-                </div>
+                <div ref={graphParentRef}>{vegaGraphElement}</div>
             ) : (
                 <FormatFullScreenMode>
                     <div
                         ref={graphParentRef}
                         style={{ width: '100%', height: '100%' }}
                     >
-                        <Vega
-                            style={
-                                aspectRatio === ASPECT_RATIO_NONE
-                                    ? {
-                                          width: '100%',
-                                          aspectRatio:
-                                              // If no height is provided when the spec height is set to container,
-                                              // the graph height is very small. As a workaround we set a default aspect ratio of 2/1.
-                                              specHeight === 'container'
-                                                  ? '2 / 1'
-                                                  : undefined,
-                                      }
-                                    : { width: '100%', aspectRatio }
-                            }
-                            spec={deepClone(specWithData)}
-                            actions={actions}
-                            mode="vega-lite"
-                            i18n={{
-                                SVG_ACTION: polyglot.t('vega_export_svg'),
-                                PNG_ACTION: polyglot.t('vega_export_png'),
-                                CLICK_TO_VIEW_ACTIONS: polyglot.t(
-                                    'vega_click_to_view_actions',
-                                ),
-                                COMPILED_ACTION: polyglot.t(
-                                    'vega_compiled_action',
-                                ),
-                                EDITOR_ACTION: polyglot.t('vega_editor_action'),
-                                SOURCE_ACTION: polyglot.t('vega_source_action'),
-                            }}
-                        />
+                        {vegaGraphElement}
                     </div>
                 </FormatFullScreenMode>
             )}

--- a/src/app/js/formats/utils/components/vega-lite-component/VegaLiteComponent.js
+++ b/src/app/js/formats/utils/components/vega-lite-component/VegaLiteComponent.js
@@ -34,6 +34,7 @@ function CustomActionVegaLite({
     const graphParentRef = useVegaCsvExport(polyglot, data);
 
     const specWithData = spec;
+    const { height: specHeight } = specWithData;
 
     switch (injectType) {
         case VEGA_LITE_DATA_INJECT_TYPE_A:
@@ -65,7 +66,15 @@ function CustomActionVegaLite({
                     <Vega
                         style={
                             aspectRatio === ASPECT_RATIO_NONE
-                                ? { width: '100%', aspectRatio: '2 / 1' }
+                                ? {
+                                      width: '100%',
+                                      aspectRatio:
+                                          // If no height is provided when the spec height is set to container,
+                                          // the graph height is very small. As a workaround we set a default aspect ratio of 2/1.
+                                          specHeight === 'container'
+                                              ? '2 / 1'
+                                              : undefined,
+                                  }
                                 : { width: '100%', aspectRatio }
                         }
                         spec={deepClone(specWithData)}
@@ -92,7 +101,15 @@ function CustomActionVegaLite({
                         <Vega
                             style={
                                 aspectRatio === ASPECT_RATIO_NONE
-                                    ? { width: '100%', aspectRatio: '2 / 1' }
+                                    ? {
+                                          width: '100%',
+                                          aspectRatio:
+                                              // If no height is provided when the spec height is set to container,
+                                              // the graph height is very small. As a workaround we set a default aspect ratio of 2/1.
+                                              specHeight === 'container'
+                                                  ? '2 / 1'
+                                                  : undefined,
+                                      }
                                     : { width: '100%', aspectRatio }
                             }
                             spec={deepClone(specWithData)}

--- a/src/app/js/formats/utils/components/vega-lite-component/VegaLiteComponent.js
+++ b/src/app/js/formats/utils/components/vega-lite-component/VegaLiteComponent.js
@@ -65,7 +65,7 @@ function CustomActionVegaLite({
                     <Vega
                         style={
                             aspectRatio === ASPECT_RATIO_NONE
-                                ? { width: '100%' }
+                                ? { width: '100%', aspectRatio: '2 / 1' }
                                 : { width: '100%', aspectRatio }
                         }
                         spec={deepClone(specWithData)}
@@ -92,7 +92,7 @@ function CustomActionVegaLite({
                         <Vega
                             style={
                                 aspectRatio === ASPECT_RATIO_NONE
-                                    ? { width: '100%' }
+                                    ? { width: '100%', aspectRatio: '2 / 1' }
                                     : { width: '100%', aspectRatio }
                             }
                             spec={deepClone(specWithData)}

--- a/src/app/js/formats/vega-lite/VegaLiteView.js
+++ b/src/app/js/formats/vega-lite/VegaLiteView.js
@@ -14,12 +14,13 @@ import {
     VEGA_LITE_DATA_INJECT_TYPE_A,
 } from '../utils/chartsUtils';
 import { useSizeObserver } from '../utils/chartsHooks';
+import stylesToClassName from '../../lib/stylesToClassName';
 
-const styles = {
+const styles = stylesToClassName({
     container: {
         userSelect: 'none',
     },
-};
+});
 
 const VegaLiteView = ({ field, data, aspectRatio, specTemplate }) => {
     const { ref, width } = useSizeObserver();
@@ -43,7 +44,7 @@ const VegaLiteView = ({ field, data, aspectRatio, specTemplate }) => {
     }
 
     return (
-        <div style={styles.container} ref={ref}>
+        <div className={styles.container} ref={ref}>
             <CustomActionVegaLite
                 spec={spec || {}}
                 data={data}


### PR DESCRIPTION
#2886 

This PR fixes the default aspect ratio of a custom Vega Lite graph when the aspect ratio is not defined (set to "No aspect ratio"), and its height is set to `"container"`. It also fixes the aspect ratio selector, which saved the translated label of "none" aspect ratio.