### PR TITLE
Allow precomputed everywhere

### DIFF
--- a/packages/admin-app/src/fields/sourceValue/SourceValueToggle.tsx
+++ b/packages/admin-app/src/fields/sourceValue/SourceValueToggle.tsx
@@ -411,7 +411,7 @@ export const SourceValueToggle = ({
                     </Typography>
                 </ToggleButton>
 
-                <ToggleButton disabled={!arbitraryMode} value="precomputed">
+                <ToggleButton value="precomputed">
                     <ProcessingIcon style={{ fontSize: 50 }} />
                     <Typography variant="caption">
                         {translate('precomputed_processing')}


### PR DESCRIPTION
There is no obvious reason to limit access to pre-calculations only in graphs, so we allow it everywhere.