### PR TITLE
New routine to generate gexf-json for resources with a tree structure…

### DIFF
--- a/config.json
+++ b/config.json
@@ -19,6 +19,7 @@
         "distinct-alpha-3-ISO639-from",
         "distinct-by-field",
         "distinct-by",
+        "hierarchy-by",
         "ventilate-by",
         "distinct-ISO3166-1-alpha2-from",
         "distinct-ISO3166-1-alpha3-from",

--- a/src/app/custom/routines/routines-catalog.json
+++ b/src/app/custom/routines/routines-catalog.json
@@ -204,6 +204,12 @@
         "recommendedWith": ["HierarchicalGraph"]
     },
     {
+        "id": "r-hierarchy-by",
+        "url": "/api/run/hierarchy-by/",
+        "doc": "https://www.lodex.fr/docs/documentation/principales-fonctionnalites-disponibles/les-routines-et-graphes/les-routines/#hierarchy-by",
+        "recommendedWith": []
+    },
+    {
         "id": "r-ventilate-by",
         "url": "/api/run/ventilate-by/",
         "doc": "https://www.lodex.fr/docs/documentation/principales-fonctionnalites-disponibles/les-routines-et-graphes/les-routines/#ventilate-by",

--- a/src/app/custom/translations.tsv
+++ b/src/app/custom/translations.tsv
@@ -921,6 +921,8 @@
 "r-distinct-alpha-3-ISO639-from_description"	"Transforms the ISO 3 codes of the languages of the represented field into verbalised headings."	"Transforme les codes ISO 3 des langues du champ représenté en intitulés verbalisés."
 "r-distinct-by_title"	"distinct-by"	"distinct-by"
 "r-distinct-by_description"	"Counts, for each element of the represented field (identifier), the number of times this element appears."	"Compte, pour chaque élément du champ représenté (identifiant), le nombre de fois où cet élément apparaît."
+"r-hierarchy-by_title"	"hierarchy-by"	"hierarchy-by"
+"r-hierarchy-by_description"	"For datasets with resources organized in a tree structure according to the parent reference model, this routine retrieves each resource's ascending hierarchy and only its own children (not its entire descending hierarchy)."	"Pour jeu de données avec des ressources organisées en arborescence selon le modèle de références parentales, cette routine récupère pour chaque ressource, sa hiérarchie ascendante, et uniquement propres enfants (et non toute sa hiérarchie descendante)"
 "r-ventilate-by_title"	"ventilate-by"	"ventilate-by"
 "r-ventilate-by_description"	"Counts, for multiple elements (source) and multiple values (target), the number of times each same element and same value appears"	"Compte, pour plusieurs éléments (source) et pour plusieurs valeurs (target), le nombre de fois où chaque même élément et même valeur apparaîent."
 "r-group-and-sum-with_title"	"group-and-sum-with"	"group-and-sum-with"

--- a/workers/routines/hierarchy-by.ini
+++ b/workers/routines/hierarchy-by.ini
@@ -1,0 +1,69 @@
+; For a document selected by a URI (otherwise the first one in the stream), and with two fields as parameters, we build a hierarchy with a parent link between the two fields.
+; Exemple d'URL http://localhost:3000/api/run/hierarchy-by/0yck/OEOA?maxSize=200&orderBy=value%2Fasc
+
+prepend = delegate?file=../worker.ini
+mimeType = application/json
+label = hierarchy
+
+[use]
+plugin = basics
+plugin = lodex
+plugin = analytics
+
+[env]
+path = connectionStringURI
+value = get('connectionStringURI')
+
+[buildContext]
+connectionStringURI = env('connectionStringURI')
+
+; On garde dans l'environnement quelques paramètres
+[env]
+path = minValue
+value = env('minValue').split('§').map(parseFloat).shift().defaultTo(0)
+
+path = maxValue
+value = env('maxValue').split('§').map(parseFloat).shift().defaultTo(1)
+
+path = maxSize
+value = env('maxSize').parseInt().defaultTo(10)
+
+path = reverse
+value = env('orderBy').split('/').get(1).replace('asc', 0).replace('desc', 1).parseInt()
+
+path = uri
+value = get('filter.uri')
+
+path = field
+value = get('field').castArray()
+
+; On récupére les documents filtrés
+[LodexAggregateQuery]
+stage = fix('$unwind: "$versions"')
+stage = fix(`$graphLookup: { from: "publishedDataset", startWith: "$versions.${env('field.0')}", connectFromField: "versions.${env('field.0')}", connectToField: "versions.${env('field.1')}", as: "parents" }`)
+stage = fix(`$lookup: { from: "publishedDataset", localField: "versions.${env('field.1')}", foreignField: "versions.${env('field.0')}", as: "enfants" }`)
+
+[replace]
+path = courant.id
+value = get('uri')
+
+path = courant.value.label
+value = get(`versions.${env('field.1')}`)
+
+path = courant.value.target
+value = get('enfants').map(x =>({ id: x.uri }))
+
+path = parents
+value = get('parents').map(x =>({id: x.uri, value : { label: _.get(x,`versions.0.${env('field.1')}`)}}))
+
+path = enfants
+value = get('enfants').map(x =>({id: x.uri, value: { label: _.get(x,`versions.0.${env('field.1')}`)}}))
+
+[exchange]
+value = get('parents').reduceRight((result, current, key) => { current.value.target = [{ id: result.at(-1).id }]; return [...result, current]; }, [self.courant]).concat(self.enfants)
+
+[ungroup]
+
+# On génére le json de sortie
+[LodexOutput]
+indent = true

--- a/workers/routines/hierarchy-by.ini
+++ b/workers/routines/hierarchy-by.ini
@@ -1,5 +1,6 @@
 ; For a document selected by a URI (otherwise the first one in the stream), and with two fields as parameters, we build a hierarchy with a parent link between the two fields.
-; Exemple d'URL http://localhost:3000/api/run/hierarchy-by/0yck/OEOA?maxSize=200&orderBy=value%2Fasc
+; Exemple d'URL http://localhost:3000/api/run/hierarchy-by/0yck/OEOA
+; Exemple d'URL http://localhost:3000/api/run/hierarchy-by/0yck/OEOA?uri=uid:/nGrpMScfa
 
 prepend = delegate?file=../worker.ini
 mimeType = application/json
@@ -19,6 +20,7 @@ connectionStringURI = env('connectionStringURI')
 
 ; On garde dans l'environnement quelques paramètres
 [env]
+; On garde dans l'environnement quelques paramètres
 path = minValue
 value = env('minValue').split('§').map(parseFloat).shift().defaultTo(0)
 
@@ -62,7 +64,7 @@ path = enfants
 value = get('enfants').map(x =>({id: x.uri, value: { label: _.get(x,`versions.0.${env('field.1')}`)}}))
 
 [exchange]
-value = get('parents').reduceRight((result, current, key) => { current.value.target = [{ id: result.at(-1).id }]; return [...result, current]; }, [self.courant]).concat(self.enfants)
+value = get('parents').reduceRight((result, current, key) => { const newcur = _.clone(current); _.set(newcur, 'value.target', [{ id: result.at(-1).id }]); return [...result, newcur]; }, [self.courant]).concat(self.enfants)
 
 [ungroup]
 
@@ -71,14 +73,30 @@ value = get('parents').reduceRight((result, current, key) => { current.value.tar
 
 [merging]
 
-
 [assign]
 path = value.label
-value = get('value.label').uniq()
+value = get('value.label').castArray().uniq().join('')
 
 path = value.target
 value = get('value.target').uniqBy('id')
 
+path = total
+value = env('total')
+
+path = maxSize
+value = env('maxSize')
+
+path = minValue
+value = env('minValue')
+
+path = maxValue
+value = env('maxValue')
+
+
 # On génére le json de sortie
 [LodexOutput]
 indent = true
+extract = total
+extract = maxSize
+extract = maxValue
+extract = minValue

--- a/workers/routines/hierarchy-by.ini
+++ b/workers/routines/hierarchy-by.ini
@@ -38,6 +38,8 @@ path = field
 value = get('field').castArray()
 
 ; On récupére les documents filtrés
+; Field.0 => identifiant du champ contenant la référence au parent, c'est-à-dire l'identifiant de la ressource liée hiérarchiquement
+; Field.1 => identifiant du champ contenant l'identifiant de la ressource
 [LodexAggregateQuery]
 stage = fix('$unwind: "$versions"')
 stage = fix(`$graphLookup: { from: "publishedDataset", startWith: "$versions.${env('field.0')}", connectFromField: "versions.${env('field.0')}", connectToField: "versions.${env('field.1')}", as: "parents" }`)
@@ -63,6 +65,19 @@ value = get('enfants').map(x =>({id: x.uri, value: { label: _.get(x,`versions.0.
 value = get('parents').reduceRight((result, current, key) => { current.value.target = [{ id: result.at(-1).id }]; return [...result, current]; }, [self.courant]).concat(self.enfants)
 
 [ungroup]
+
+# On regroupe les noeuds similaires
+[aggregate]
+
+[merging]
+
+
+[assign]
+path = value.label
+value = get('value.label').uniq()
+
+path = value.target
+value = get('value.target').uniqBy('id')
 
 # On génére le json de sortie
 [LodexOutput]


### PR DESCRIPTION
… of models with parent references


Cette routine  permet de produire un arbre hiérarchique à partir d'une ressource, en récupérant la hiérarchie ascendante et ses propres enfants. Utilisée sans filtre, elle récupère le même arbre pour chaque ressource.


Le format produit est un json-gexf cad une version GEXF transformé en JSON selon un règle adhoc, (comprendre avec perte)

## Format généré:

Exemple : 
```json
{
    "data": [
        {
            "id": "uid:/TKVPJCDVB",
            "value": [
                {
                    "label": "Ressource",
                    "target": []
                }
            ]
        },
        {
            "id": "uid:/nGrpMScfa",
            "value": [
                {
                    "label": "Ressource Parente",
                    "target": [
                        {
                            "id": "uid:/TKVPJCDVB"
                        }
                    ]
                }
            ]
        }
    ]
}

```  

# Usage


/api/run/hierarchy-by/REFERENCE_PARENT/IDENTIFIANT_RESSOURCE
/api/run/hierarchy-by/REFERENCE_PARENT/IDENTIFIANT_RESSOURCE?uri=uid:/nGrpMScfa


REFERENCE_PARENT = identifiant du champ contenant la référence au parent, c'est-à-dire l'identifiant de la ressource liée hiérarchiquement
REFERENCE_IDENTIFIANT = identifiant du champ contenant l'identifiant de la ressource


##  Instance pour tests

https://lodex-dev.inist.fr/instance/nico-termino

