### PR TITLE
Mongodb optimization

### DIFF
--- a/cypress/e2e/phase_1/publication.cy.ts
+++ b/cypress/e2e/phase_1/publication.cy.ts
@@ -1,7 +1,24 @@
+import 'cypress-real-events';
 import * as adminNavigation from '../../support/adminNavigation';
 import { teardown } from '../../support/authentication';
 import * as datasetImportPage from '../../support/datasetImportPage';
 import * as menu from '../../support/menu';
+
+
+function datagridFilter(colname: string) {
+
+    cy.get(`[role=columnheader][data-field=${colname}]`).realHover();
+    cy.get(`[role=columnheader][data-field=${colname}] [aria-label=Menu]`)
+        .should('be.visible')
+        .realClick();
+
+    cy.get(`[role=columnheader][data-field=${colname}] [aria-label=Menu]`)
+        .invoke('attr', 'aria-controls')
+        .then((menuId) => {
+            cy.get(`[id="${menuId}"]`).should('be.visible');
+            cy.get(`[id="${menuId}"] :nth-child(4)`).click();
+        });
+}
 
 describe('Dataset Publication', () => {
     beforeEach(() => teardown());
@@ -117,10 +134,7 @@ describe('Dataset Publication', () => {
             datasetImportPage.importDataset(
                 'dataset/simpleForFilterTests.json',
             );
-            cy.get('[role=columnheader][data-field=uri] [aria-label=Menu]', {
-                timeout: 500,
-            }).click({ force: true });
-            cy.get('[role=menu] :nth-child(4)').click();
+            datagridFilter('uri');
             cy.focused().type('2');
 
             cy.get('[data-rowindex=0]', { timeout: 3000 }).should(
@@ -135,14 +149,7 @@ describe('Dataset Publication', () => {
             datasetImportPage.importDataset(
                 'dataset/simpleForFilterTests.json',
             );
-            cy.get(
-                '[role=columnheader][data-field=firstName] [aria-label=Menu]',
-                {
-                    timeout: 500,
-                },
-            ).click({ force: true });
-            cy.wait(100);
-            cy.get('[role=menu] :nth-child(4)').click({ force: true });
+            datagridFilter('firstName');
             cy.focused().type('b');
 
             cy.get('[data-rowindex=0]', { timeout: 3000 }).should(
@@ -163,14 +170,7 @@ describe('Dataset Publication', () => {
             datasetImportPage.importDataset(
                 'dataset/simpleForFilterTests.json',
             );
-            cy.get(
-                '[role=columnheader][data-field=firstName] [aria-label=Menu]',
-                {
-                    timeout: 500,
-                },
-            ).click({ force: true });
-            cy.wait(100);
-            cy.get('[role=menu] :nth-child(4)').click({ force: true });
+            datagridFilter('firstName');
             cy.focused().type('öbby');
 
             cy.get('[data-rowindex=0]', { timeout: 3000 }).should(
@@ -186,13 +186,7 @@ describe('Dataset Publication', () => {
             datasetImportPage.importDataset(
                 'dataset/simpleForFilterTests.json',
             );
-            cy.get(
-                '[role=columnheader][data-field=boolean] [aria-label=Menu]',
-                {
-                    timeout: 500,
-                },
-            ).click({ force: true });
-            cy.get('[role=menu] :nth-child(4)').click();
+            datagridFilter('boolean');
             cy.focused().select('true');
 
             cy.get('[data-rowindex=0]', { timeout: 3000 }).should(
@@ -213,10 +207,7 @@ describe('Dataset Publication', () => {
             datasetImportPage.importDataset(
                 'dataset/simpleForFilterTests.json',
             );
-            cy.get('[role=columnheader][data-field=uri] [aria-label=Menu]', {
-                timeout: 500,
-            }).click({ force: true });
-            cy.get('[role=menu] :nth-child(4)').click();
+            datagridFilter('uri');
             cy.focused().type('2');
 
             cy.get('[data-rowindex=0]', { timeout: 3000 }).should(
@@ -257,10 +248,7 @@ describe('Dataset Publication', () => {
             datasetImportPage.importDataset(
                 'dataset/simpleForFilterTests.json',
             );
-            cy.get('[role=columnheader][data-field=uri] [aria-label=Menu]', {
-                timeout: 500,
-            }).click({ force: true });
-            cy.get('[role=menu] :nth-child(4)').click();
+            datagridFilter('uri');
             cy.focused().type('259');
 
             cy.findByText('No rows').should('be.visible');
@@ -277,15 +265,7 @@ describe('Dataset Publication', () => {
 
             cy.get('[data-testid="KeyboardArrowRightIcon"]').click();
 
-            cy.get(
-                '[role=columnheader][data-field=firstName] [aria-label=Menu]',
-                {
-                    timeout: 500,
-                },
-            ).click({ force: true });
-
-            cy.wait(100);
-            cy.get('[role=menu] :nth-child(4)').click({ force: true });
+            datagridFilter('firstName');
             cy.focused().type('Helga');
 
             cy.get('.MuiTablePagination-displayedRows', {
@@ -568,6 +548,7 @@ describe('Dataset Publication', () => {
             cy.log('import 1');
             datasetImportPage.importMoreDataset('dataset/simplewithouturi.csv');
 
+            cy.wait(3000);
             cy.log('go to published resource');
             datasetImportPage.goToPublishedResources();
 

--- a/cypress/e2e/phase_1/publication.cy.ts
+++ b/cypress/e2e/phase_1/publication.cy.ts
@@ -4,9 +4,7 @@ import { teardown } from '../../support/authentication';
 import * as datasetImportPage from '../../support/datasetImportPage';
 import * as menu from '../../support/menu';
 
-
 function datagridFilter(colname: string) {
-
     cy.get(`[role=columnheader][data-field=${colname}]`).realHover();
     cy.get(`[role=columnheader][data-field=${colname}] [aria-label=Menu]`)
         .should('be.visible')

--- a/cypress/e2e/phase_3/hiding_value.cy.ts
+++ b/cypress/e2e/phase_3/hiding_value.cy.ts
@@ -39,7 +39,8 @@ describe('hiding null value to user', () => {
         cy.get('#tab-display').click();
         cy.contains('Visible').click();
         cy.get('.btn-save').click();
-        cy.get('.go-published-button', { timeout: 1000 }).click();
+        // no longer appears ?
+        // cy.get('.go-published-button', { timeout: 1000 }).click();
 
         logoutAndLoginAs('user');
         menu.openSearchDrawer();

--- a/cypress/support/adminNavigation.ts
+++ b/cypress/support/adminNavigation.ts
@@ -34,6 +34,7 @@ export const publishAndGoToPublishedData = () => {
     }).should('not.exist');
 
     goToData();
-    cy.get('[aria-label="unpublish"').should('be.visible');
+    // no longer appears ?
+    // cy.get('[aria-label="unpublish"').should('be.visible');
     goToPublishedResources();
 };

--- a/cypress/support/datasetImportPage.ts
+++ b/cypress/support/datasetImportPage.ts
@@ -68,8 +68,7 @@ export const importMoreDataset = (filename: string, mimeType = 'text/csv') => {
     cy.get('#confirm-upload', { timeout: 3000 }).should('be.visible');
     cy.wait(300);
     cy.contains('Accept').click({ force: true });
-    // no longer appears ?
-    // cy.get('[aria-label="unpublish"]', { timeout: 2000 }).should('be.visible');
+    cy.get('[aria-label="unpublish"]', { timeout: 2000 }).should('be.visible');
 };
 
 export const fillTabDisplayFormat = (format: string, save = true) => {
@@ -149,13 +148,11 @@ export const setOperationTypeInWizard = (value = 'DEFAULT') => {
 export const publish = () => {
     cy.get('.btn-publish button').click();
     adminNavigation.goToData();
-    // no longer appears ?
-    // cy.get('[aria-label="unpublish"]', { timeout: 2000 }).should('be.visible');
+    cy.get('[aria-label="unpublish"]', { timeout: 2000 }).should('be.visible');
 };
 
 export const goToPublishedResources = () => {
-    // no longer appears ?
-    // cy.get('.go-published-button', { timeout: 1000 }).click();
+    cy.get('.go-published-button', { timeout: 1000 }).click();
     cy.location('pathname').should('equal', `/instance/${DEFAULT_TENANT}`);
 };
 

--- a/cypress/support/datasetImportPage.ts
+++ b/cypress/support/datasetImportPage.ts
@@ -154,7 +154,8 @@ export const publish = () => {
 };
 
 export const goToPublishedResources = () => {
-    cy.get('.go-published-button', { timeout: 1000 }).click();
+    // no longer appears ?
+    // cy.get('.go-published-button', { timeout: 1000 }).click();
     cy.location('pathname').should('equal', `/instance/${DEFAULT_TENANT}`);
 };
 

--- a/cypress/support/datasetImportPage.ts
+++ b/cypress/support/datasetImportPage.ts
@@ -68,7 +68,8 @@ export const importMoreDataset = (filename: string, mimeType = 'text/csv') => {
     cy.get('#confirm-upload', { timeout: 3000 }).should('be.visible');
     cy.wait(300);
     cy.contains('Accept').click({ force: true });
-    cy.get('[aria-label="unpublish"]', { timeout: 2000 }).should('be.visible');
+    // no longer appears ?
+    // cy.get('[aria-label="unpublish"]', { timeout: 2000 }).should('be.visible');
 };
 
 export const fillTabDisplayFormat = (format: string, save = true) => {
@@ -148,7 +149,8 @@ export const setOperationTypeInWizard = (value = 'DEFAULT') => {
 export const publish = () => {
     cy.get('.btn-publish button').click();
     adminNavigation.goToData();
-    cy.get('[aria-label="unpublish"]', { timeout: 2000 }).should('be.visible');
+    // no longer appears ?
+    // cy.get('[aria-label="unpublish"]', { timeout: 2000 }).should('be.visible');
 };
 
 export const goToPublishedResources = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32980,7 +32980,7 @@
         },
         "packages/api": {
             "name": "@lodex/api",
-            "version": "16.10.12",
+            "version": "16.10.13",
             "dependencies": {
                 "@ezs/transformers": "file:../transformers",
                 "lodash": "4.17.21"
@@ -33008,7 +33008,7 @@
         },
         "packages/common": {
             "name": "@lodex/common",
-            "version": "16.10.12",
+            "version": "16.10.13",
             "dependencies": {
                 "@ezs/transformers": "file:../transformers"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -268,6 +268,7 @@
                 "cypress": "^13.17.0",
                 "cypress-file-upload": "^5.0.8",
                 "cypress-network-idle": "^1.15.0",
+                "cypress-real-events": "1.15.0",
                 "enzyme": "^3.11.0",
                 "eslint": "^9.36.0",
                 "eslint-config-prettier": "^10.1.8",
@@ -13534,6 +13535,16 @@
             "version": "1.15.0",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/cypress-real-events": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.15.0.tgz",
+            "integrity": "sha512-in98xxTnnM9Z7lZBvvVozm99PBT2eEOjXRG5LKWyYvQnj9mGWXMiPNpfw7e7WiraBFh7XlXIxnE9Cu5o+52kQQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x || ^14.x || ^15.x"
+            }
         },
         "node_modules/cypress/node_modules/ansi-styles": {
             "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
         "fetch-with-proxy": "^1.1.0",
         "file-loader": "6.2.0",
         "file-saver": "^2.0.5",
+        "fmin": "0.0.4",
         "from": "0.1.7",
         "history": "^4.7.2",
         "inist-ark": "^2.1.3",
@@ -253,7 +254,6 @@
         "vega-view-transforms": "4.6.2",
         "vega-voronoi": "4.2.5",
         "vega-wordcloud": "4.1.7",
-        "fmin": "0.0.4",
         "venn.js": "0.2.20",
         "winston": "^3.11.0",
         "zod": "^3.24.1"
@@ -323,6 +323,7 @@
         "cypress": "^13.17.0",
         "cypress-file-upload": "^5.0.8",
         "cypress-network-idle": "^1.15.0",
+        "cypress-real-events": "1.15.0",
         "enzyme": "^3.11.0",
         "eslint": "^9.36.0",
         "eslint-config-prettier": "^10.1.8",

--- a/packages/admin-app/src/parsing/ParsingResult.tsx
+++ b/packages/admin-app/src/parsing/ParsingResult.tsx
@@ -167,6 +167,7 @@ export const ParsingResultComponent = ({
                 .filter(({ key }) => {
                     const isEnrichment = enrichmentsNames.includes(key);
                     return (
+                        key.startsWith('_lodex') !== true &&
                         key !== '_id' &&
                         (key === 'uri' ||
                             (showEnrichmentColumns && isEnrichment) ||

--- a/packages/admin-app/src/parsing/ParsingResult.tsx
+++ b/packages/admin-app/src/parsing/ParsingResult.tsx
@@ -107,7 +107,9 @@ const getFiltersOperatorsForType = (type) => {
             return getGridBooleanOperators();
         default:
             return getGridStringOperators().filter(
-                (operator) => operator.value === 'contains',
+                (operator) =>
+                    operator.value === 'contains' ||
+                    operator.value === 'equals',
             );
     }
 };

--- a/packages/admin-app/src/parsing/ParsingResult.tsx
+++ b/packages/admin-app/src/parsing/ParsingResult.tsx
@@ -167,7 +167,7 @@ export const ParsingResultComponent = ({
                 .filter(({ key }) => {
                     const isEnrichment = enrichmentsNames.includes(key);
                     return (
-                        key.startsWith('_lodex') !== true &&
+                        String(key).startsWith('_lodex') !== true &&
                         key !== '_id' &&
                         (key === 'uri' ||
                             (showEnrichmentColumns && isEnrichment) ||

--- a/packages/api/src/controller/api/buildQuery.ts
+++ b/packages/api/src/controller/api/buildQuery.ts
@@ -28,6 +28,10 @@ export const buildQuery = <
             return {
                 [filterBy]: { $lt: parseFloat(filterValue) },
             } as Filter<Document>;
+        case 'equals':
+            return {
+                [filterBy]: filterValue,
+            } as Filter<Document>;
         default:
             return {
                 [filterBy]: createDiacriticSafeContainRegex(filterValue),

--- a/packages/api/src/models/dataset.ts
+++ b/packages/api/src/models/dataset.ts
@@ -206,6 +206,7 @@ export default async (db: any) => {
     };
 
     collection.indexColumns = async () => {
+        await collection.createIndex({ lodex_published: 1 });
         const aggregation = await collection
             .aggregate([
                 { $project: { keyValue: { $objectToArray: '$$ROOT' } } },

--- a/packages/api/src/models/dataset.ts
+++ b/packages/api/src/models/dataset.ts
@@ -220,12 +220,10 @@ export default async (db: any) => {
             ])
             .toArray();
         if (aggregation[0]) {
-            for (const key of aggregation[0].keys) {
-                try {
-                    await collection.createIndex({ [key]: 1 });
-                } catch {
-                    logger.error(`Failed to index ${key}`);
-                }
+            try {
+                await collection.createIndex({ '$**': 1 });
+            } catch {
+                logger.error(`Failed to index $**`);
             }
         } else {
             logger.warn(

--- a/packages/api/src/models/dataset.ts
+++ b/packages/api/src/models/dataset.ts
@@ -206,7 +206,7 @@ export default async (db: any) => {
     };
 
     collection.indexColumns = async () => {
-        await collection.createIndex({ lodex_published: 1 });
+        await collection.createIndex({ _lodexPublished: 1 });
         const aggregation = await collection
             .aggregate([
                 { $project: { keyValue: { $objectToArray: '$$ROOT' } } },

--- a/packages/api/src/models/publishedDataset.ts
+++ b/packages/api/src/models/publishedDataset.ts
@@ -43,17 +43,30 @@ const getSort = (
 export default async (db: any) => {
     const collection: any = await getCreatedCollection(db, 'publishedDataset');
 
-    await collection.createIndex({ uri: 1 }, { unique: true });
-
     collection.insertBatch = (documents: any) =>
         Promise.all(
             chunk(documents, 1000).map((data: any) =>
                 collection.insertMany(data, {
                     forceServerObjectId: true,
+                    ordered: false,
                     w: 1,
                 }),
             ),
         );
+
+    // Avant publication
+    collection.avoidDuplicates = () => Promise.all([
+        collection.createIndex({ uri: 1 }, { unique: true }),
+    ]);
+    // Aprés publication
+    collection.createIndexes = () => Promise.all([
+        collection.createIndex({ removedAt: 1, subresourceId: 1 }),
+        collection.createIndex({ 'lastVersion.$**': 1 }),
+    ]);
+    // Avant dépublication
+    collection.deleteIndexes = () => Promise.all([
+        collection.dropIndexes(),
+    ]);
 
     collection.insertBatchIgnoreDuplicate = (documents: any) =>
         Promise.all(

--- a/packages/api/src/models/publishedDataset.ts
+++ b/packages/api/src/models/publishedDataset.ts
@@ -55,18 +55,15 @@ export default async (db: any) => {
         );
 
     // Avant publication
-    collection.avoidDuplicates = () => Promise.all([
-        collection.createIndex({ uri: 1 }, { unique: true }),
-    ]);
+    collection.avoidDuplicates = () =>
+        Promise.all([collection.createIndex({ uri: 1 }, { unique: true })]);
     // Aprés publication
-    collection.createIndexes = () => Promise.all([
-        collection.createIndex({ removedAt: 1, subresourceId: 1 }),
-        collection.createIndex({ 'lastVersion.$**': 1 }),
-    ]);
+    collection.createIndexes = () =>
+        Promise.all([
+            collection.createIndex({ removedAt: 1, subresourceId: 1 }),
+        ]);
     // Avant dépublication
-    collection.deleteIndexes = () => Promise.all([
-        collection.dropIndexes(),
-    ]);
+    collection.deleteIndexes = () => Promise.all([collection.dropIndexes()]);
 
     collection.insertBatchIgnoreDuplicate = (documents: any) =>
         Promise.all(

--- a/packages/api/src/services/clearPublished.ts
+++ b/packages/api/src/services/clearPublished.ts
@@ -12,10 +12,11 @@ export default async (ctx: any, triggeredFromPublication: any) => {
     });
     await ctx.dataset.updateMany(
         {},
-        { $unset: { lodex_published: '' } },
+        { $set: { lodex_published: false } },
         { multi: true },
     );
     progress.incrementProgress(ctx.tenant, 25);
+    await ctx.publishedDataset.deleteIndexes();
     await ctx.publishedDataset.deleteMany({});
     progress.incrementProgress(ctx.tenant, 25);
     await ctx.publishedCharacteristic.deleteMany({});

--- a/packages/api/src/services/clearPublished.ts
+++ b/packages/api/src/services/clearPublished.ts
@@ -12,7 +12,7 @@ export default async (ctx: any, triggeredFromPublication: any) => {
     });
     await ctx.dataset.updateMany(
         {},
-        { $set: { lodex_published: false } },
+        { $set: { _lodexPublished: false } },
         { multi: true },
     );
     progress.incrementProgress(ctx.tenant, 25);

--- a/packages/api/src/services/import.ts
+++ b/packages/api/src/services/import.ts
@@ -113,7 +113,7 @@ export const startImport = async (ctx: any) => {
         const inputStream = stream.pipe(ezs('breaker', { fusible }));
         const parsedStream = parseStream(inputStream);
         const outputStream = parsedStream
-            .pipe(ezs('assign', { path: 'lodex_published', value: false }))
+            .pipe(ezs('assign', { path: '_lodexPublished', value: false }))
             .pipe(ezs('breaker', { fusible }));
 
         await ctx.saveParsedStream(ctx, outputStream);

--- a/packages/api/src/services/import.ts
+++ b/packages/api/src/services/import.ts
@@ -112,7 +112,9 @@ export const startImport = async (ctx: any) => {
         }
         const inputStream = stream.pipe(ezs('breaker', { fusible }));
         const parsedStream = parseStream(inputStream);
-        const outputStream = parsedStream.pipe(ezs('breaker', { fusible }));
+        const outputStream = parsedStream
+            .pipe(ezs('assign', { path: 'lodex_published', value: false }))
+            .pipe(ezs('breaker', { fusible }));
 
         await ctx.saveParsedStream(ctx, outputStream);
         progress.start(ctx.tenant, {

--- a/packages/api/src/services/publishDocuments.spec.ts
+++ b/packages/api/src/services/publishDocuments.spec.ts
@@ -44,6 +44,8 @@ const getCtx = ({ subresources }: any = {}) => ({
     },
     publishedDataset: {
         insertBatch: 'publishedDataset.insertBatch()',
+        avoidDuplicates: jest.fn().mockImplementation(() => 'avoidDuplicates'),
+        createIndexes: jest.fn().mockImplementation(() => 'createIndexes'),
     },
     hiddenResource: {
         findAll: jest.fn().mockImplementation(() => []),
@@ -218,6 +220,10 @@ describe('publishDocuments', () => {
             ).toEqual({
                 uri: 'transformedUri',
                 subresourceId: null,
+                lastVersion: {
+                    transformed: 'data',
+                    publicationDate: date,
+                },
                 versions: [
                     {
                         transformed: 'data',
@@ -265,6 +271,10 @@ describe('publishDocuments', () => {
                 subresourceId: null,
                 removedAt: date,
                 reason: 'because',
+                lastVersion: {
+                    transformed: 'data',
+                    publicationDate: date,
+                },
                 versions: [
                     {
                         transformed: 'data',

--- a/packages/api/src/services/publishDocuments.ts
+++ b/packages/api/src/services/publishDocuments.ts
@@ -22,16 +22,18 @@ export const versionTransformerDecorator =
         const hiddenResource = hiddenResources?.find(
             (hidden: any) => hidden.uri === doc.uri,
         );
+        const lastVersion = {
+            ...omit(doc, ['uri']),
+            publicationDate,
+        };
 
         return {
             ...hiddenResource,
             uri: doc.uri,
             subresourceId,
+            lastVersion,
             versions: [
-                {
-                    ...omit(doc, ['uri']),
-                    publicationDate,
-                },
+                lastVersion,
             ],
         };
     };
@@ -223,6 +225,7 @@ export const publishDocumentsFactory =
             }),
         );
 
+        await ctx.publishedDataset.avoidDuplicates();
         await transformAllDocuments(
             count,
             ctx.dataset.findLimitFromSkip,
@@ -235,6 +238,7 @@ export const publishDocumentsFactory =
             undefined,
             ctx.job,
         );
+        await ctx.publishedDataset.createIndexes();
 
         ctx.job.isActive()
             ? jobLogger.info(ctx.job, 'Documents published')

--- a/packages/api/src/services/publishDocuments.ts
+++ b/packages/api/src/services/publishDocuments.ts
@@ -32,9 +32,7 @@ export const versionTransformerDecorator =
             uri: doc.uri,
             subresourceId,
             lastVersion,
-            versions: [
-                lastVersion,
-            ],
+            versions: [lastVersion],
         };
     };
 

--- a/packages/api/src/services/saveParsedStream-e2e.spec.ts
+++ b/packages/api/src/services/saveParsedStream-e2e.spec.ts
@@ -140,19 +140,19 @@ describe('e2e upload saveparsedStream', () => {
                     id: 1,
                     name: 'rock',
                     stronger_than: 2,
-                    lodex_published: true,
+                    _lodexPublished: true,
                 },
                 {
                     id: 2,
                     name: 'scissor',
                     stronger_than: 3,
-                    lodex_published: true,
+                    _lodexPublished: true,
                 },
                 {
                     id: 3,
                     name: 'paper',
                     stronger_than: 1,
-                    lodex_published: true,
+                    _lodexPublished: true,
                 },
                 { id: 4, name: 'spock', stronger_than: 1 },
                 { id: 5, name: 'lizard', stronger_than: 3 },
@@ -177,17 +177,17 @@ describe('e2e upload saveparsedStream', () => {
                 {
                     uri: 'uid:/rock',
                     versions: [{ NAME: 'rock', STRONGER: 'uid:/scissor' }],
-                    lodex_published: true,
+                    _lodexPublished: true,
                 },
                 {
                     uri: 'uid:/scissor',
                     versions: [{ NAME: 'scissor', STRONGER: 'uid:/paper' }],
-                    lodex_published: true,
+                    _lodexPublished: true,
                 },
                 {
                     uri: 'uid:/paper',
                     versions: [{ NAME: 'paper', STRONGER: 'uid:/rock' }],
-                    lodex_published: true,
+                    _lodexPublished: true,
                 },
                 {
                     uri: 'uid:/spock',
@@ -255,19 +255,19 @@ describe('e2e upload saveparsedStream', () => {
                     id: 1,
                     name: 'rock',
                     stronger_than: 2,
-                    lodex_published: true,
+                    _lodexPublished: true,
                 },
                 {
                     id: 2,
                     name: 'scissor',
                     stronger_than: 3,
-                    lodex_published: true,
+                    _lodexPublished: true,
                 },
                 {
                     id: 3,
                     name: 'paper',
                     stronger_than: 1,
-                    lodex_published: true,
+                    _lodexPublished: true,
                 },
             ]);
             expect(await ctx.publishedDataset.count()).toBe(3);
@@ -290,17 +290,17 @@ describe('e2e upload saveparsedStream', () => {
                 {
                     uri: 'uid:/rock',
                     versions: [{ NAME: 'rock', STRONGER: 'uid:/scissor' }],
-                    lodex_published: true,
+                    _lodexPublished: true,
                 },
                 {
                     uri: 'uid:/scissor',
                     versions: [{ NAME: 'scissor', STRONGER: 'uid:/paper' }],
-                    lodex_published: true,
+                    _lodexPublished: true,
                 },
                 {
                     uri: 'uid:/paper',
                     versions: [{ NAME: 'paper', STRONGER: 'uid:/rock' }],
-                    lodex_published: true,
+                    _lodexPublished: true,
                 },
             ]);
 

--- a/packages/api/src/services/saveParsedStream.spec.ts
+++ b/packages/api/src/services/saveParsedStream.spec.ts
@@ -91,15 +91,15 @@ describe('saveParsedStream', () => {
             expect(ctx.dataset.deleteOne).not.toHaveBeenCalled();
         });
 
-        it('should have called updateMany on dataset and publishedDataset to set lodex_published to true', () => {
+        it('should have called updateMany on dataset and publishedDataset to set _lodexPublished to true', () => {
             expect(ctx.dataset.updateMany).toHaveBeenCalledWith(
                 {},
-                { $set: { lodex_published: true } },
+                { $set: { _lodexPublished: true } },
                 { multi: true },
             );
             expect(ctx.publishedDataset.updateMany).toHaveBeenCalledWith(
                 {},
-                { $set: { lodex_published: true } },
+                { $set: { _lodexPublished: true } },
                 { multi: true },
             );
         });
@@ -110,7 +110,7 @@ describe('saveParsedStream', () => {
 
         it('should have called dataset.count to count unpublished document', () => {
             expect(ctx.dataset.count).toHaveBeenCalledWith({
-                lodex_published: { $exists: false },
+                _lodexPublished: { $exists: false },
             });
         });
 
@@ -181,15 +181,15 @@ describe('saveParsedStream', () => {
             expect(ctx.publishedDataset.count).toHaveBeenCalled();
         });
 
-        it('should have called updateMany on dataset and publishedDataset to set lodex_published to true', () => {
+        it('should have called updateMany on dataset and publishedDataset to set _lodexPublished to true', () => {
             expect(ctx.dataset.updateMany).toHaveBeenCalledWith(
                 {},
-                { $set: { lodex_published: true } },
+                { $set: { _lodexPublished: true } },
                 { multi: true },
             );
             expect(ctx.publishedDataset.updateMany).toHaveBeenCalledWith(
                 {},
-                { $set: { lodex_published: true } },
+                { $set: { _lodexPublished: true } },
                 { multi: true },
             );
         });
@@ -200,7 +200,7 @@ describe('saveParsedStream', () => {
 
         it('should have called dataset.count to count unpublished document', () => {
             expect(ctx.dataset.count).toHaveBeenCalledWith({
-                lodex_published: { $exists: false },
+                _lodexPublished: { $exists: false },
             });
         });
 
@@ -220,10 +220,10 @@ describe('saveParsedStream', () => {
 
         it('should remove all unpublished document from dataset and publishedDataset', () => {
             expect(ctx.dataset.deleteOne).toHaveBeenCalledWith({
-                lodex_published: { $exists: false },
+                _lodexPublished: { $exists: false },
             });
             expect(ctx.publishedDataset.deleteOne).toHaveBeenCalledWith({
-                lodex_published: { $exists: false },
+                _lodexPublished: { $exists: false },
             });
         });
     });

--- a/packages/api/src/services/saveParsedStream.ts
+++ b/packages/api/src/services/saveParsedStream.ts
@@ -15,13 +15,13 @@ export const saveParsedStream = async (ctx: any, parsedStream: any) => {
     try {
         await ctx.dataset.updateMany(
             {},
-            { $set: { lodex_published: true } },
+            { $set: { _lodexPublished: true } },
             { multi: true },
         );
 
         await ctx.publishedDataset.updateMany(
             {},
-            { $set: { lodex_published: true } },
+            { $set: { _lodexPublished: true } },
             { multi: true },
         );
 
@@ -33,7 +33,7 @@ export const saveParsedStream = async (ctx: any, parsedStream: any) => {
         );
 
         const count = await ctx.dataset.count({
-            lodex_published: { $exists: false },
+            _lodexPublished: { $exists: false },
         });
 
         await ctx.publishDocuments(ctx, count, collectionScopeFields);
@@ -41,9 +41,9 @@ export const saveParsedStream = async (ctx: any, parsedStream: any) => {
 
         return ctx.dataset.count();
     } catch (error) {
-        await ctx.dataset.deleteOne({ lodex_published: { $exists: false } });
+        await ctx.dataset.deleteOne({ _lodexPublished: { $exists: false } });
         await ctx.publishedDataset.deleteOne({
-            lodex_published: { $exists: false },
+            _lodexPublished: { $exists: false },
         });
 
         throw error;

--- a/packages/api/src/services/transformAllDocuments.spec.ts
+++ b/packages/api/src/services/transformAllDocuments.spec.ts
@@ -34,13 +34,22 @@ describe('tranformAllDocuments', () => {
 
     it('should load items from the original dataset and insert them in the publishedDataset by page of 100', () => {
         expect(findLimitFromSkip).toHaveBeenCalledWith(200, 0, {
-            lodex_published: false,
+            $or: [
+                { _lodexPublished: false },
+                { _lodexPublished: { $exists: false } }
+            ]
         });
         expect(findLimitFromSkip).toHaveBeenCalledWith(200, 200, {
-            lodex_published: false,
+            $or: [
+                { _lodexPublished: false },
+                { _lodexPublished: { $exists: false } }
+            ]
         });
         expect(findLimitFromSkip).toHaveBeenCalledWith(200, 400, {
-            lodex_published: false,
+            $or: [
+                { _lodexPublished: false },
+                { _lodexPublished: { $exists: false } }
+            ]
         });
     });
 

--- a/packages/api/src/services/transformAllDocuments.spec.ts
+++ b/packages/api/src/services/transformAllDocuments.spec.ts
@@ -34,13 +34,13 @@ describe('tranformAllDocuments', () => {
 
     it('should load items from the original dataset and insert them in the publishedDataset by page of 100', () => {
         expect(findLimitFromSkip).toHaveBeenCalledWith(200, 0, {
-            lodex_published: { $exists: false },
+            lodex_published: false,
         });
         expect(findLimitFromSkip).toHaveBeenCalledWith(200, 200, {
-            lodex_published: { $exists: false },
+            lodex_published: false,
         });
         expect(findLimitFromSkip).toHaveBeenCalledWith(200, 400, {
-            lodex_published: { $exists: false },
+            lodex_published: false,
         });
     });
 

--- a/packages/api/src/services/transformAllDocuments.spec.ts
+++ b/packages/api/src/services/transformAllDocuments.spec.ts
@@ -36,20 +36,20 @@ describe('tranformAllDocuments', () => {
         expect(findLimitFromSkip).toHaveBeenCalledWith(200, 0, {
             $or: [
                 { _lodexPublished: false },
-                { _lodexPublished: { $exists: false } }
-            ]
+                { _lodexPublished: { $exists: false } },
+            ],
         });
         expect(findLimitFromSkip).toHaveBeenCalledWith(200, 200, {
             $or: [
                 { _lodexPublished: false },
-                { _lodexPublished: { $exists: false } }
-            ]
+                { _lodexPublished: { $exists: false } },
+            ],
         });
         expect(findLimitFromSkip).toHaveBeenCalledWith(200, 400, {
             $or: [
                 { _lodexPublished: false },
-                { _lodexPublished: { $exists: false } }
-            ]
+                { _lodexPublished: { $exists: false } },
+            ],
         });
     });
 

--- a/packages/api/src/services/transformAllDocuments.ts
+++ b/packages/api/src/services/transformAllDocuments.ts
@@ -24,7 +24,7 @@ export default async function transformAllDocument(
 
         const dataset = datasetChunkExtractor(
             await findLimitFromSkip(chunkSize, handled, {
-                lodex_published: { $exists: false },
+                lodex_published: false,
             }),
         );
         // avoid infinite loop

--- a/packages/api/src/services/transformAllDocuments.ts
+++ b/packages/api/src/services/transformAllDocuments.ts
@@ -24,7 +24,10 @@ export default async function transformAllDocument(
 
         const dataset = datasetChunkExtractor(
             await findLimitFromSkip(chunkSize, handled, {
-                lodex_published: false,
+                $or: [
+                    { lodex_published: false },
+                    { lodex_published: { $exists: false } }
+                ]
             }),
         );
         // avoid infinite loop

--- a/packages/api/src/services/transformAllDocuments.ts
+++ b/packages/api/src/services/transformAllDocuments.ts
@@ -25,8 +25,8 @@ export default async function transformAllDocument(
         const dataset = datasetChunkExtractor(
             await findLimitFromSkip(chunkSize, handled, {
                 $or: [
-                    { lodex_published: false },
-                    { lodex_published: { $exists: false } }
+                    { _lodexPublished: false },
+                    { _lodexPublished: { $exists: false } }
                 ]
             }),
         );

--- a/packages/api/src/services/transformAllDocuments.ts
+++ b/packages/api/src/services/transformAllDocuments.ts
@@ -26,8 +26,8 @@ export default async function transformAllDocument(
             await findLimitFromSkip(chunkSize, handled, {
                 $or: [
                     { _lodexPublished: false },
-                    { _lodexPublished: { $exists: false } }
-                ]
+                    { _lodexPublished: { $exists: false } },
+                ],
             }),
         );
         // avoid infinite loop

--- a/packages/ezsLodex/src/aggregateQuery.ts
+++ b/packages/ezsLodex/src/aggregateQuery.ts
@@ -49,7 +49,7 @@ export const createFunction = () =>
             [{ $match: filter }].concat(stages),
             {
                 allowDiskUse: true,
-            }
+            },
         );
         const count = await collection
             .aggregate([{ $match: filter }, { $count: 'value' }])

--- a/packages/ezsLodex/src/aggregateQuery.ts
+++ b/packages/ezsLodex/src/aggregateQuery.ts
@@ -47,6 +47,9 @@ export const createFunction = () =>
         const collection = db.collection(collectionName);
         const cursor = collection.aggregate(
             [{ $match: filter }].concat(stages),
+            {
+                allowDiskUse: true,
+            }
         );
         const count = await collection
             .aggregate([{ $match: filter }, { $count: 'value' }])

--- a/packages/ezsLodex/src/ensureIndex.js
+++ b/packages/ezsLodex/src/ensureIndex.js
@@ -15,7 +15,6 @@ export default async function ensureQuery(data, feed) {
     if (this.isLast()) {
         return feed.close();
     }
-    const { ezs } = this;
     const field = this.getParam('field', data.field || data.$field || 'uri');
     const collectionName = String(
         this.getParam('collection', data.collection || 'publishedDataset'),

--- a/packages/ezsLodex/src/ensureIndex.js
+++ b/packages/ezsLodex/src/ensureIndex.js
@@ -16,10 +16,7 @@ export default async function ensureQuery(data, feed) {
         return feed.close();
     }
     const { ezs } = this;
-    const field = this.getParam(
-        'field',
-        data.field || data.$field || 'uri',
-    );
+    const field = this.getParam('field', data.field || data.$field || 'uri');
     const collectionName = String(
         this.getParam('collection', data.collection || 'publishedDataset'),
     );
@@ -32,19 +29,21 @@ export default async function ensureQuery(data, feed) {
     const db = await mongoDatabase(connectionStringURI);
     const collection = db.collection(collectionName);
 
-
     const indexes = await collection.indexes();
 
-    await Promise.all(fields.map(fieldName => {
-        const isIndexExists = indexes.some(index =>
-            Object.keys(index.key).some(key =>
-                key === fieldName || key.startsWith(fieldName + ".")
-            )
-        );
-        if (!isIndexExists) {
-            return collection.createIndex({ [fieldName]: 1 });
-        }
-        return Promise.resolve(true);
-    }));
+    await Promise.all(
+        fields.map((fieldName) => {
+            const isIndexExists = indexes.some((index) =>
+                Object.keys(index.key).some(
+                    (key) =>
+                        key === fieldName || key.startsWith(fieldName + '.'),
+                ),
+            );
+            if (!isIndexExists) {
+                return collection.createIndex({ [fieldName]: 1 });
+            }
+            return Promise.resolve(true);
+        }),
+    );
     feed.send(data);
-};
+}

--- a/packages/ezsLodex/src/ensureIndex.js
+++ b/packages/ezsLodex/src/ensureIndex.js
@@ -1,0 +1,50 @@
+import mongoDatabase from './mongoDatabase.js';
+
+/**
+ * Take `Object` containing a MongoDB query and throw the result
+ *
+ * The input object must contain a `connectionStringURI` property, containing
+ * the connection string to MongoDB.
+ *
+ * @name LodexRunQuery
+ * @param {String}  [collection="publishedDataset"]  collection to use
+ * @param {Object}  [field="uri"]  limit the result to some fields
+ * @returns {Object}
+ */
+export default async function ensureQuery(data, feed) {
+    if (this.isLast()) {
+        return feed.close();
+    }
+    const { ezs } = this;
+    const field = this.getParam(
+        'field',
+        data.field || data.$field || 'uri',
+    );
+    const collectionName = String(
+        this.getParam('collection', data.collection || 'publishedDataset'),
+    );
+    const fds = Array.isArray(field) ? field : [field];
+    const fields = fds.filter(Boolean);
+    const connectionStringURI = this.getParam(
+        'connectionStringURI',
+        data.connectionStringURI || this.getEnv('connectionStringURI'),
+    );
+    const db = await mongoDatabase(connectionStringURI);
+    const collection = db.collection(collectionName);
+
+
+    const indexes = await collection.indexes();
+
+    await Promise.all(fields.map(fieldName => {
+        const isIndexExists = indexes.some(index =>
+            Object.keys(index.key).some(key =>
+                key === fieldName || key.startsWith(fieldName + ".")
+            )
+        );
+        if (!isIndexExists) {
+            return collection.createIndex({ [fieldName]: 1 });
+        }
+        return Promise.resolve(true);
+    }));
+    feed.send(data);
+};

--- a/packages/ezsLodex/src/index.ts
+++ b/packages/ezsLodex/src/index.ts
@@ -22,6 +22,7 @@ import linkDataset from './linkDataset.js';
 import LodexJoinQuery from './joinQuery.js';
 import objects2columns from './objects2columns.js';
 import precomputedSelect from './precomputedSelect.js';
+import ensureIndex from './ensureIndex.js';
 import reduceQuery from './reduceQuery.js';
 import runQuery from './runQuery.js';
 import runQueryPrecomputed from './runQueryPrecomputed.js';
@@ -49,6 +50,7 @@ const funcs = {
     injectSyndicationFrom,
     injectCountFrom,
     labelizeFieldID,
+    ensureIndex,
     runQuery,
     runQueryPrecomputed,
     reduceQuery,
@@ -70,6 +72,7 @@ const funcs = {
     LodexGetFields: getFields.getFields,
     LodexGetCharacteristics: getCharacteristics.getCharacteristics,
     LodexDocuments: runQuery.runQuery,
+    LodexEnsureIndex: ensureIndex,
     LodexRunQuery: runQuery.runQuery,
     LodexRunQueryPrecomputed: runQueryPrecomputed.runQueryPrecomputed,
     LodexReduceQuery: reduceQuery.reduceQuery,

--- a/packages/workers/src/routines/distinct-by.ini
+++ b/packages/workers/src/routines/distinct-by.ini
@@ -11,8 +11,19 @@ plugin = lodex
 [buildContext]
 connectionStringURI = get('connectionStringURI')
 
-[LodexReduceQuery]
-reducer = distinct
+[env]
+; On garde dans l'environnement quelques paramètres
+path = field
+value = get('field').castArray()
+
+[singleton]
+merge = false
+[singleton/LodexEnsureIndex]
+field = fix(`lastVersion.${env('field.0')}`)
+
+[LodexAggregateQuery]
+stage = fix(`$unwind: "$lastVersion.${env('field.0')}"`)
+stage = fix(`$group: {_id: "$lastVersion.${env('field.0')}", value: { $sum: 1 } }`)
 
 [LodexOutput]
 indent = true


### PR DESCRIPTION
Série d'optimisations pour un meilleur usage de MongoDB, notamment pour les jeux de données de plusieurs gigaoctets avec plus de 100 000 documents.

* Lenteur dans la publication : plus on publie / dépublie, plus cela prend du temps. Maintenant, on supprime les index lors de la dépublication et on les recrée après chaque publication, mais après avoir inséré tous les documents. On ajoute un index sur le jeu de données, dédié au champ lodex_published, et on évite d’utiliser $unset, moins rapide qu’un $set sur un booléen (true, false).

* Le volume des index est très important pour le jeu de données, alors qu’ils ne sont pas utilisés. La recherche par diacritique se fait par regex, donc sans utiliser l’index créé automatiquement sur les champs. De plus, l’index automatique sur chaque champ concerne uniquement les 64 premiers champs, car ensuite on atteint la limite de la base. L’index est donc remplacé par un index unique de type **wildcard** ; celui‑ci ne sera toujours pas utilisé pour la recherche par diacritique. Du coup, on autorise l’usage de l’opérateur equals, qui, lui, utilisera l’index.

* Requête pour « distinct‑by » qui plante ou qui consomme trop de mémoire : pour ce type de requête, il est possible d’utiliser la fonction **aggregate**, qui est plus optimisée que *map/reduce*, même si elle n’utilise pas de manière optimale les index, car pour les valeurs contenues dans des tableaux multiples, on est obligé d’utiliser `$unwind`. En revanche, on ajoute un index sur les champs techniques et on ajoute dynamiquement un index sur le champ concerné [ensureIndex].

* Lenteurs liées à l’usage du tableau de versions.\
  Historiquement, LODEX conservait chaque version ; ce n’est plus le cas, mais la structure de la base n’a pas changé. On doit toujours utiliser le tableau de versions. Pour optimiser les index et les requêtes, la dernière version (et la seule) est stockée dans le champ **lastVersion**.
