### PR TITLE
Feat(network): provide the ability to display network graphs unweighted

### DIFF
--- a/packages/frontend-common/fields/sagas/loadFields.ts
+++ b/packages/frontend-common/fields/sagas/loadFields.ts
@@ -6,16 +6,14 @@ import {
     loadFieldError,
     loadFieldSuccess,
 } from '@lodex/frontend-common/fields/reducer';
-import { UPLOAD_SUCCESS } from '../../../admin-app/src/upload';
-import { IMPORT_FIELDS_SUCCESS } from '../../../admin-app/src/import';
 import { fromUser } from '@lodex/frontend-common/sharedSelectors';
+import { IMPORT_FIELDS_SUCCESS } from '../../../admin-app/src/import';
+import { UPLOAD_SUCCESS } from '../../../admin-app/src/upload';
 
 export function* handleLoadField() {
     // @ts-expect-error TS7057
     const request = yield select(fromUser.getLoadFieldRequest);
     const { error, response } = yield call(fetchSaga, request);
-
-    console.log('handleLoadField', { error, response });
 
     if (error) {
         // @ts-expect-error TS7057

--- a/packages/frontend-common/fields/types.ts
+++ b/packages/frontend-common/fields/types.ts
@@ -8,6 +8,12 @@ export type Field = {
     position?: number;
     isDefaultSortField?: boolean;
     sortOrder?: 'asc' | 'desc';
+    format?: {
+        name: string;
+        args?: {
+            [key: string]: unknown;
+        };
+    };
 };
 
 export interface TransformerDraft {

--- a/packages/frontend-common/formats/chart/fieldClone/FieldCloneView.tsx
+++ b/packages/frontend-common/formats/chart/fieldClone/FieldCloneView.tsx
@@ -1,7 +1,7 @@
 import type { Field } from '../../../fields/types';
+import getColorSetFromField from '../../../utils/getColorSetFromField';
 import InvalidFormat from '../../InvalidFormat';
 import { getViewComponent } from '../../getFormat';
-import getColorSetFromField from '../../../utils/getColorSetFromField';
 
 interface FieldCloneViewProps {
     className?: string;
@@ -26,10 +26,8 @@ const FieldCloneView = ({
     if (
         !clonedField ||
         typeof clonedField !== 'object' ||
-        // @ts-expect-error TS2339
         (clonedField.format && clonedField.format.name === 'fieldClone')
     ) {
-        // @ts-expect-error TS18046
         return <InvalidFormat format={field.format} value={value} />;
     }
 

--- a/packages/frontend-common/formats/chart/network/NetworkAdmin.tsx
+++ b/packages/frontend-common/formats/chart/network/NetworkAdmin.tsx
@@ -86,8 +86,6 @@ const NetworkAdmin: React.FC<NetworkAdminProps> = ({
 
     const { params } = args;
 
-    console.log('NetworkAdmin render', args);
-
     return (
         <FormatGroupedFieldSet>
             <FormatDataParamsFieldSet>

--- a/packages/frontend-common/formats/chart/network/NetworkAdmin.tsx
+++ b/packages/frontend-common/formats/chart/network/NetworkAdmin.tsx
@@ -1,8 +1,10 @@
 import React, { useCallback } from 'react';
 
-import RoutineParamsAdmin from '../../utils/components/admin/RoutineParamsAdmin';
-import ColorPickerParamsAdmin from '../../utils/components/admin/ColorPickerParamsAdmin';
+import { FormControlLabel, Switch } from '@mui/material';
+import { useTranslate } from '../../../i18n/I18NContext';
 import { MONOCHROMATIC_DEFAULT_COLORSET } from '../../utils/colorUtils';
+import ColorPickerParamsAdmin from '../../utils/components/admin/ColorPickerParamsAdmin';
+import RoutineParamsAdmin from '../../utils/components/admin/RoutineParamsAdmin';
 import {
     FormatChartParamsFieldSet,
     FormatDataParamsFieldSet,
@@ -17,6 +19,7 @@ type NetworkArgs = {
         orderBy?: string;
         uri?: string;
     };
+    displayWeighted?: boolean;
     colors?: string;
 };
 
@@ -28,6 +31,7 @@ export const defaultArgs = {
         minValue: undefined,
         uri: undefined,
     },
+    displayWeighted: true,
     colors: MONOCHROMATIC_DEFAULT_COLORSET,
 };
 
@@ -48,11 +52,23 @@ const NetworkAdmin: React.FC<NetworkAdminProps> = ({
     showMinValue = true,
     showOrderBy = true,
 }) => {
+    const { translate } = useTranslate();
+
     const handleParams = useCallback(
         (params: NetworkArgs['params']) => {
             onChange({
                 ...args,
                 params,
+            });
+        },
+        [onChange, args],
+    );
+
+    const handleChangeDisplayWeighted = useCallback(
+        (_: unknown, checked: boolean) => {
+            onChange({
+                ...args,
+                displayWeighted: checked,
             });
         },
         [onChange, args],
@@ -69,6 +85,8 @@ const NetworkAdmin: React.FC<NetworkAdminProps> = ({
     );
 
     const { params } = args;
+
+    console.log('NetworkAdmin render', args);
 
     return (
         <FormatGroupedFieldSet>
@@ -87,6 +105,12 @@ const NetworkAdmin: React.FC<NetworkAdminProps> = ({
                 />
             </FormatDataParamsFieldSet>
             <FormatChartParamsFieldSet defaultExpanded>
+                <FormControlLabel
+                    control={<Switch defaultChecked />}
+                    checked={args.displayWeighted ?? true}
+                    onChange={handleChangeDisplayWeighted}
+                    label={translate('display_weighted')}
+                />
                 <ColorPickerParamsAdmin
                     colors={args.colors}
                     onChange={handleColors}

--- a/packages/frontend-common/formats/chart/network/NetworkView.tsx
+++ b/packages/frontend-common/formats/chart/network/NetworkView.tsx
@@ -1,20 +1,13 @@
-import { scaleLinear } from 'd3-scale';
-import get from 'lodash/get';
-import {
-    lazy,
-    Suspense,
-    useCallback,
-    useEffect,
-    useMemo,
-    useState,
-} from 'react';
+import { lazy, Suspense, useCallback, useEffect, useState } from 'react';
 import compose from 'recompose/compose';
 
-import { useTranslate } from '../../../i18n/I18NContext';
 import Loading from '../../../components/Loading';
+import type { Field } from '../../../fields/types';
+import { useTranslate } from '../../../i18n/I18NContext';
 import injectData from '../../injectData';
 import FormatFullScreenMode from '../../utils/components/FormatFullScreenMode';
 import MouseIcon from '../../utils/components/MouseIcon';
+import { useFormatNetworkData, type NetworkData } from './useFormatNetworkData';
 
 const ForceGraph2D = lazy(() => import('react-force-graph-2d'));
 
@@ -30,10 +23,11 @@ const styles = {
 
 interface NetworkProps {
     colorSet?: string[];
-    formatData?: unknown[];
+    formatData?: NetworkData[];
+    field: Field;
 }
 
-const Network = ({ formatData, colorSet }: NetworkProps) => {
+const Network = ({ formatData, colorSet, field }: NetworkProps) => {
     const { translate } = useTranslate();
     const [{ width, height }, setDimensions] = useState({
         width: 0,
@@ -64,112 +58,15 @@ const Network = ({ formatData, colorSet }: NetworkProps) => {
         setHighlightedLinks([]);
     }, [formatData]);
 
-    const { nodes, links } = useMemo(() => {
-        if (!formatData) {
-            return {
-                nodes: [],
-                links: [],
-            };
-        }
-        const sanitizedFormatData = formatData.filter(
-            // @ts-expect-error TS7031
-            ({ source, target }) => source && target,
-        );
+    const { nodes, links } = useFormatNetworkData({
+        formatData,
+        displayWeighted:
+            typeof field?.format?.args?.displayWeighted === 'boolean'
+                ? field.format.args.displayWeighted
+                : true,
+    });
 
-        const nodesDic = sanitizedFormatData.reduce(
-            // @ts-expect-error TS7006
-            (acc, { source, target }) => ({
-                // @ts-expect-error TS2698
-                ...acc,
-                [source]: {
-                    id: source,
-                    label: source,
-                    radius: get(acc, [source, 'radius'], 0) + 1,
-                },
-                [target]: {
-                    id: target,
-                    label: target,
-                    radius: get(acc, [target, 'radius'], 0) + 1,
-                },
-            }),
-            {},
-        );
-
-        // @ts-expect-error TS2769
-        const nodes = Object.values(nodesDic);
-        // @ts-expect-error TS2345
-        const radiusList = nodes.map(({ radius }) => radius);
-        // @ts-expect-error TS2345
-        const max = Math.max(...radiusList);
-        // @ts-expect-error TS2345
-        const min = Math.min(...radiusList);
-
-        const nodeScale = scaleLinear().domain([min, max]).range([1, 10]);
-
-        // @ts-expect-error TS7031
-        const weightList = sanitizedFormatData.map(({ weight }) => weight);
-        // @ts-expect-error TS2345
-        const maxWeight = Math.max(...weightList);
-        // @ts-expect-error TS2345
-        const minWeight = Math.min(...weightList);
-
-        const linkScale = scaleLinear()
-            .domain([minWeight, maxWeight])
-            .range([1, 20]);
-
-        // @ts-expect-error TS7031
-        const links = sanitizedFormatData.map(({ source, target, weight }) => ({
-            source,
-            target,
-            value: linkScale(weight),
-        }));
-
-        links.forEach((link) => {
-            // @ts-expect-error TS18046
-            const a = nodes.find((node) => node.id === link.source);
-            // @ts-expect-error TS18046
-            const b = nodes.find((node) => node.id === link.target);
-            // @ts-expect-error TS18046
-            if (!a.neighbors) {
-                // @ts-expect-error TS18046
-                a.neighbors = [];
-            }
-            // @ts-expect-error TS18046
-            if (!b.neighbors) {
-                // @ts-expect-error TS18046
-                b.neighbors = [];
-            }
-            // @ts-expect-error TS18046
-            a.neighbors.push(b);
-            // @ts-expect-error TS18046
-            b.neighbors.push(a);
-
-            // @ts-expect-error TS18046
-            if (!a.links) {
-                // @ts-expect-error TS18046
-                a.links = [];
-            }
-            // @ts-expect-error TS18046
-            if (!b.links) {
-                // @ts-expect-error TS18046
-                b.links = [];
-            }
-            // @ts-expect-error TS18046
-            a.links.push(link);
-            // @ts-expect-error TS18046
-            b.links.push(link);
-        });
-
-        return {
-            nodes: nodes.map((node) => ({
-                // @ts-expect-error TS2698
-                ...node,
-                // @ts-expect-error TS18046
-                radius: nodeScale(node.radius),
-            })),
-            links,
-        };
-    }, [formatData]);
+    console.log({ formatData, field, nodes, links });
 
     // @ts-expect-error TS7006
     const handleNodeHover = (node) => {
@@ -239,7 +136,6 @@ const Network = ({ formatData, colorSet }: NetworkProps) => {
                         <ForceGraph2D
                             width={width}
                             height={height}
-                            // @ts-expect-error TS2322
                             graphData={{ nodes, links }}
                             nodeCanvasObject={(node, ctx, globalScale) => {
                                 if (

--- a/packages/frontend-common/formats/chart/network/NetworkView.tsx
+++ b/packages/frontend-common/formats/chart/network/NetworkView.tsx
@@ -66,8 +66,6 @@ const Network = ({ formatData, colorSet, field }: NetworkProps) => {
                 : true,
     });
 
-    console.log({ formatData, field, nodes, links });
-
     // @ts-expect-error TS7006
     const handleNodeHover = (node) => {
         // freeze the chart so that it does not rearrange itself every time we interact with it

--- a/packages/frontend-common/formats/chart/network/useFormatNetworkData.spec.ts
+++ b/packages/frontend-common/formats/chart/network/useFormatNetworkData.spec.ts
@@ -1,0 +1,149 @@
+import { renderHook } from '@testing-library/react-hooks';
+import {
+    useFormatNetworkData,
+    type NetworkData,
+    type Node,
+    type UseFormatNetworkDataReturn,
+} from './useFormatNetworkData';
+
+describe('useFormatNetworkData', () => {
+    it('returns empty nodes and links when formatData is undefined', () => {
+        const { result } = renderHook(() =>
+            useFormatNetworkData({
+                formatData: undefined,
+                displayWeighted: true,
+            }),
+        );
+
+        expect(result.current).toEqual({ nodes: [], links: [] });
+    });
+
+    it('filters out entries without source or target', () => {
+        const data: NetworkData[] = [
+            { source: 'A', target: 'B', weight: 1 },
+            // invalid entries
+            { source: '', target: 'C', weight: 2 } as unknown as NetworkData,
+            { source: 'D', target: '', weight: 3 } as unknown as NetworkData,
+        ];
+
+        const { result } = renderHook(() =>
+            useFormatNetworkData({ formatData: data, displayWeighted: true }),
+        );
+
+        expect(result.current.nodes.length).toBe(2);
+        expect(result.current.links.length).toBe(1);
+
+        const nodeIds = new Set(result.current.nodes.map((n) => String(n.id)));
+        expect(nodeIds).toEqual(new Set(['A', 'B']));
+    });
+
+    it('builds nodes with neighbors and links, and scales values monotonically', () => {
+        const data: NetworkData[] = [
+            { source: 'A', target: 'B', weight: 1 },
+            { source: 'A', target: 'C', weight: 3 },
+            // should be ignored
+            { source: '', target: 'X', weight: 2 } as unknown as NetworkData,
+        ];
+
+        const { result } = renderHook(() =>
+            useFormatNetworkData({ formatData: data, displayWeighted: true }),
+        );
+
+        const graph = result.current as NonNullable<UseFormatNetworkDataReturn>;
+
+        // structure
+        expect(graph.nodes).toHaveLength(3);
+        expect(graph.links).toHaveLength(2);
+
+        const getNode = (id: string) =>
+            graph.nodes.find((n) => String(n.id) === id);
+        const A = getNode('A');
+        const B = getNode('B');
+        const C = getNode('C');
+
+        expect(A).toBeTruthy();
+        expect(B).toBeTruthy();
+        expect(C).toBeTruthy();
+
+        // neighbors and links wiring
+        const neighborsA = (A?.neighbors ?? [])
+            .map((n: Node) => String(n.id))
+            .sort();
+        expect(neighborsA).toEqual(['B', 'C']);
+
+        const neighborsB = (B?.neighbors ?? []).map((n: Node) => String(n.id));
+        expect(neighborsB).toEqual(['A']);
+
+        const neighborsC = (C?.neighbors ?? []).map((n: Node) => String(n.id));
+        expect(neighborsC).toEqual(['A']);
+
+        expect(A?.links).toHaveLength(2);
+        expect(B?.links).toHaveLength(1);
+        expect(C?.links).toHaveLength(1);
+
+        // link weights are scaled monotonically
+        const linkAB = graph.links.find(
+            (l: { source?: unknown; target?: unknown; value?: number }) =>
+                String(l.source) === 'A' && String(l.target) === 'B',
+        );
+        const linkAC = graph.links.find(
+            (l: { source?: unknown; target?: unknown; value?: number }) =>
+                String(l.source) === 'A' && String(l.target) === 'C',
+        );
+        expect(typeof linkAB?.value).toBe('number');
+        expect(typeof linkAC?.value).toBe('number');
+        expect((linkAC?.value as number) > (linkAB?.value as number)).toBe(
+            true,
+        );
+
+        // node radius is scaled so that higher degree has larger radius
+        expect(typeof A?.radius).toBe('number');
+        expect(typeof B?.radius).toBe('number');
+        expect(typeof C?.radius).toBe('number');
+        expect((A?.radius as number) > (B?.radius as number)).toBe(true);
+        expect((A?.radius as number) > (C?.radius as number)).toBe(true);
+    });
+
+    it('handles single-link (degenerate domain) case without NaN values', () => {
+        const data: NetworkData[] = [{ source: 'A', target: 'B', weight: 5 }];
+
+        const { result } = renderHook(() =>
+            useFormatNetworkData({ formatData: data, displayWeighted: true }),
+        );
+
+        const graph = result.current as NonNullable<UseFormatNetworkDataReturn>;
+        expect(graph.nodes).toHaveLength(2);
+        expect(graph.links).toHaveLength(1);
+
+        // values should be finite numbers
+        for (const n of graph.nodes) {
+            expect(Number.isFinite(n.radius as number)).toBe(true);
+        }
+        expect(Number.isFinite(graph.links[0].value as number)).toBe(true);
+    });
+
+    it('updates output when formatData changes', () => {
+        const data1: NetworkData[] = [{ source: 'A', target: 'B', weight: 1 }];
+        const data2: NetworkData[] = [
+            { source: 'A', target: 'B', weight: 1 },
+            { source: 'B', target: 'C', weight: 2 },
+        ];
+
+        const { result, rerender } = renderHook(
+            ({ d }) =>
+                useFormatNetworkData({
+                    formatData: d,
+                    displayWeighted: true,
+                }),
+            { initialProps: { d: data1 } },
+        );
+
+        expect(result.current.nodes).toHaveLength(2);
+        expect(result.current.links).toHaveLength(1);
+
+        rerender({ d: data2 });
+
+        expect(result.current.nodes).toHaveLength(3);
+        expect(result.current.links).toHaveLength(2);
+    });
+});

--- a/packages/frontend-common/formats/chart/network/useFormatNetworkData.spec.ts
+++ b/packages/frontend-common/formats/chart/network/useFormatNetworkData.spec.ts
@@ -115,17 +115,13 @@ describe('useFormatNetworkData', () => {
         expect(linkAB?.value).toBe(1);
         expect(linkAC?.value).toBe(20);
 
-        // @ts-expect-error: value is number
-        expect(linkAC?.value > linkAB?.value).toBe(true);
+        expect(linkAC!.value > linkAB!.value).toBe(true);
 
         expect(A?.radius).toBe(10);
         expect(B?.radius).toBe(1);
         expect(C?.radius).toBe(1);
-
-        // @ts-expect-error: radius is number
-        expect(A?.radius > B?.radius).toBe(true);
-        // @ts-expect-error: radius is number
-        expect(A?.radius > C?.radius).toBe(true);
+        expect(A!.radius > B!.radius).toBe(true);
+        expect(A!.radius > C!.radius).toBe(true);
     });
 
     it('updates output when formatData changes', () => {

--- a/packages/frontend-common/formats/chart/network/useFormatNetworkData.spec.ts
+++ b/packages/frontend-common/formats/chart/network/useFormatNetworkData.spec.ts
@@ -7,35 +7,58 @@ import {
 } from './useFormatNetworkData';
 
 describe('useFormatNetworkData', () => {
-    it('returns empty nodes and links when formatData is undefined', () => {
+    it.each<[{ label: string; d: NetworkData[] | undefined }]>([
+        [{ label: 'undefined', d: undefined }],
+        [{ label: 'an empty array', d: [] as NetworkData[] }],
+    ])('returns empty nodes and links when formatData is $label', ({ d }) => {
         const { result } = renderHook(() =>
-            useFormatNetworkData({
-                formatData: undefined,
-                displayWeighted: true,
-            }),
+            useFormatNetworkData({ formatData: d, displayWeighted: true }),
         );
 
         expect(result.current).toEqual({ nodes: [], links: [] });
     });
 
-    it('filters out entries without source or target', () => {
-        const data: NetworkData[] = [
-            { source: 'A', target: 'B', weight: 1 },
-            // invalid entries
-            { source: '', target: 'C', weight: 2 } as unknown as NetworkData,
-            { source: 'D', target: '', weight: 3 } as unknown as NetworkData,
-        ];
+    it.each([
+        {
+            label: 'missing source',
+            invalid: {
+                source: '',
+                target: 'C',
+                weight: 2,
+            } as unknown as NetworkData,
+        },
+        {
+            label: 'missing target',
+            invalid: {
+                source: 'D',
+                target: '',
+                weight: 3,
+            } as unknown as NetworkData,
+        },
+    ])(
+        'filters out entries without source or target ($label)',
+        ({ invalid }) => {
+            const data: NetworkData[] = [
+                { source: 'A', target: 'B', weight: 1 },
+                invalid,
+            ];
 
-        const { result } = renderHook(() =>
-            useFormatNetworkData({ formatData: data, displayWeighted: true }),
-        );
+            const { result } = renderHook(() =>
+                useFormatNetworkData({
+                    formatData: data,
+                    displayWeighted: true,
+                }),
+            );
 
-        expect(result.current.nodes.length).toBe(2);
-        expect(result.current.links.length).toBe(1);
+            expect(result.current.nodes.length).toBe(2);
+            expect(result.current.links.length).toBe(1);
 
-        const nodeIds = new Set(result.current.nodes.map((n) => String(n.id)));
-        expect(nodeIds).toEqual(new Set(['A', 'B']));
-    });
+            const nodeIds = new Set(
+                result.current.nodes.map((n) => String(n.id)),
+            );
+            expect(nodeIds).toEqual(new Set(['A', 'B']));
+        },
+    );
 
     it('builds nodes with neighbors and links, and scales values monotonically', () => {
         const data: NetworkData[] = [
@@ -145,5 +168,58 @@ describe('useFormatNetworkData', () => {
 
         expect(result.current.nodes).toHaveLength(3);
         expect(result.current.links).toHaveLength(2);
+    });
+
+    it('uses radius=1 for nodes and value=1 for links when displayWeighted is false', () => {
+        const data: NetworkData[] = [
+            { source: 'A', target: 'B', weight: 1 },
+            { source: 'A', target: 'C', weight: 10 },
+            { source: 'B', target: 'C', weight: 5 },
+        ];
+
+        const { result } = renderHook(() =>
+            useFormatNetworkData({ formatData: data, displayWeighted: false }),
+        );
+
+        const graph = result.current as NonNullable<UseFormatNetworkDataReturn>;
+
+        // All nodes should have radius exactly 1
+        for (const n of graph.nodes) {
+            expect(n.radius).toBe(1);
+        }
+
+        // All links should have value exactly 1
+        for (const l of graph.links) {
+            expect(l.value).toBe(1);
+        }
+    });
+
+    it('recomputes when toggling displayWeighted', () => {
+        const data: NetworkData[] = [
+            { source: 'A', target: 'B', weight: 1 },
+            { source: 'A', target: 'C', weight: 3 },
+        ];
+
+        const { result, rerender } = renderHook(
+            ({ weighted }) =>
+                useFormatNetworkData({
+                    formatData: data,
+                    displayWeighted: weighted,
+                }),
+            { initialProps: { weighted: false } },
+        );
+
+        // Non weighted: all ones
+        expect(result.current.nodes.every((n) => n.radius === 1)).toBe(true);
+        expect(result.current.links.every((l) => l.value === 1)).toBe(true);
+
+        // Toggle to weighted
+        rerender({ weighted: true });
+
+        // Weighted: at least one node should not be 1 (A has higher degree), and link values should not all be 1
+        const radii = result.current.nodes.map((n) => n.radius as number);
+        expect(radii.some((r) => r !== 1)).toBe(true);
+        const values = result.current.links.map((l) => l.value as number);
+        expect(values.some((v) => v !== 1)).toBe(true);
     });
 });

--- a/packages/frontend-common/formats/chart/network/useFormatNetworkData.tsx
+++ b/packages/frontend-common/formats/chart/network/useFormatNetworkData.tsx
@@ -9,6 +9,7 @@ import type {
 
 export function useFormatNetworkData({
     formatData,
+    displayWeighted = true,
 }: UseFormatNetworkDataParams) {
     return useMemo(() => {
         if (!formatData) {
@@ -57,7 +58,7 @@ export function useFormatNetworkData({
         const links = sanitizedFormatData.map(({ source, target, weight }) => ({
             source,
             target,
-            value: linkScale(weight),
+            value: displayWeighted ? linkScale(weight) : 1,
         }));
 
         links.forEach((link) => {
@@ -93,11 +94,11 @@ export function useFormatNetworkData({
         return {
             nodes: nodes.map((node) => ({
                 ...node,
-                radius: nodeScale(node.radius),
+                radius: displayWeighted ? nodeScale(node.radius) : 1,
             })),
             links,
         };
-    }, [formatData]);
+    }, [formatData, displayWeighted]);
 }
 
 export type NetworkData = {

--- a/packages/frontend-common/formats/chart/network/useFormatNetworkData.tsx
+++ b/packages/frontend-common/formats/chart/network/useFormatNetworkData.tsx
@@ -1,0 +1,119 @@
+import { scaleLinear } from 'd3-scale';
+import { get } from 'lodash';
+import { useMemo } from 'react';
+import type {
+    ForceGraphProps,
+    LinkObject,
+    NodeObject,
+} from 'react-force-graph-2d';
+
+export function useFormatNetworkData({
+    formatData,
+}: UseFormatNetworkDataParams) {
+    return useMemo(() => {
+        if (!formatData) {
+            return {
+                nodes: [],
+                links: [],
+            };
+        }
+        const sanitizedFormatData = formatData.filter(
+            ({ source, target }) => source && target,
+        );
+
+        const nodesDic = sanitizedFormatData.reduce<Record<string, Node>>(
+            (acc, { source, target }) => ({
+                ...acc,
+                [source]: {
+                    id: source,
+                    label: source,
+                    radius: get(acc, [source, 'radius'], 0) + 1,
+                },
+                [target]: {
+                    id: target,
+                    label: target,
+                    radius: get(acc, [target, 'radius'], 0) + 1,
+                },
+            }),
+            {},
+        );
+
+        const nodes = Object.values(nodesDic);
+        const radiusList = nodes.map(({ radius }) => radius);
+        const max = Math.max(...radiusList);
+        const min = Math.min(...radiusList);
+
+        const nodeScale = scaleLinear().domain([min, max]).range([1, 10]);
+
+        const weightList = sanitizedFormatData.map(({ weight }) => weight);
+
+        const maxWeight = Math.max(...weightList);
+        const minWeight = Math.min(...weightList);
+
+        const linkScale = scaleLinear()
+            .domain([minWeight, maxWeight])
+            .range([1, 20]);
+
+        const links = sanitizedFormatData.map(({ source, target, weight }) => ({
+            source,
+            target,
+            value: linkScale(weight),
+        }));
+
+        links.forEach((link) => {
+            const a = nodes.find((node) => node.id === link.source);
+            const b = nodes.find((node) => node.id === link.target);
+            if (!a || !b) {
+                console.warn('Node not found for link', link);
+                return;
+            }
+
+            if (!a.neighbors) {
+                a.neighbors = [];
+            }
+
+            if (!b.neighbors) {
+                b.neighbors = [];
+            }
+
+            a.neighbors.push(b);
+            b.neighbors.push(a);
+
+            if (!a.links) {
+                a.links = [];
+            }
+
+            if (!b.links) {
+                b.links = [];
+            }
+            a.links.push(link);
+            b.links.push(link);
+        });
+
+        return {
+            nodes: nodes.map((node) => ({
+                ...node,
+                radius: nodeScale(node.radius),
+            })),
+            links,
+        };
+    }, [formatData]);
+}
+
+export type NetworkData = {
+    source: string;
+    target: string;
+    weight: number;
+};
+
+export type UseFormatNetworkDataParams = {
+    formatData?: NetworkData[];
+    displayWeighted: boolean;
+};
+
+export type UseFormatNetworkDataReturn = ForceGraphProps['graphData'];
+export type NodeType = {
+    neighbors?: NodeObject<NodeType>[];
+    links?: LinkObject<NodeType, Record<string, unknown>>[];
+};
+export type Node = NodeObject<NodeType>;

--- a/packages/frontend-common/formats/chart/network/useFormatNetworkData.tsx
+++ b/packages/frontend-common/formats/chart/network/useFormatNetworkData.tsx
@@ -55,11 +55,13 @@ export function useFormatNetworkData({
             .domain([minWeight, maxWeight])
             .range([1, 20]);
 
-        const links = sanitizedFormatData.map(({ source, target, weight }) => ({
-            source,
-            target,
-            value: displayWeighted ? linkScale(weight) : 1,
-        }));
+        const links = sanitizedFormatData.map<Link>(
+            ({ source, target, weight }) => ({
+                source,
+                target,
+                value: displayWeighted ? linkScale(weight) : 1,
+            }),
+        );
 
         links.forEach((link) => {
             const a = nodes.find((node) => node.id === link.source);
@@ -113,8 +115,16 @@ export type UseFormatNetworkDataParams = {
 };
 
 export type UseFormatNetworkDataReturn = ForceGraphProps['graphData'];
+
 export type NodeType = {
-    neighbors?: NodeObject<NodeType>[];
-    links?: LinkObject<NodeType, Record<string, unknown>>[];
+    neighbors?: Node[];
+    links?: Link[];
+    radius: number;
 };
+
+export type LinkType = {
+    value: number;
+};
+
 export type Node = NodeObject<NodeType>;
+export type Link = LinkObject<NodeType, LinkType>;

--- a/packages/frontend-common/formats/injectData.tsx
+++ b/packages/frontend-common/formats/injectData.tsx
@@ -1,15 +1,15 @@
-import { useState, useEffect, useCallback, memo, useMemo } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import { useLocation } from 'react-router';
 import get from 'lodash/get';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useLocation } from 'react-router';
 
-import Loading from '../components/Loading';
-import InvalidFormat from './InvalidFormat';
 import { CircularProgress } from '@mui/material';
-import { useTranslate } from '../i18n/I18NContext';
 import { isEqual } from 'lodash';
-import type { Field } from '../fields/types';
 import { createAction } from 'redux-actions';
+import Loading from '../components/Loading';
+import type { Field } from '../fields/types';
+import { useTranslate } from '../i18n/I18NContext';
+import InvalidFormat from './InvalidFormat';
 
 // redeclaring action reactors here to avoid moving every reducer inside frontend-common
 // Nice to have: refactor to use react-query
@@ -197,7 +197,6 @@ export default (url = null, checkFormatLoaded = null, withUri = false) =>
             if (formatError) {
                 return formatError === 'bad value' ? (
                     <InvalidFormat
-                        // @ts-expect-error TS18046
                         format={field.format}
                         // @ts-expect-error TS7053
                         value={resource[field.name]}

--- a/packages/frontend-common/formats/text/latex/LatexView.tsx
+++ b/packages/frontend-common/formats/text/latex/LatexView.tsx
@@ -3,8 +3,8 @@ import katex from 'katex';
 import Helmet from 'react-helmet';
 import InvalidFormat from '../../InvalidFormat';
 
-import stylesToClassname from '../../../utils/stylesToClassName';
 import type { Field } from '../../../fields/types';
+import stylesToClassname from '../../../utils/stylesToClassName';
 
 const styles = stylesToClassname(
     {
@@ -59,7 +59,6 @@ const LatexView = ({ resource, field }: LatexViewProps) => {
             )
             .join('');
     } catch (e) {
-        // @ts-expect-error TS18046
         return <InvalidFormat format={field.format} value={value} />;
     }
 

--- a/packages/frontend-common/formats/text/markdown/modal/MarkdownModalView.tsx
+++ b/packages/frontend-common/formats/text/markdown/modal/MarkdownModalView.tsx
@@ -1,17 +1,17 @@
+import CloseIcon from '@mui/icons-material/Close';
+import Button from '@mui/material/Button';
+import Container from '@mui/material/Container';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import IconButton from '@mui/material/IconButton';
 // @ts-expect-error TS7016
 import MarkdownIt from 'markdown-it';
 import { useMemo, useState } from 'react';
-import Button from '@mui/material/Button';
-import Dialog from '@mui/material/Dialog';
-import DialogTitle from '@mui/material/DialogTitle';
-import DialogContent from '@mui/material/DialogContent';
-import IconButton from '@mui/material/IconButton';
-import Container from '@mui/material/Container';
-import CloseIcon from '@mui/icons-material/Close';
 
+import type { Field } from '../../../../fields/types';
 import InvalidFormat from '../../../InvalidFormat';
 import getLabel from '../../../utils/getLabel';
-import type { Field } from '../../../../fields/types';
 
 const markdown = new MarkdownIt();
 
@@ -68,7 +68,6 @@ const MarkdownModalView = ({
     };
 
     if (content == null) {
-        // @ts-expect-error TS18046
         return <InvalidFormat format={field.format} value={value} />;
     }
 

--- a/packages/frontend-common/formats/text/markdown/simple/MarkdownView.tsx
+++ b/packages/frontend-common/formats/text/markdown/simple/MarkdownView.tsx
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 // @ts-expect-error TS7016
 import MarkdownIt from 'markdown-it';
 
-import InvalidFormat from '../../../InvalidFormat';
 import type { Field } from '../../../../fields/types';
+import InvalidFormat from '../../../InvalidFormat';
 
 const markdown = new MarkdownIt();
 
@@ -26,7 +26,6 @@ const MarkdownView = ({ className, resource, field }: MarkdownViewProps) => {
     }, [resource, field.name]);
 
     if (content == null) {
-        // @ts-expect-error TS18046
         return <InvalidFormat format={field.format} value={value} />;
     }
 

--- a/packages/frontend-common/formats/vega-lite/VegaLiteView.tsx
+++ b/packages/frontend-common/formats/vega-lite/VegaLiteView.tsx
@@ -1,19 +1,19 @@
+import { clamp } from 'lodash';
 import { useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
-import { clamp } from 'lodash';
 
+import type { Field } from '../../fields/types';
+import stylesToClassName from '../../utils/stylesToClassName';
 import InvalidFormat from '../InvalidFormat';
 import injectData from '../injectData';
-import { CustomActionVegaLite } from '../utils/components/vega-lite-component';
+import { useSizeObserver } from '../utils/chartsHooks';
 import {
     convertSpecTemplate,
     VEGA_ACTIONS_WIDTH,
     VEGA_LITE_DATA_INJECT_TYPE_A,
 } from '../utils/chartsUtils';
-import { useSizeObserver } from '../utils/chartsHooks';
-import stylesToClassName from '../../utils/stylesToClassName';
-import type { Field } from '../../fields/types';
+import { CustomActionVegaLite } from '../utils/components/vega-lite-component';
 
 // @ts-expect-error TS2554
 const styles = stylesToClassName({
@@ -54,7 +54,6 @@ const VegaLiteView = ({
     }, [specTemplate, width]);
 
     if (!spec) {
-        // @ts-expect-error TS18046
         return <InvalidFormat format={field.format} value={error} />;
     }
 

--- a/packages/frontend-common/formats/vega/component/radar-chart/RadarChartView.tsx
+++ b/packages/frontend-common/formats/vega/component/radar-chart/RadarChartView.tsx
@@ -2,18 +2,18 @@ import { useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 
-import { CustomActionVega } from '../../../utils/components/vega-component';
-import RadarChart from '../../models/RadarChart';
+import type { Field } from '../../../../fields/types';
+import injectData from '../../../injectData';
+import InvalidFormat from '../../../InvalidFormat';
+import { useSizeObserver } from '../../../utils/chartsHooks';
 import {
     convertSpecTemplate,
     lodexScaleToIdScale,
     VEGA_ACTIONS_WIDTH,
     VEGA_DATA_INJECT_TYPE_A,
 } from '../../../utils/chartsUtils';
-import InvalidFormat from '../../../InvalidFormat';
-import { useSizeObserver } from '../../../utils/chartsHooks';
-import injectData from '../../../injectData';
-import type { Field } from '../../../../fields/types';
+import { CustomActionVega } from '../../../utils/components/vega-component';
+import RadarChart from '../../models/RadarChart';
 
 const styles = {
     container: {
@@ -115,7 +115,6 @@ const RadarChartView = ({
     ]);
 
     if (spec === null) {
-        // @ts-expect-error TS18046
         return <InvalidFormat format={field.format} value={error} />;
     }
 

--- a/packages/public-app/src/characteristics/DatasetCharacteristics.tsx
+++ b/packages/public-app/src/characteristics/DatasetCharacteristics.tsx
@@ -1,15 +1,15 @@
 import { useSelector } from 'react-redux';
 
 import {
-    fromFields,
     fromCharacteristic,
+    fromFields,
 } from '@lodex/frontend-common/sharedSelectors';
 
-import DatasetCharacteristicItem from './DatasetCharacteristicItem';
-import { fromDisplayConfig } from '../selectors';
-import { useEffect, type CSSProperties } from 'react';
 import { useTranslate } from '@lodex/frontend-common/i18n/I18NContext';
+import { type CSSProperties } from 'react';
 import type { State } from '../reducers';
+import { fromDisplayConfig } from '../selectors';
+import DatasetCharacteristicItem from './DatasetCharacteristicItem';
 
 const styles: Record<string, CSSProperties> = {
     container: {
@@ -24,10 +24,6 @@ const styles: Record<string, CSSProperties> = {
 };
 
 const DatasetCharacteristicsView = () => {
-    console.log('DatasetCharacteristicsView render');
-    useEffect(() => {
-        console.log('DatasetCharacteristicsView mount useEffect');
-    }, []);
     const fields = useSelector(fromFields.getDatasetFields);
     const characteristics =
         useSelector((state: State) =>

--- a/src/app/custom/translations.tsv
+++ b/src/app/custom/translations.tsv
@@ -371,6 +371,7 @@
 "max_fields"	"Maximum number of fields"	"Nombre max de champs"
 "colors_set"	"Color set"	"Jeu de couleurs"
 "colors_string"	"String of color code"	"Chaîne de code couleur"
+"display_weighted"	"Display nodes and edges according to their weight"	"Afficher les noeuds et les relations selon leur poids"
 "Color"	"Color"	"Couleur"
 "user_can_interact_with_mouse_1"	"Use the mouse wheel to zoom in/out and"	"Utilisez la molette de la souris pour zoomer/dézoomer puis cliquez"
 "user_can_interact_with_mouse_2"	"click to move the chart"	"et faites glisser la souris pour déplacer le graphique."


### PR DESCRIPTION
https://github.com/user-attachments/assets/321e019c-e0c3-41ee-ac01-a64aab3e56eb

## Problem

Administrators wants to display a network graph without weights

## Solution

Add a toggle to select if a network graph should be displayed as weighted or not.

## How to Test

- `make start-dev`, then create an instance with dataset and model from `https://lodex-dev.inist.fr/instance/test-vbo-presta-copie`
- Go to Display > Graphs > Catégories WoS > Display and edit the format type, then unselect display by weight
- Go to the graph on front and check the result