### PR TITLE
add message explaining that field on the main resource are kept

### DIFF
--- a/src/app/custom/translations.tsv
+++ b/src/app/custom/translations.tsv
@@ -654,6 +654,8 @@
 "new_subresource"	"New subresource"	"Nouvelle sous-ressource"
 "delete"	"Delete"	"Supprimer"
 "confirm_delete_subresource"	"This subresource and all its fields will be definitively deleted, Are you sure?"	"Cette sous-ressource ainsi que tous les champs associés vont êtres supprimés. Êtes-vous sûr de vouloir continuer ?"
+"confirm_delete_subresource_details"	"This will not delete the fields on the main resource. If you want them gone, you will need to delete them by hand."	"Cela ne supprimera pas les champs dans la ressource principale. Si vous souhaitez les supprimer, vous devrez le faire manuellement."
+
 "no_field_add"	"Configure your display by clicking on the button « New Field »"	"Configurez votre affichage  en cliquant sur le bouton « Nouveau champ »"
 "no_field_add_resource"	"Configure your display by clicking on one of the buttons above"	"Configurez votre affichage  en cliquant sur l'un des boutons ci-dessus"
 "transformer_no_editable_with_subresource_uid_value"	"Transformation operations can't be edited when subresource uid is selected"	"Les opérations de transformation ne peuvent êtres éditées quand la valeur choisie est un uid de sous-ressource"

--- a/src/app/js/admin/subresource/DeleteSubresourceButton.tsx
+++ b/src/app/js/admin/subresource/DeleteSubresourceButton.tsx
@@ -1,4 +1,10 @@
-import { Button, Dialog, DialogTitle, DialogActions } from '@mui/material';
+import {
+    Button,
+    Dialog,
+    DialogTitle,
+    DialogActions,
+    DialogContent,
+} from '@mui/material';
 import CancelButton from '../../lib/components/CancelButton';
 import { useTranslate } from '../../i18n/I18NContext';
 import { useState } from 'react';
@@ -24,6 +30,9 @@ export const DeleteSubresourceButton = ({
                     <DialogTitle>
                         {translate('confirm_delete_subresource')}
                     </DialogTitle>
+                    <DialogContent>
+                        {translate('confirm_delete_subresource_details')}
+                    </DialogContent>
                     <DialogActions>
                         <CancelButton onClick={() => setShowDeletePopup(false)}>
                             {translate('cancel')}


### PR DESCRIPTION
see https://github.com/orgs/Inist-CNRS/projects/5/views/1?pane=issue&itemId=134015959&issue=Inist-CNRS%7Clodex%7C3002

- Field "linked to a subresource" are not actually linked to it.
- Even with the subresource deleted they will continue to work.
- Unless the use Format of type internal uri pointing toward the deleted subresource which will will be broken. But today there is no validation on the field format. And adding such validation is no small task.