### PR TITLE
Update dataset dump API to support commas

### DIFF
--- a/src/api/controller/api/dump.js
+++ b/src/api/controller/api/dump.js
@@ -1,13 +1,12 @@
 import mime from 'mime';
-import fs from 'fs';
-import os from 'os';
 import moment from 'moment';
 import { streamEnd } from '../../services/streamHelper';
-import { unlinkFile } from '../../services/fsHelpers.js';
 
 export default async (ctx) => {
     const { fields } = ctx.query;
-    const fieldsArray = fields ? fields.split(',') : [];
+    const fieldsArray = !Array.isArray(fields)
+        ? fields.split(',')
+        : fields ?? [];
     const filename = `dataset_${moment().format('YYYY-MM-DD-HHmmss')}.jsonl`;
 
     const stream = await ctx.dataset.dumpAsJsonLStream(fieldsArray);

--- a/src/app/js/user/index.js
+++ b/src/app/js/user/index.js
@@ -434,11 +434,14 @@ export const getClearDatasetRequest = (state) =>
         method: 'DELETE',
     });
 
-export const getDumpDatasetRequest = (state, fields) =>
-    getRequest(state, {
-        url: `/api/dump?fields=${encodeURIComponent(fields.join(','))}`,
+export const getDumpDatasetRequest = (state, fields) => {
+    const searchParams = new URLSearchParams();
+    fields.forEach((field) => searchParams.append('fields[]', field));
+    return getRequest(state, {
+        url: `/api/dump?${searchParams.toString()}`,
         method: 'GET',
     });
+};
 
 export const getAddFieldToResourceRequest = (state, data) =>
     getRequest(state, {

--- a/src/app/js/user/index.spec.js
+++ b/src/app/js/user/index.spec.js
@@ -101,7 +101,7 @@ describe('user reducer', () => {
                 'field3',
             ]);
             expect(result).toEqual({
-                url: '/api/dump?fields=field1%2Cfield2%2Cfield3',
+                url: '/api/dump?fields%5B%5D=field1&fields%5B%5D=field2&fields%5B%5D=field3',
                 method: 'GET',
                 credentials: 'same-origin',
                 body: undefined,
@@ -128,7 +128,7 @@ describe('user reducer', () => {
             ]);
             console.log(result.url);
             expect(result).toEqual({
-                url: '/api/dump?fields=field%20%26%20cie%2Canother%20field%2C%3D%3D%20field%20%3D%3D%2Cfield%2Fwith%2Fslash%2Cfield%3Fwith%3Fquestion%2Cfield%2Bwith%2Bplus%2Cfield%2Cwith%2Ccomma%2Cfield%25with%25percent%2Cfield%23with%23hash',
+                url: '/api/dump?fields%5B%5D=field+%26+cie&fields%5B%5D=another+field&fields%5B%5D=%3D%3D+field+%3D%3D&fields%5B%5D=field%2Fwith%2Fslash&fields%5B%5D=field%3Fwith%3Fquestion&fields%5B%5D=field%2Bwith%2Bplus&fields%5B%5D=field%2Cwith%2Ccomma&fields%5B%5D=field%25with%25percent&fields%5B%5D=field%23with%23hash',
                 method: 'GET',
                 credentials: 'same-origin',
                 body: undefined,


### PR DESCRIPTION
#2842

When using commas in a column name of a dataset, they can't be included in the exported dataset. This PR changes the existing dump API to support commas in dataset field names.