### PR TITLE
inject syndication data if uri is found  in source or target fields

### DIFF
--- a/packages/ezsLodex/src/injectSyndicationFrom.ts
+++ b/packages/ezsLodex/src/injectSyndicationFrom.ts
@@ -29,8 +29,19 @@ export async function LodexInjectSyndicationFrom(
     data: any,
     feed: any,
 ) {
+    if (this.isLast()) {
+        return feed.close();
+    }
     const connectionStringURI = this.getParam('connectionStringURI');
-    if (this.isFirst()) {
+    const path = this.getParam('path', 'value');
+    const key = Array.isArray(path) ? path.shift() : path;
+    const uri = String(get(data, key, ''));
+
+    if (!uri.startsWith('uid:') && !uri.startsWith('ark:')) {
+        return feed.send(data);
+    }
+
+    if (!this.collection) {
         const db = await mongoDatabase(connectionStringURI);
         this.collection = db.collection('publishedDataset');
 
@@ -41,29 +52,35 @@ export async function LodexInjectSyndicationFrom(
             .toArray();
         this.titleFieldName = get(find(fields, { overview: 1 }), 'name');
         this.summaryFieldName = get(find(fields, { overview: 2 }), 'name');
+        this.detail1FieldName = get(find(fields, { overview: 3 }), 'name');
+        this.detail2FieldName = get(find(fields, { overview: 4 }), 'name');
+        this.subtitleFieldName = get(find(fields, { overview: 6 }), 'name');
         this.lru = new QuickLRU({ maxSize: 100 });
     }
-    if (this.isLast()) {
-        return feed.close();
-    }
-
-    const path = this.getParam('path', 'value');
-    const key = Array.isArray(path) ? path.shift() : path;
-    const uri = get(data, key);
     let title;
     let summary;
+    let detail1;
+    let detail2;
+    let subtitle;
     if (this.lru.has(uri)) {
-        [title, summary] = this.lru.get(uri);
+        [title, summary, detail1, detail2, subtitle] = this.lru.get(uri);
     } else {
         const docs = await this.collection.find({ uri }).toArray();
         const doc = get(docs.pop(), 'versions').shift();
         title = get(doc, this.titleFieldName);
         summary = get(doc, this.summaryFieldName);
-        this.lru.set(uri, [title, summary]);
+        detail1 = get(doc, this.detail1FieldName);
+        detail2 = get(doc, this.detail2FieldName);
+        subtitle = get(doc, this.subtitleFieldName);
+        this.lru.set(uri, [title, summary, detail1, detail2, subtitle]);
     }
 
     data[`${key}_title`] = title;
     data[`${key}_summary`] = summary;
+    data[`${key}_detail1`] = detail1;
+    data[`${key}_detail2`] = detail2;
+    data[`${key}_subtitle`] = subtitle;
+
     feed.send(data);
 }
 

--- a/packages/workers/src/routines/classif-by.ini
+++ b/packages/workers/src/routines/classif-by.ini
@@ -94,6 +94,10 @@ value = env('minValue')
 path = maxValue
 value = env('maxValue')
 
+[injectSyndicationFrom]
+connectionStringURI = env('connectionStringURI')
+path = target
+
 # On génére le json de sortie
 [LodexOutput]
 indent = true

--- a/packages/workers/src/routines/decompose-by.ini
+++ b/packages/workers/src/routines/decompose-by.ini
@@ -102,6 +102,10 @@ value = env('minValue')
 path = maxValue
 value = env('maxValue')
 
+[injectSyndicationFrom]
+connectionStringURI = env('connectionStringURI')
+path = target
+
 # On génére le json de sortie
 [LodexOutput]
 indent = true

--- a/packages/workers/src/routines/graph-by.ini
+++ b/packages/workers/src/routines/graph-by.ini
@@ -25,6 +25,10 @@ value = get('value.weight')
 path = total
 value = get('total')
 
+[injectSyndicationFrom]
+connectionStringURI = env('connectionStringURI')
+path = target
+
 [LodexOutput]
 indent = true
 extract = total

--- a/packages/workers/src/routines/hierarchy-by.ini
+++ b/packages/workers/src/routines/hierarchy-by.ini
@@ -18,8 +18,10 @@ value = get('connectionStringURI')
 [buildContext]
 connectionStringURI = env('connectionStringURI')
 
-; On garde dans l'environnement quelques paramètres
 [env]
+path = view
+value = env('view').thru(x => (x === 'label' ? 'label' : 'uri'))
+
 ; On garde dans l'environnement quelques paramètres
 path = minValue
 value = env('minValue').split('§').map(parseFloat).shift().defaultTo(0)
@@ -51,22 +53,21 @@ stage = fix(`$lookup: { from: "publishedDataset", localField: "versions.${env('f
 path = id
 value = get(`versions.${env('field.1')}`)
 
-
 [replace]
 path = id
 value = get('id')
 
 path = value
-value = get('enfants').map(x =>[self.id,_.get(x,`versions.0.${env('field.1')}`)])
+value = get('enfants').map(x =>[{uri:self.uri, label:self.id},{uri:x.uri, label:_.get(x,`versions.0.${env('field.1')}`)}])
 
 path = parentsA
-value = get('parents').sortBy(['profondeur']).reverse().map(x =>_.get(x,`versions.0.${env('field.1')}`))
+value = get('parents').sortBy(['profondeur']).reverse().map(x =>({uri: x.uri, label:_.get(x,`versions.0.${env('field.1')}`)}))
 
 path = parentsB
-value = get('parents').sortBy(['profondeur']).reverse().map(x =>_.get(x,`versions.0.${env('field.1')}`)).slice(1).concat(self.id)
+value = get('parents').sortBy(['profondeur']).reverse().map(x =>({uri: x.uri, label:_.get(x,`versions.0.${env('field.1')}`)})).slice(1).concat({uri: self.uri, label:self.id})
 
 [exchange]
-value = get('parentsA').zip(self.parentsB).concat(self.value).filter(y => (y[0] && y[1] && y[0] !== y[1])).map((x) => ({value:[x[0],x[1]], id: x.join('-')}))
+value = get('parentsA').zip(self.parentsB).concat(self.value).filter(y => (y[0] && y[1])).filter(y => (y[0].label && y[1].label && y[0].label !== y[1].label)).map((x) => ({value:[x[0],x[1]], id: `${x[0].label}-${x[1].label}`}))
 
 [ungroup]
 
@@ -75,10 +76,10 @@ path = id
 
 [replace]
 path = source
-value = get('value.0.0')
+value = get(`value.0.0.${env('view')}`)
 
 path = target
-value = get('value.0.1')
+value = get(`value.0.1.${env('view')}`)
 
 # Doit thériquement correspondre aux nombres de documents dans la hiérachie, (sauf pour le noeud de tete qui n'ai pas pris en compte)
 path = weight
@@ -96,6 +97,13 @@ value = env('minValue')
 path = maxValue
 value = env('maxValue')
 
+[injectSyndicationFrom]
+connectionStringURI = env('connectionStringURI')
+path = source
+
+[injectSyndicationFrom]
+connectionStringURI = env('connectionStringURI')
+path = target
 
 # On génére le json de sortie
 [LodexOutput]

--- a/packages/workers/src/routines/pairing-with.ini
+++ b/packages/workers/src/routines/pairing-with.ini
@@ -26,6 +26,10 @@ value = get('value.weight')
 path = total
 value = get('total')
 
+[injectSyndicationFrom]
+connectionStringURI = env('connectionStringURI')
+path = target
+
 [LodexOutput]
 indent = true
 extract = total

--- a/packages/workers/src/routines/ventilate-by.ini
+++ b/packages/workers/src/routines/ventilate-by.ini
@@ -31,6 +31,10 @@ value = get('value.weight')
 path = total
 value = get('total')
 
+[injectSyndicationFrom]
+connectionStringURI = env('connectionStringURI')
+path = target
+
 [LodexOutput]
 indent = true
 extract = total


### PR DESCRIPTION
Apply the technique used in the close-by routine to all routines.


Example :

```json
{
    "maxSize": 5000,
    "maxValue": 1,
    "minValue": 0,
    "data": [
        {
            "source": "uid:/rtDTDtt5Q",
            "target": "uid:/wxWhca9ZT",
            "weight": 1,
            "source_title": "ESPACE",
            "source_summary": "Ensembles complexes terrestres et célestes, biosphère, écosphère, galaxie",
            "source_detail1": "ESPA",
            "target_title": "Objet céleste",
            "target_summary": "Ensemble des objets présents dans l'univers",
            "target_detail1": "OBJC"
        },
        {
            "source": "uid:/rtDTDtt5Q",
            "target": "uid:/kV3JtzRdb",
            "weight": 2,
            "source_title": "ESPACE",
            "source_summary": "Ensembles complexes terrestres et célestes, biosphère, écosphère, galaxie",
            "source_detail1": "ESPA",
            "target_title": "Environnement",
            "target_summary": "Tout ce qui est lié à la structure et à l'organisation de l'espace \"naturel\" terrestre et de la biosphère, environnement, géographie physique et humaine.",
            "target_detail1": "ENVI"
        }
    ]
}
```

With the ability to enrich the results of precomputed, it becomes possible to create display information dedicated to visualization.  
