### PR TITLE
Fix @babel/preset-typescript dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
                 "@babel/polyfill": "^7.12.1",
                 "@babel/preset-env": "^7.26.0",
                 "@babel/preset-react": "^7.26.3",
+                "@babel/preset-typescript": "^7.27.1",
                 "@babel/register": "^7.25.9",
                 "@babel/runtime": "^7.26.0",
                 "@bull-board/api": "^5.23.0",
@@ -196,7 +197,6 @@
             },
             "devDependencies": {
                 "@babel/eslint-parser": "^7.26.5",
-                "@babel/preset-typescript": "^7.27.1",
                 "@eslint/compat": "^1.4.0",
                 "@eslint/eslintrc": "^3.3.1",
                 "@eslint/js": "^9.36.0",
@@ -1685,7 +1685,6 @@
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
             "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.27.1"
@@ -2473,7 +2472,6 @@
             "version": "7.28.0",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
             "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -2700,7 +2698,6 @@
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
             "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.27.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "@babel/polyfill": "^7.12.1",
         "@babel/preset-env": "^7.26.0",
         "@babel/preset-react": "^7.26.3",
+        "@babel/preset-typescript": "^7.27.1",
         "@babel/register": "^7.25.9",
         "@babel/runtime": "^7.26.0",
         "@bull-board/api": "^5.23.0",
@@ -240,7 +241,6 @@
     },
     "devDependencies": {
         "@babel/eslint-parser": "^7.26.5",
-        "@babel/preset-typescript": "^7.27.1",
         "@eslint/compat": "^1.4.0",
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.36.0",


### PR DESCRIPTION
@babel/preset-typescript needs to be in dependencies for the workers to run in production mode.