### PR TITLE
check pathname insead of full url on front route

### DIFF
--- a/src/api/controller/front.tsx
+++ b/src/api/controller/front.tsx
@@ -176,12 +176,14 @@ export const getPreloadedState = async (
     };
 };
 
-const handleRender = async (ctx: any, next: any) => {
-    const { url } = ctx.request;
+const handleRender = async (ctx: Koa.Context, next: any) => {
+    const { url, URL } = ctx.request;
+    // testing URL.pathname to ignore query parameter
     if (
-        (url.match(/\.([a-z]+)$/) && !url.match(/\/uid:\//)) ||
-        url.match(/\.html$/) ||
-        url.match('/admin')
+        (URL.pathname.match(/\.([a-z]+)$/) &&
+            !URL.pathname.match(/\/uid:\//)) ||
+        URL.pathname.match(/\.html$/) ||
+        URL.pathname.match('/admin')
     ) {
         // no route matched switch to static file
         return next();


### PR DESCRIPTION
Istex themes were loading css with a ?v2.0 parameter that front handleRender was interpreting as a page of the app.
I updated the url chack to check the URL pathname and ignore all query parameter
