### PR TITLE
Fix search form inputs not updated properly after mutation

### DIFF
--- a/src/app/js/admin/Search/SearchForm.spec.tsx
+++ b/src/app/js/admin/Search/SearchForm.spec.tsx
@@ -4,11 +4,12 @@ import React from 'react';
 import { SearchForm } from './SearchForm';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, waitFor, within } from '@testing-library/react';
+import { fireEvent, waitFor, within } from '@testing-library/react';
 import PropTypes from 'prop-types';
 import * as overview from '../../../../common/overview';
 import fieldApi from '../../admin/api/field';
-import { TestI18N } from '../../i18n/I18NContext';
+import { render } from '../../../../test-utils.tsx';
+
 jest.mock('../../admin/api/field', () => ({
     patchSearchableFields: jest.fn(),
     patchOverview: jest.fn(),
@@ -25,11 +26,9 @@ function TestSearchForm(props) {
         props.p.currentLocale = 'fr';
     }
     return (
-        <TestI18N>
-            <QueryClientProvider client={new QueryClient()}>
-                <SearchForm {...props} />
-            </QueryClientProvider>
-        </TestI18N>
+        <QueryClientProvider client={new QueryClient()}>
+            <SearchForm {...props} />
+        </QueryClientProvider>
     );
 }
 

--- a/src/app/js/admin/Search/usePatchFieldOverview.ts
+++ b/src/app/js/admin/Search/usePatchFieldOverview.ts
@@ -2,20 +2,26 @@ import { useMutation } from '@tanstack/react-query';
 import { toast } from '../../../../common/tools/toast';
 import fieldApi from '../../admin/api/field';
 import { useTranslate } from '../../i18n/I18NContext';
+import { useDispatch } from 'react-redux';
+import { changeOverview } from '../../fields';
 
 export function usePatchFieldOverview() {
     const { translate } = useTranslate();
+    const dispatch = useDispatch();
 
     return useMutation({
         mutationFn(payload) {
             return fieldApi.patchOverview(payload);
         },
-        onSuccess(res) {
+        onSuccess(res, payload) {
             if (!res) {
                 toast(translate('syndication_error'), {
                     type: toast.TYPE.ERROR,
                 });
+                return;
             }
+
+            dispatch(changeOverview(payload));
         },
     });
 }

--- a/src/app/js/admin/Search/usePatchSortField.ts
+++ b/src/app/js/admin/Search/usePatchSortField.ts
@@ -2,20 +2,26 @@ import { useMutation } from '@tanstack/react-query';
 import { toast } from '../../../../common/tools/toast';
 import fieldApi from '../../admin/api/field';
 import { useTranslate } from '../../i18n/I18NContext';
+import { useDispatch } from 'react-redux';
+import { changeSortField } from '../../fields';
 
 export function usePatchSortField() {
     const { translate } = useTranslate();
+    const dispatch = useDispatch();
 
     return useMutation({
         mutationFn(payload) {
             return fieldApi.patchSortField(payload);
         },
-        onSuccess(res) {
+        onSuccess(res, payload) {
             if (!res.ok) {
                 toast(translate('syndication_error'), {
                     type: toast.TYPE.ERROR,
                 });
+                return;
             }
+
+            dispatch(changeSortField(payload));
         },
     });
 }

--- a/src/app/js/admin/Search/usePatchSortOrder.ts
+++ b/src/app/js/admin/Search/usePatchSortOrder.ts
@@ -2,20 +2,26 @@ import { useMutation } from '@tanstack/react-query';
 import { toast } from '../../../../common/tools/toast';
 import fieldApi from '../../admin/api/field';
 import { useTranslate } from '../../i18n/I18NContext';
+import { useDispatch } from 'react-redux';
+import { changeSortOrder } from '../../fields';
 
 export function usePatchSortOrder() {
     const { translate } = useTranslate();
+    const dispatch = useDispatch();
 
     return useMutation({
         mutationFn(payload) {
             return fieldApi.patchSortOrder(payload);
         },
-        onSuccess(res) {
+        onSuccess(res, payload) {
             if (!res.ok) {
                 toast(translate('syndication_error'), {
                     type: toast.TYPE.ERROR,
                 });
+                return;
             }
+
+            dispatch(changeSortOrder(payload));
         },
     });
 }

--- a/src/app/js/fields/index.spec.ts
+++ b/src/app/js/fields/index.spec.ts
@@ -35,8 +35,8 @@ describe('field reducer', () => {
             const state = reducer(
                 {
                     byName: {
-                        name1: { name: 'name1', label: 'foo' },
-                        name2: { name: 'name2', label: 'bar' },
+                        name1: { _id: '1', name: 'name1', label: 'foo' },
+                        name2: { _id: '2', name: 'name2', label: 'bar' },
                     },
                     // @ts-expect-error TS2322
                     list: ['name1', 'name2'],
@@ -48,8 +48,8 @@ describe('field reducer', () => {
                 ...state,
                 list: ['name1', 'name2', 'new'],
                 byName: {
-                    name2: { name: 'name2', label: 'bar' },
-                    name1: { name: 'name1', label: 'foo' },
+                    name2: { _id: '2', name: 'name2', label: 'bar' },
+                    name1: { _id: '1', name: 'name1', label: 'foo' },
                     new: {
                         label: 'newField 3',
                         scope: SCOPE_DOCUMENT,
@@ -69,8 +69,8 @@ describe('field reducer', () => {
             const state = reducer(
                 {
                     byName: {
-                        name1: { name: 'name1', label: 'foo' },
-                        name2: { name: 'name2', label: 'bar' },
+                        name1: { _id: '1', name: 'name1', label: 'foo' },
+                        name2: { _id: '2', name: 'name2', label: 'bar' },
                     },
                     // @ts-expect-error TS2322
                     list: ['name1', 'name2'],
@@ -82,8 +82,8 @@ describe('field reducer', () => {
                 ...state,
                 list: ['name1', 'name2', 'new'],
                 byName: {
-                    name2: { name: 'name2', label: 'bar' },
-                    name1: { name: 'name1', label: 'foo' },
+                    name2: { _id: '2', name: 'name2', label: 'bar' },
+                    name1: { _id: '1', name: 'name1', label: 'foo' },
                     new: {
                         label: 'target_col',
                         scope: SCOPE_DOCUMENT,
@@ -113,8 +113,8 @@ describe('field reducer', () => {
             const state = reducer(
                 {
                     byName: {
-                        name1: { name: 'name1', label: 'foo' },
-                        name2: { name: 'name2', label: 'bar' },
+                        name1: { _id: '1', name: 'name1', label: 'foo' },
+                        name2: { _id: '2', name: 'name2', label: 'bar' },
                     },
                     // @ts-expect-error TS2322
                     list: ['name1', 'name2'],
@@ -130,8 +130,8 @@ describe('field reducer', () => {
                 ...state,
                 list: ['name1', 'name2', 'new'],
                 byName: {
-                    name2: { name: 'name2', label: 'bar' },
-                    name1: { name: 'name1', label: 'foo' },
+                    name2: { _id: '2', name: 'name2', label: 'bar' },
+                    name1: { _id: '1', name: 'name1', label: 'foo' },
                     new: {
                         label: 'newField 3',
                         scope: SCOPE_DOCUMENT,
@@ -151,8 +151,8 @@ describe('field reducer', () => {
             const state = reducer(
                 {
                     byName: {
-                        name1: { name: 'name1', label: 'foo' },
-                        name2: { name: 'name2', label: 'bar' },
+                        name1: { _id: '1', name: 'name1', label: 'foo' },
+                        name2: { _id: '2', name: 'name2', label: 'bar' },
                     },
                     // @ts-expect-error TS2322
                     list: ['name1', 'name2'],
@@ -169,8 +169,8 @@ describe('field reducer', () => {
                 ...state,
                 list: ['name1', 'name2', 'new'],
                 byName: {
-                    name2: { name: 'name2', label: 'bar' },
-                    name1: { name: 'name1', label: 'foo' },
+                    name2: { _id: '2', name: 'name2', label: 'bar' },
+                    name1: { _id: '1', name: 'name1', label: 'foo' },
                     new: {
                         label: 'target_col',
                         scope: SCOPE_DOCUMENT,
@@ -254,9 +254,9 @@ describe('field reducer', () => {
             const state = reducer(
                 {
                     loading: true,
-                    // @ts-expect-error TS2353
                     error: true,
                     published: false,
+                    // @ts-expect-error TS2353
                     byName: { new: { name: 'foo', value: 'bar' } },
                 },
                 action,
@@ -432,8 +432,8 @@ describe('field reducer', () => {
                     // @ts-expect-error TS2322
                     list: ['bar', 'foo'],
                     byName: {
-                        bar: { name: 'bar' },
-                        foo: { name: 'foo' },
+                        bar: { _id: '1', name: 'bar' },
+                        foo: { _id: '2', name: 'foo' },
                     },
                 },
                 removeFieldSuccess({ name: 'foo' }),
@@ -441,7 +441,7 @@ describe('field reducer', () => {
             expect(state).toEqual({
                 list: ['bar'],
                 byName: {
-                    bar: { name: 'bar' },
+                    bar: { _id: '1', name: 'bar' },
                 },
             });
         });
@@ -454,6 +454,7 @@ describe('field reducer', () => {
                     const state = reducer(
                         {
                             byName: {
+                                // @ts-expect-error TS2322
                                 field: 'data',
                             },
                             // @ts-expect-error TS2322
@@ -485,6 +486,7 @@ describe('field reducer', () => {
                     const state = reducer(
                         {
                             byName: {
+                                // @ts-expect-error TS2322
                                 field: { data: 'data' },
                             },
                             // @ts-expect-error TS2322
@@ -534,9 +536,9 @@ describe('field reducer', () => {
                 // @ts-expect-error TS2353
                 foo: 'bar',
                 byName: {
-                    a: { position: 1 },
-                    b: { position: 2 },
-                    c: { position: 3 },
+                    a: { _id: '1', name: 'a', position: 1 },
+                    b: { _id: '2', name: 'b', position: 2 },
+                    c: { _id: '3', name: 'c', position: 3 },
                 },
             },
             changePositionValue({
@@ -551,9 +553,9 @@ describe('field reducer', () => {
             expect(state).toEqual({
                 foo: 'bar',
                 byName: {
-                    a: { position: 2 },
-                    b: { position: 1 },
-                    c: { position: 3 },
+                    a: { _id: '1', name: 'a', position: 2 },
+                    b: { _id: '2', name: 'b', position: 1 },
+                    c: { _id: '3', name: 'c', position: 3 },
                 },
             });
         });

--- a/src/app/js/fields/types.ts
+++ b/src/app/js/fields/types.ts
@@ -1,8 +1,13 @@
 export interface Field {
+    _id: string;
     name: string;
-    label: string;
-    scheme: string;
+    label?: string;
+    scheme?: string;
     subresourceId?: string;
+    overview?: number;
+    position?: number;
+    isDefaultSortField?: boolean;
+    sortOrder?: 'asc' | 'desc';
 }
 
 export interface TransformerDraft {


### PR DESCRIPTION
#2989

The form inputs were not updated properly after mutation. The fields stored internally were only updated after a full publication, and were _never_ updated when the dataset was not published.