### PR TITLE
Feat(precomputed): Ask for confirm before running

### DIFF
--- a/config.json
+++ b/config.json
@@ -112,7 +112,7 @@
         "https://query.wikidata.org/sparql",
         "http://www.lotico.com:3030/lotico/sparql"
     ],
-    "alternativePrecomputedBaseUrl": "{public url of the server accessible from webhooks (ie ngrok)}",
+    "alternativePrecomputedBaseUrl": "https://9be525a0b46b.ngrok-free.app",
     "activateBullDashboard": false,
     "themes": [
         "voscouleurs",

--- a/jest.config.js
+++ b/jest.config.js
@@ -96,6 +96,7 @@ module.exports = {
             workerIdleMemoryLimit,
             moduleFileExtensions: ['js', 'json', 'jsx', 'mjs', 'ts', 'tsx'],
             testEnvironment: 'jsdom',
+            transformIgnorePatterns: ['<rootDir>/node_modules/d3'],
         },
         {
             displayName: 'workers',

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,8 +13,8 @@ module.exports = {
     workerIdleMemoryLimit,
     projects: [
         {
-            displayName: 'frontend',
-            rootDir: `${__dirname}/src/app`,
+            displayName: 'admin-app',
+            rootDir: `${__dirname}/packages/admin-app`,
             setupFiles: [`${__dirname}/setupTest.ts`],
             setupFilesAfterEnv: [`${__dirname}/setupTestAfterEnv.ts`],
             testMatch: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -82,6 +82,22 @@ module.exports = {
             workerIdleMemoryLimit,
         },
         {
+            displayName: 'frontend-common',
+            setupFiles: [`${__dirname}/setupTest.ts`],
+            setupFilesAfterEnv: [`${__dirname}/setupTestAfterEnv.ts`],
+            rootDir: `${__dirname}/packages/frontend-common`,
+            transform,
+            testMatch: [
+                '/**/*.spec.js',
+                '/**/*.spec.jsx',
+                '/**/*.spec.tsx',
+                '/**/*.spec.ts',
+            ],
+            workerIdleMemoryLimit,
+            moduleFileExtensions: ['js', 'json', 'jsx', 'mjs', 'ts', 'tsx'],
+            testEnvironment: 'jsdom',
+        },
+        {
             displayName: 'workers',
             rootDir: `${__dirname}/packages/workers/src`,
             transform,

--- a/packages/admin-app/src/Search/SearchForm.spec.tsx
+++ b/packages/admin-app/src/Search/SearchForm.spec.tsx
@@ -1,10 +1,10 @@
 import { SearchForm, type SearchFormProps } from './SearchForm';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Overview } from '@lodex/common';
-import fieldApi from '../api/field';
 import { I18NContext } from '@lodex/frontend-common/i18n/I18NContext.tsx';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, waitFor, within } from '@testing-library/dom';
+import fieldApi from '../api/field';
 import { render } from '../test-utils';
 
 jest.mock('../api/field', () => ({
@@ -13,7 +13,7 @@ jest.mock('../api/field', () => ({
 }));
 
 // eslint-disable-next-line react/display-name
-jest.mock('../../../../src/app/js/fields/FieldRepresentation', () => () => (
+jest.mock('../fields/FieldRepresentation', () => () => (
     <div>FieldRepresentation</div>
 ));
 

--- a/packages/admin-app/src/precomputed/PrecomputedForm.spec.tsx
+++ b/packages/admin-app/src/precomputed/PrecomputedForm.spec.tsx
@@ -1,7 +1,15 @@
 import '@testing-library/jest-dom';
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { render } from '../test-utils';
 
 import { PrecomputedForm, type PrecomputedFormProps } from './PrecomputedForm';
+
+jest.mock('../api/job', () => ({
+    cancelJob: jest.fn(),
+    clearJobs: jest.fn(),
+    getJobLogs: jest.fn().mockResolvedValue({ response: { logs: [] } }),
+}));
 
 const defaultProps: PrecomputedFormProps = {
     datasetFields: ['field1', 'field2'],
@@ -21,22 +29,22 @@ const defaultProps: PrecomputedFormProps = {
 
 describe('<PrecomputedForm />', () => {
     it('renders the name field', () => {
-        const screen = render(<PrecomputedForm {...defaultProps} />);
+        render(<PrecomputedForm {...defaultProps} />);
         expect(screen.getByLabelText('fieldName *')).toBeInTheDocument();
     });
 
     it('renders the webServiceUrl field', () => {
-        const screen = render(<PrecomputedForm {...defaultProps} />);
+        render(<PrecomputedForm {...defaultProps} />);
         expect(screen.getByLabelText('webServiceUrl *')).toBeInTheDocument();
     });
 
     it('renders the sourceColumns field', () => {
-        const screen = render(<PrecomputedForm {...defaultProps} />);
+        render(<PrecomputedForm {...defaultProps} />);
         expect(screen.getByLabelText('sourceColumns *')).toBeInTheDocument();
     });
 
     it('renders the logs dialog button in edit mode', () => {
-        const screen = render(
+        render(
             <PrecomputedForm
                 {...defaultProps}
                 initialValues={{
@@ -53,5 +61,184 @@ describe('<PrecomputedForm />', () => {
             />,
         );
         expect(screen.getByText(/see_logs/i)).toBeInTheDocument();
+    });
+
+    describe('RunButton', () => {
+        it('renders the RunButton in edit mode', () => {
+            render(
+                <PrecomputedForm
+                    {...defaultProps}
+                    initialValues={{
+                        _id: '123',
+                        status: 'FINISHED',
+                        data: {},
+                        name: 'test',
+                        jobId: 'job_123',
+                        webServiceUrl: 'http://example.com',
+                        sourceColumns: ['field1'],
+                        subPath: '',
+                        startedAt: '2025-01-01',
+                    }}
+                />,
+            );
+            expect(
+                screen.getByRole('button', { name: 'run' }),
+            ).toBeInTheDocument();
+        });
+
+        it('opens a confirmation modal when RunButton is clicked', async () => {
+            const user = userEvent.setup();
+            render(
+                <PrecomputedForm
+                    {...defaultProps}
+                    initialValues={{
+                        _id: '123',
+                        status: 'FINISHED',
+                        data: {},
+                        name: 'test',
+                        jobId: 'job_123',
+                        webServiceUrl: 'http://example.com',
+                        sourceColumns: ['field1'],
+                        subPath: '',
+                        startedAt: '2025-01-01',
+                    }}
+                />,
+            );
+
+            await act(() => {
+                return user.click(screen.getByRole('button', { name: /run/i }));
+            });
+
+            await waitFor(() => {
+                expect(
+                    screen.getByRole('dialog', {
+                        name: 'precomputed_confirm_run',
+                    }),
+                ).toBeVisible();
+            });
+        });
+
+        it('closes the modal when cancel button is clicked', async () => {
+            const user = userEvent.setup();
+            render(
+                <PrecomputedForm
+                    {...defaultProps}
+                    initialValues={{
+                        _id: '123',
+                        status: 'FINISHED',
+                        data: {},
+                        name: 'test',
+                        jobId: 'job_123',
+                        webServiceUrl: 'http://example.com',
+                        sourceColumns: ['field1'],
+                        subPath: '',
+                        startedAt: '2025-01-01',
+                    }}
+                />,
+            );
+
+            await act(() => {
+                return user.click(screen.getByRole('button', { name: /run/i }));
+            });
+
+            await waitFor(() => {
+                expect(
+                    screen.getByRole('dialog', {
+                        name: 'precomputed_confirm_run',
+                    }),
+                ).toBeVisible();
+            });
+
+            await act(() => {
+                return user.click(
+                    screen.getByRole('button', {
+                        name: 'cancel',
+                    }),
+                );
+            });
+
+            await waitFor(() => {
+                expect(
+                    screen.queryByRole('dialog', {
+                        name: 'precomputed_confirm_run',
+                    }),
+                ).not.toBeInTheDocument();
+            });
+        });
+
+        it('calls onLaunchPrecomputed when confirm button is clicked', async () => {
+            const user = userEvent.setup();
+            const onLaunchPrecomputedMock = jest.fn();
+            render(
+                <PrecomputedForm
+                    {...defaultProps}
+                    onLaunchPrecomputed={onLaunchPrecomputedMock}
+                    initialValues={{
+                        _id: '123',
+                        status: 'FINISHED',
+                        data: {},
+                        name: 'test',
+                        jobId: 'job_123',
+                        webServiceUrl: 'http://example.com',
+                        sourceColumns: ['field1'],
+                        subPath: '',
+                        startedAt: '2025-01-01',
+                    }}
+                />,
+            );
+
+            await act(() =>
+                user.click(
+                    screen.getByRole('button', {
+                        name: 'run',
+                    }),
+                ),
+            );
+
+            await waitFor(() => {
+                expect(
+                    screen.getByRole('dialog', {
+                        name: 'precomputed_confirm_run',
+                    }),
+                ).toBeVisible();
+            });
+
+            await act(() =>
+                user.click(
+                    screen.getByRole('button', {
+                        name: 'confirm',
+                    }),
+                ),
+            );
+
+            await waitFor(() => {
+                expect(onLaunchPrecomputedMock).toHaveBeenCalledWith({
+                    id: '123',
+                    action: 'relaunch',
+                });
+            });
+        });
+
+        it('disables RunButton when status is IN_PROGRESS', () => {
+            render(
+                <PrecomputedForm
+                    {...defaultProps}
+                    initialValues={{
+                        _id: '123',
+                        status: 'IN_PROGRESS',
+                        data: {},
+                        name: 'test',
+                        jobId: 'job_123',
+                        webServiceUrl: 'http://example.com',
+                        sourceColumns: ['field1'],
+                        subPath: '',
+                        startedAt: '2025-01-01',
+                    }}
+                />,
+            );
+
+            const runButton = screen.getByRole('button', { name: 'run' });
+            expect(runButton).toBeDisabled();
+        });
     });
 });

--- a/packages/admin-app/src/precomputed/RunButton.spec.tsx
+++ b/packages/admin-app/src/precomputed/RunButton.spec.tsx
@@ -1,0 +1,115 @@
+import { TaskStatus } from '@lodex/common';
+import '@testing-library/jest-dom';
+import { act, screen, waitFor } from '@testing-library/react';
+import { render, userEvent } from '../test-utils';
+import { RunButton } from './RunButton';
+
+describe('<RunButton />', () => {
+    const setup = (props?: Partial<React.ComponentProps<typeof RunButton>>) => {
+        const handleLaunchPrecomputed = jest.fn();
+        render(
+            <RunButton
+                handleLaunchPrecomputed={handleLaunchPrecomputed}
+                precomputedStatus={TaskStatus.FINISHED}
+                variant="contained"
+                {...props}
+            />,
+        );
+        return { handleLaunchPrecomputed };
+    };
+
+    it('renders the Run button', () => {
+        setup();
+        expect(screen.getByRole('button', { name: 'run' })).toBeInTheDocument();
+    });
+
+    it.each([TaskStatus.CANCELED, TaskStatus.ERROR, undefined])(
+        'calls handleLaunchPrecomputed  when status is %s and button is clicked',
+        async (status) => {
+            const user = userEvent.setup();
+            const { handleLaunchPrecomputed } = setup({
+                precomputedStatus: status,
+            });
+
+            await act(() => {
+                return user.click(screen.getByRole('button', { name: 'run' }));
+            });
+
+            expect(handleLaunchPrecomputed).toHaveBeenCalledTimes(1);
+        },
+    );
+
+    it('opens a confirmation modal when the button is clicked and status is FINISHED', async () => {
+        const user = userEvent.setup();
+        setup();
+
+        await act(() => {
+            return user.click(screen.getByRole('button', { name: /run/i }));
+        });
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('dialog', { name: 'precomputed_confirm_run' }),
+            ).toBeVisible();
+        });
+    });
+
+    it('closes the modal when cancel is clicked', async () => {
+        const user = userEvent.setup();
+        setup();
+
+        await act(() => {
+            return user.click(screen.getByRole('button', { name: /run/i }));
+        });
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('dialog', { name: 'precomputed_confirm_run' }),
+            ).toBeVisible();
+        });
+
+        await act(() => {
+            return user.click(screen.getByRole('button', { name: 'cancel' }));
+        });
+
+        await waitFor(() => {
+            expect(
+                screen.queryByRole('dialog', {
+                    name: 'precomputed_confirm_run',
+                }),
+            ).not.toBeInTheDocument();
+        });
+    });
+
+    it('calls handleLaunchPrecomputed when confirm is clicked', async () => {
+        const user = userEvent.setup();
+        const { handleLaunchPrecomputed } = setup();
+
+        await act(() => {
+            return user.click(screen.getByRole('button', { name: /run/i }));
+        });
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('dialog', { name: 'precomputed_confirm_run' }),
+            ).toBeVisible();
+        });
+
+        await act(() => {
+            return user.click(screen.getByRole('button', { name: 'confirm' }));
+        });
+
+        await waitFor(() => {
+            expect(handleLaunchPrecomputed).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it.each([TaskStatus.IN_PROGRESS, TaskStatus.PENDING, TaskStatus.ON_HOLD])(
+        'disables the Run button when status is %s',
+        (status) => {
+            setup({ precomputedStatus: status });
+            const runButton = screen.getByRole('button', { name: 'run' });
+            expect(runButton).toBeDisabled();
+        },
+    );
+});

--- a/packages/admin-app/src/precomputed/RunButton.tsx
+++ b/packages/admin-app/src/precomputed/RunButton.tsx
@@ -1,15 +1,16 @@
 import { TaskStatus, type TaskStatusType } from '@lodex/common';
+import { ButtonWithConfirm } from '@lodex/frontend-common/components/ButtonWithConfirm';
 import { useTranslate } from '@lodex/frontend-common/i18n/I18NContext';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import {
-    Button,
-    Dialog,
-    DialogActions,
-    DialogContent,
-    DialogTitle,
-    type ButtonProps,
-} from '@mui/material';
-import { useState, type MouseEvent } from 'react';
+import { Button, type ButtonProps } from '@mui/material';
+import { useEffect, useState, type MouseEvent } from 'react';
+
+const RUNNABLE_STATUSES: (TaskStatusType | undefined)[] = [
+    undefined,
+    TaskStatus.FINISHED,
+    TaskStatus.ERROR,
+    TaskStatus.CANCELED,
+];
 
 export const RunButton = ({
     handleLaunchPrecomputed,
@@ -21,61 +22,45 @@ export const RunButton = ({
     variant: ButtonProps['variant'];
 }) => {
     const { translate } = useTranslate();
-    const [isOpen, setIsOpen] = useState(false);
     const [isClicked, setIsClicked] = useState<boolean>(false);
 
-    const handleButtonClick = (event: MouseEvent) => {
-        if (precomputedStatus === TaskStatus.FINISHED) {
-            setIsOpen(true);
-        } else {
-            handleLaunchPrecomputed(event);
-            setIsClicked(true);
-        }
+    const handleConfirm = (event: MouseEvent) => {
+        setIsClicked(true);
+        handleLaunchPrecomputed(event);
     };
 
-    const handleConfirm = (event: MouseEvent) => {
-        handleLaunchPrecomputed(event);
-        setIsClicked(true);
-        setIsOpen(false);
-    };
+    useEffect(() => {
+        if (!RUNNABLE_STATUSES.includes(precomputedStatus)) {
+            return;
+        }
+        setIsClicked(false);
+    }, [precomputedStatus]);
+
+    if (precomputedStatus === TaskStatus.FINISHED) {
+        return (
+            <ButtonWithConfirm
+                onConfirm={handleConfirm}
+                buttonLabel={translate('run')}
+                buttonIcon={<PlayArrowIcon />}
+                buttonVariant={variant}
+                dialogTitle={translate('precomputed_confirm_run')}
+                dialogContent={translate('precomputed_confirm_run_description')}
+            />
+        );
+    }
 
     return (
-        <>
-            <Button
-                color="primary"
-                variant={variant}
-                sx={{ height: '100%' }}
-                startIcon={<PlayArrowIcon />}
-                onClick={handleButtonClick}
-                disabled={
-                    isClicked ||
-                    precomputedStatus === TaskStatus.IN_PROGRESS ||
-                    precomputedStatus === TaskStatus.PENDING ||
-                    precomputedStatus === TaskStatus.ON_HOLD
-                }
-            >
-                {translate('run')}
-            </Button>
-            <Dialog
-                open={isOpen}
-                onClose={() => setIsOpen(false)}
-                aria-labelledby="precomputed-confirm-run-title"
-            >
-                <DialogTitle id="precomputed-confirm-run-title">
-                    {translate('precomputed_confirm_run')}
-                </DialogTitle>
-                <DialogContent>
-                    {translate('precomputed_confirm_run_description')}
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={() => setIsOpen(false)} color="secondary">
-                        {translate('cancel')}
-                    </Button>
-                    <Button onClick={handleConfirm} color="primary" autoFocus>
-                        {translate('confirm')}
-                    </Button>
-                </DialogActions>
-            </Dialog>
-        </>
+        <Button
+            color="primary"
+            variant={variant}
+            sx={{ height: '100%' }}
+            startIcon={<PlayArrowIcon />}
+            onClick={handleConfirm}
+            disabled={
+                isClicked || !RUNNABLE_STATUSES.includes(precomputedStatus)
+            }
+        >
+            {translate('run')}
+        </Button>
     );
 };

--- a/packages/admin-app/src/precomputed/RunButton.tsx
+++ b/packages/admin-app/src/precomputed/RunButton.tsx
@@ -1,8 +1,15 @@
-import { Button, type ButtonProps } from '@mui/material';
-import { type MouseEvent, useState } from 'react';
-import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import { TaskStatus, type TaskStatusType } from '@lodex/common';
 import { useTranslate } from '@lodex/frontend-common/i18n/I18NContext';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    type ButtonProps,
+} from '@mui/material';
+import { useState, type MouseEvent } from 'react';
 
 export const RunButton = ({
     handleLaunchPrecomputed,
@@ -14,27 +21,61 @@ export const RunButton = ({
     variant: ButtonProps['variant'];
 }) => {
     const { translate } = useTranslate();
+    const [isOpen, setIsOpen] = useState(false);
     const [isClicked, setIsClicked] = useState<boolean>(false);
-    const handleClick = (event: MouseEvent) => {
+
+    const handleButtonClick = (event: MouseEvent) => {
+        if (precomputedStatus === TaskStatus.FINISHED) {
+            setIsOpen(true);
+        } else {
+            handleLaunchPrecomputed(event);
+            setIsClicked(true);
+        }
+    };
+
+    const handleConfirm = (event: MouseEvent) => {
         handleLaunchPrecomputed(event);
         setIsClicked(true);
+        setIsOpen(false);
     };
 
     return (
-        <Button
-            color="primary"
-            variant={variant}
-            sx={{ height: '100%' }}
-            startIcon={<PlayArrowIcon />}
-            onClick={handleClick}
-            disabled={
-                isClicked ||
-                precomputedStatus === TaskStatus.IN_PROGRESS ||
-                precomputedStatus === TaskStatus.PENDING ||
-                precomputedStatus === TaskStatus.ON_HOLD
-            }
-        >
-            {translate('run')}
-        </Button>
+        <>
+            <Button
+                color="primary"
+                variant={variant}
+                sx={{ height: '100%' }}
+                startIcon={<PlayArrowIcon />}
+                onClick={handleButtonClick}
+                disabled={
+                    isClicked ||
+                    precomputedStatus === TaskStatus.IN_PROGRESS ||
+                    precomputedStatus === TaskStatus.PENDING ||
+                    precomputedStatus === TaskStatus.ON_HOLD
+                }
+            >
+                {translate('run')}
+            </Button>
+            <Dialog
+                open={isOpen}
+                onClose={() => setIsOpen(false)}
+                aria-labelledby="precomputed-confirm-run-title"
+            >
+                <DialogTitle id="precomputed-confirm-run-title">
+                    {translate('precomputed_confirm_run')}
+                </DialogTitle>
+                <DialogContent>
+                    {translate('precomputed_confirm_run_description')}
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setIsOpen(false)} color="secondary">
+                        {translate('cancel')}
+                    </Button>
+                    <Button onClick={handleConfirm} color="primary" autoFocus>
+                        {translate('confirm')}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </>
     );
 };

--- a/packages/frontend-common/components/ButtonWithConfirm.spec.tsx
+++ b/packages/frontend-common/components/ButtonWithConfirm.spec.tsx
@@ -1,0 +1,187 @@
+import '@testing-library/jest-dom';
+import { screen, waitFor } from '@testing-library/react';
+import { render, userEvent } from '../test-utils';
+import { ButtonWithConfirm } from './ButtonWithConfirm';
+
+describe('<ButtonWithConfirm />', () => {
+    const defaultProps = {
+        buttonLabel: 'Test Action',
+        dialogTitle: 'Confirm Action',
+        dialogContent: 'Are you sure you want to proceed?',
+        onConfirm: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should render the button with the correct label', () => {
+        render(<ButtonWithConfirm {...defaultProps} />);
+
+        expect(screen.getByText('Test Action')).toBeInTheDocument();
+    });
+
+    it('should render the button with default variant (contained)', () => {
+        render(<ButtonWithConfirm {...defaultProps} />);
+
+        const button = screen.getByRole('button', { name: 'Test Action' });
+        expect(button).toHaveClass('MuiButton-contained');
+    });
+
+    it('should render the button with custom variant', () => {
+        render(
+            <ButtonWithConfirm {...defaultProps} buttonVariant="outlined" />,
+        );
+
+        const button = screen.getByRole('button', { name: 'Test Action' });
+        expect(button).toHaveClass('MuiButton-outlined');
+    });
+
+    it('should not show dialog initially', () => {
+        render(<ButtonWithConfirm {...defaultProps} />);
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('should open dialog when button is clicked', async () => {
+        const user = userEvent.setup();
+        render(<ButtonWithConfirm {...defaultProps} />);
+
+        const button = screen.getByRole('button', { name: 'Test Action' });
+        await user.click(button);
+
+        await waitFor(() => {
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
+            expect(
+                screen.getByText('Are you sure you want to proceed?'),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('should show cancel and confirm buttons in dialog', async () => {
+        const user = userEvent.setup();
+        render(<ButtonWithConfirm {...defaultProps} />);
+
+        const button = screen.getByRole('button', { name: 'Test Action' });
+        await user.click(button);
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('button', { name: 'cancel' }),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: 'confirm' }),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('should close dialog when cancel button is clicked', async () => {
+        const user = userEvent.setup();
+        render(<ButtonWithConfirm {...defaultProps} />);
+
+        const openButton = screen.getByRole('button', { name: 'Test Action' });
+        await user.click(openButton);
+
+        await waitFor(() => {
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
+        });
+
+        const cancelButton = screen.getByRole('button', { name: 'cancel' });
+        await user.click(cancelButton);
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
+
+    it('should call onConfirm and close dialog when confirm button is clicked', async () => {
+        const user = userEvent.setup();
+        const onConfirm = jest.fn();
+        render(<ButtonWithConfirm {...defaultProps} onConfirm={onConfirm} />);
+
+        const openButton = screen.getByRole('button', { name: 'Test Action' });
+        await user.click(openButton);
+
+        await waitFor(() => {
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
+        });
+
+        const confirmButton = screen.getByRole('button', { name: 'confirm' });
+        await user.click(confirmButton);
+
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
+
+    it('should not call onConfirm when cancel button is clicked', async () => {
+        const user = userEvent.setup();
+        const onConfirm = jest.fn();
+        render(<ButtonWithConfirm {...defaultProps} onConfirm={onConfirm} />);
+
+        const openButton = screen.getByRole('button', { name: 'Test Action' });
+        await user.click(openButton);
+
+        await waitFor(() => {
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
+        });
+
+        const cancelButton = screen.getByRole('button', { name: 'cancel' });
+        await user.click(cancelButton);
+
+        expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it('should handle multiple open/close cycles', async () => {
+        const user = userEvent.setup();
+        const onConfirm = jest.fn();
+        render(<ButtonWithConfirm {...defaultProps} onConfirm={onConfirm} />);
+
+        const openButton = screen.getByRole('button', { name: 'Test Action' });
+
+        // First cycle - cancel
+        await user.click(openButton);
+        await waitFor(() => {
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
+        });
+        await user.click(screen.getByRole('button', { name: 'cancel' }));
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+
+        // Second cycle - confirm
+        await user.click(openButton);
+        await waitFor(() => {
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
+        });
+        await user.click(screen.getByRole('button', { name: 'confirm' }));
+
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
+
+    it('should pass event to onConfirm callback', async () => {
+        const user = userEvent.setup();
+        const onConfirm = jest.fn();
+        render(<ButtonWithConfirm {...defaultProps} onConfirm={onConfirm} />);
+
+        const openButton = screen.getByRole('button', { name: 'Test Action' });
+        await user.click(openButton);
+
+        await waitFor(() => {
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
+        });
+
+        const confirmButton = screen.getByRole('button', { name: 'confirm' });
+        await user.click(confirmButton);
+
+        expect(onConfirm).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'click',
+            }),
+        );
+    });
+});

--- a/packages/frontend-common/components/ButtonWithConfirm.tsx
+++ b/packages/frontend-common/components/ButtonWithConfirm.tsx
@@ -1,0 +1,71 @@
+import { Button, type ButtonProps } from '@mui/material';
+import { useState, type MouseEvent } from 'react';
+import { useTranslate } from '../i18n/I18NContext';
+import ButtonWithDialog from './ButtonWithDialog';
+import CancelButton from './CancelButton';
+
+export function ButtonWithConfirm({
+    buttonLabel,
+    buttonIcon,
+    buttonVariant,
+    dialogTitle,
+    dialogContent,
+    onConfirm,
+}: ButtonWithConfirmProps) {
+    const { translate } = useTranslate();
+
+    const [open, setOpen] = useState(false);
+
+    const handleOpen = () => {
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+    };
+
+    const handleConfirm = (event: MouseEvent<HTMLButtonElement>) => {
+        onConfirm(event);
+        handleClose();
+    };
+
+    return (
+        <ButtonWithDialog
+            open={open}
+            handleOpen={handleOpen}
+            handleClose={handleClose}
+            openButton={
+                <Button
+                    variant={buttonVariant ?? 'contained'}
+                    color="primary"
+                    startIcon={buttonIcon}
+                    onClick={handleOpen}
+                >
+                    {buttonLabel}
+                </Button>
+            }
+            actions={
+                <>
+                    <CancelButton onClick={handleClose}>
+                        {translate('cancel')}
+                    </CancelButton>
+
+                    <Button onClick={handleConfirm}>
+                        {translate('confirm')}
+                    </Button>
+                </>
+            }
+            label={dialogTitle}
+            dialog={dialogContent}
+        />
+    );
+}
+
+type ButtonWithConfirmProps = {
+    buttonIcon?: ButtonProps['startIcon'];
+    buttonVariant?: ButtonProps['variant'];
+    buttonLabel: string;
+    dialogTitle: string;
+    dialogContent: string;
+    onConfirm: (event: MouseEvent<HTMLButtonElement>) => unknown;
+};

--- a/packages/frontend-common/components/ButtonWithDialog.tsx
+++ b/packages/frontend-common/components/ButtonWithDialog.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 
 import {
+    Box,
     Button,
     Dialog,
-    DialogTitle,
-    DialogContent,
     DialogActions,
-    Box,
+    DialogContent,
+    DialogTitle,
 } from '@mui/material';
 
-import CancelButton from './CancelButton';
 import { translate } from '../i18n/I18NContext';
+import CancelButton from './CancelButton';
 
 const dialogStyle = {
     container: {
@@ -81,10 +81,11 @@ export const PureButtonWithDialog = ({
                 open={open}
                 onClose={handleClose}
                 scroll="body"
+                aria-labelledby="dialog-title"
             >
                 {/*
                  // @ts-expect-error TS2322 */}
-                <DialogTitle>{label}</DialogTitle>
+                <DialogTitle id="dialog-title">{label}</DialogTitle>
                 <DialogContent style={dialogStyle.content}>
                     <div className="dialog-body">
                         <div className="dialog-content">{dialog}</div>

--- a/packages/frontend-common/formats/other/istex/IstexView.spec.tsx
+++ b/packages/frontend-common/formats/other/istex/IstexView.spec.tsx
@@ -1,12 +1,12 @@
-import { shallow } from 'enzyme';
 import { List } from '@mui/material';
+import { shallow } from 'enzyme';
 
 import Alert from '../../../components/Alert';
-import { IstexView } from './IstexView';
-import IstexItem from './IstexItem';
 import { render } from '../../../test-utils';
+import IstexItem from './IstexItem';
+import { IstexView } from './IstexView';
 
-jest.mock('../../../lib/stylesToClassName', () => ({
+jest.mock('../../../utils/stylesToClassName', () => ({
     __esModule: true,
     default: (styles: Record<string, unknown>, prefix: string) => {
         const classes: Record<string, string> = {};

--- a/packages/frontend-common/formats/other/istexCitation/IstexCitationView.spec.tsx
+++ b/packages/frontend-common/formats/other/istexCitation/IstexCitationView.spec.tsx
@@ -10,7 +10,7 @@ import IstexCitationList from './IstexCitationList';
 import { IstexCitationView, IstexDocument } from './IstexCitationView';
 import JournalFold from './JournalFold';
 
-jest.mock('../../../lib/composeRenderProps');
+jest.mock('../../../utils/composeRenderProps');
 jest.mock('./getIstexCitationData');
 
 describe('IstexCitationView', () => {

--- a/packages/frontend-common/formats/other/istexSummary/IstexSummaryView.spec.tsx
+++ b/packages/frontend-common/formats/other/istexSummary/IstexSummaryView.spec.tsx
@@ -13,7 +13,7 @@ import { IstexDocument, IstexSummaryView } from './IstexSummaryView';
 import VolumeFold from './VolumeFold';
 import YearFold from './YearFold';
 
-jest.mock('../../../lib/composeRenderProps');
+jest.mock('../../../utils/composeRenderProps');
 jest.mock('./getIstexData');
 jest.mock('./getDecadeFromData');
 

--- a/packages/frontend-common/user/LoginForm.spec.tsx
+++ b/packages/frontend-common/user/LoginForm.spec.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
 import '@testing-library/jest-dom';
+import React from 'react';
 
-import { LoginFormComponent } from './LoginForm';
-import { act, render } from '../test-utils';
-import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useLogin } from './api/login';
 import { fireEvent } from '@testing-library/dom';
+import { MemoryRouter } from 'react-router';
+import { act, render } from '../test-utils';
+import { useLogin } from './api/login';
+import { LoginFormComponent } from './LoginForm';
 
-jest.mock('../api/login', () => ({
+jest.mock('./api/login', () => ({
     useLogin: jest
         .fn()
         .mockReturnValue({ login: jest.fn(), error: null, isLoading: false }),

--- a/packages/frontend-common/user/api/login.spec.tsx
+++ b/packages/frontend-common/user/api/login.spec.tsx
@@ -1,12 +1,12 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-import { useLogin } from './login';
-import { Wrapper as DefaultWrapper, getStore } from '../../test-utils';
 import { renderHook } from '@testing-library/react-hooks';
 import { MemoryRouter, useHistory } from 'react-router';
-import { getUserSessionStorageInfo } from '../../getUserSessionStorageInfo';
 import fetch from '../../fetch/fetch';
+import { getUserSessionStorageInfo } from '../../getUserSessionStorageInfo';
+import { Wrapper as DefaultWrapper, getStore } from '../../test-utils';
 import { loginSuccess } from '../../user/reducer';
+import { useLogin } from './login';
 
 jest.mock('../../getUserSessionStorageInfo', () => ({
     getUserSessionStorageInfo: jest.fn(),
@@ -14,8 +14,8 @@ jest.mock('../../getUserSessionStorageInfo', () => ({
 
 jest.mock('@lodex/frontend-common/fetch/fetch', () => jest.fn());
 
-jest.mock('../user', () => ({
-    ...jest.requireActual('../user'),
+jest.mock('../../user/reducer', () => ({
+    ...jest.requireActual('../../user/reducer'),
     loginSuccess: jest
         .fn()
         .mockImplementation((payload) => ({ type: 'LOGIN_SUCCESS', payload })),

--- a/src/app/custom/translations.tsv
+++ b/src/app/custom/translations.tsv
@@ -743,6 +743,8 @@
 "precomputed_logs"	"Precomputed data logs"	"Logs des données précalculées"
 "precomputed_data"	"Precomputed data"	"Données précalculées"
 "precomputed_data_limit"	"We limit the sample to the first 10 results"	"Nous limitons l'échantillon aux 10 premiers résultats"
+"precomputed_confirm_run"	"Confirm running precomputed ?"	"Confirmer l'exécution du précalcul ?"
+"precomputed_confirm_run_description"	"By running this precomputed, this will erase existing results."	"En exécutant ce précalcul, vous effacerez les résultats existants."
 "published_data"	"Published data"	"Données publiées"
 "toggle_loaded"	"Show/hide loaded columns"	"Afficher/cacher les colonnes chargées"
 "toggle_enriched"	"Show/hide enriched columns"	"Afficher/cacher les colonnes enrichies"


### PR DESCRIPTION
## Problem
Running a precompute erases existing data.

## Solution
Add a confirm modal before running when the status is `finished`

## How to Test

`make start-dev`, then run a precompute with status `finished` or status `error`