### PR TITLE
Fix(modclean): Keep enrichment configuration files

### DIFF
--- a/modclean.config.js
+++ b/modclean.config.js
@@ -58,9 +58,7 @@ module.exports = {
             '*fixture*',
             // ... glob patterns here
         ],
-        ignore: [
-            // ... glob patterns to ignore here
-        ],
+        ignore: ['**/services/enrichment/*.txt'],
     },
 
     modclean: {


### PR DESCRIPTION
Fixes [3119](https://github.com/Inist-CNRS/lodex/issues/3119)