### PR TITLE
use renderTags and remove input adornment ts to fix value rendering

### DIFF
--- a/src/app/js/admin/Search/SearchAutocomplete.js
+++ b/src/app/js/admin/Search/SearchAutocomplete.js
@@ -7,7 +7,7 @@ import {
     MenuItem,
     TextField,
 } from '@mui/material';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import PropTypes from 'prop-types';
 import FieldRepresentation from '../../fields/FieldRepresentation';
@@ -58,23 +58,12 @@ const SearchAutocomplete = ({
     limitTags = 6,
     isLoading = false,
 }) => {
-    const [autocompleteValue, setAutocompleteValue] = React.useState(value);
-
-    useEffect(() => {
-        setAutocompleteValue(value);
-    }, [value]);
-
-    const handleChange = (event, value) => {
-        setAutocompleteValue(value);
-        onChange(event, value);
-    };
-
     return (
         <Autocomplete
             data-testid={testId}
             fullWidth
             options={fields}
-            value={autocompleteValue}
+            value={value}
             disableCloseOnSelect={multiple}
             multiple={multiple}
             limitTags={limitTags}
@@ -112,7 +101,7 @@ const SearchAutocomplete = ({
                     ? renderCheckboxItem(props, option, selected)
                     : renderItem(props, option)
             }
-            onChange={handleChange}
+            onChange={onChange}
         />
     );
 };

--- a/src/app/js/admin/Search/SearchAutocomplete.js
+++ b/src/app/js/admin/Search/SearchAutocomplete.js
@@ -3,8 +3,7 @@ import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import {
     Autocomplete,
     Checkbox,
-    CircularProgress,
-    InputAdornment,
+    Chip,
     MenuItem,
     TextField,
 } from '@mui/material';
@@ -86,22 +85,26 @@ const SearchAutocomplete = ({
                     label={translation}
                     placeholder={translation}
                     disabled={isLoading}
-                    InputProps={{
-                        ...params.InputProps,
-                        startAdornment: isLoading && (
-                            <InputAdornment>
-                                <CircularProgress size={16} />
-                            </InputAdornment>
-                        ),
-                    }}
                 />
             )}
             getOptionLabel={(option) =>
-                multiple ? (
-                    <FieldRepresentation field={option} shortMode />
-                ) : (
-                    `${option.label} ${option.name && `[${option.name}]`}  `
-                )
+                `${option.label} ${option.name && `[${option.name}]`}  `
+            }
+            renderTags={(options, getTagProps) =>
+                options.map((option, index) => (
+                    <Chip
+                        key={option.name}
+                        {...getTagProps({ index })}
+                        label={
+                            <FieldRepresentation
+                                key={option._id}
+                                field={option}
+                                shortMode
+                                {...getTagProps({ index })}
+                            />
+                        }
+                    ></Chip>
+                ))
             }
             clearText={clearText}
             renderOption={(props, option, { selected }) =>

--- a/src/app/js/admin/Search/SearchForm.js
+++ b/src/app/js/admin/Search/SearchForm.js
@@ -130,11 +130,11 @@ export const SearchForm = ({ fields, loadField, p: polyglot }) => {
     useEffect(() => {
         setFacetChecked(getFacetFields(fieldsResource));
         setSearchInFields(getSearchableFields(fieldsResource));
-    }, [fieldsResource]);
+    }, [fieldsResource, setSearchInFields, setFacetChecked]);
 
     useEffect(() => {
         setResourceSortOrder(initialResourceSortOrder);
-    }, [initialResourceSortOrder]);
+    }, [initialResourceSortOrder, setResourceSortOrder]);
 
     // We could lower the complexity with only one map. But it's more readable like this. And the performance is not a problem here.
 
@@ -185,10 +185,27 @@ export const SearchForm = ({ fields, loadField, p: polyglot }) => {
         });
     };
 
-    const isPending =
-        patchFieldOverviewMutation.isLoading ||
-        patchSortFieldMutation.isLoading ||
-        patchSortOrderMutation.isLoading;
+    const [isPending, setIsPending] = React.useState(false);
+
+    useEffect(() => {
+        let timer;
+        const loading =
+            patchFieldOverviewMutation.isLoading ||
+            patchSortFieldMutation.isLoading ||
+            patchSortOrderMutation.isLoading;
+
+        if (loading) {
+            timer = setTimeout(() => setIsPending(true), 100);
+        } else {
+            setIsPending(false);
+        }
+
+        return () => clearTimeout(timer);
+    }, [
+        patchFieldOverviewMutation.isLoading,
+        patchSortFieldMutation.isLoading,
+        patchSortOrderMutation.isLoading,
+    ]);
 
     const handleResourceSortFieldChange = async (_event, value) => {
         patchSortFieldMutation.mutate({


### PR DESCRIPTION
see https://github.com/orgs/Inist-CNRS/projects/5/views/1?pane=issue&itemId=132558568&issue=Inist-CNRS%7Clodex%7C2951 and  https://github.com/orgs/Inist-CNRS/projects/5/views/1?pane=issue&itemId=132559804&issue=Inist-CNRS%7Clodex%7C2952

Due to a [bug](https://github.com/mui/material-ui/issues/22103) in mui open since 2020 :see_no_evil: if the renderInput has an InputAdornment renderTags has no effect, in fact no tags (selected values) gets rendered at all.

I also fixed the flicker on the SearchForm which concerned the same part of the app