### PR TITLE
Fix(precompute): It is now possible to launch a precompute from teh list

### DIFF
--- a/packages/frontend-common/components/ButtonWithConfirm.tsx
+++ b/packages/frontend-common/components/ButtonWithConfirm.tsx
@@ -16,7 +16,9 @@ export function ButtonWithConfirm({
 
     const [open, setOpen] = useState(false);
 
-    const handleOpen = () => {
+    const handleOpen = (e: MouseEvent<HTMLButtonElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
         setOpen(true);
     };
 


### PR DESCRIPTION
## Problem

Clicking on launch from the datagrid opens the details of the precompute instead of opening the modal

## Solution

Prevent event defaults and bubbles fromlaunch button