### PR TITLE
Revert "Bump vega-selections from 5.6.0 to 5.6.3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31752,30 +31752,24 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/vega-selections": {
-            "version": "5.6.3",
-            "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.6.3.tgz",
-            "integrity": "sha512-DXd+XVKcIjBAtSCcgtPx7cXuqG/7L98SWoFh6GKNu26EBUyn3zm0GAlZxNLPoI01Jz9Fb3YpSsewk2aIAbM68g==",
+            "version": "5.6.0",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "d3-array": "3.2.4",
-                "vega-expression": "^5.2.1",
-                "vega-util": "^1.17.4"
+                "vega-expression": "^5.2.0",
+                "vega-util": "^1.17.3"
             }
         },
         "node_modules/vega-selections/node_modules/vega-expression": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
-            "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
+            "version": "5.2.0",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@types/estree": "^1.0.0",
-                "vega-util": "^1.17.4"
+                "vega-util": "^1.17.3"
             }
         },
         "node_modules/vega-selections/node_modules/vega-util": {
-            "version": "1.17.4",
-            "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
-            "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
+            "version": "1.17.3",
             "license": "BSD-3-Clause"
         },
         "node_modules/vega-statistics": {


### PR DESCRIPTION
This reverts commit 42c8a570cad7fe45097aabcf662c5b96ae5eea9d.