### PR TITLE
feat: allow chart, Vega and Vega-Lite formats to use resource data only

### DIFF
--- a/packages/frontend-common/formats/chart/advancedNetwork/AdvancedNetworkView.tsx
+++ b/packages/frontend-common/formats/chart/advancedNetwork/AdvancedNetworkView.tsx
@@ -57,6 +57,6 @@ const AdvancedNetwork = ({ formatData, colorSet, field }: NetworkProps) => {
     );
 };
 
-export default compose<NetworkProps, NetworkProps>(injectData())(
-    AdvancedNetwork,
-);
+export default compose<NetworkProps, NetworkProps>(
+    injectData(null, null, true),
+)(AdvancedNetwork);

--- a/packages/frontend-common/formats/chart/bubbleChart/BubbleView.tsx
+++ b/packages/frontend-common/formats/chart/bubbleChart/BubbleView.tsx
@@ -120,7 +120,7 @@ export default compose<
     BubbleViewProps,
     Omit<BubbleViewProps, 'data' | 'diameter'>
 >(
-    injectData(),
+    injectData(null, null, true),
     connect(mapStateToProps),
 )(BubbleView);
 

--- a/packages/frontend-common/formats/chart/clustered-chart/ClusteredChartView.tsx
+++ b/packages/frontend-common/formats/chart/clustered-chart/ClusteredChartView.tsx
@@ -100,7 +100,7 @@ const mapStateToProps = (state, { formatData }) => {
 };
 
 export default compose(
-    injectData(),
+    injectData(null, null, true),
     connect(mapStateToProps),
     // @ts-expect-error TS2345
 )(ClusteredChartView);

--- a/packages/frontend-common/formats/chart/directed3DNetwork/Directed3DNetworkView.tsx
+++ b/packages/frontend-common/formats/chart/directed3DNetwork/Directed3DNetworkView.tsx
@@ -58,5 +58,5 @@ const Directed3DNetwork = ({
 };
 
 export default compose<Directed3DNetworkProps, Directed3DNetworkProps>(
-    injectData(),
+    injectData(null, null, true),
 )(Directed3DNetwork);

--- a/packages/frontend-common/formats/chart/directedNetwork/DirectedNetworkView.tsx
+++ b/packages/frontend-common/formats/chart/directedNetwork/DirectedNetworkView.tsx
@@ -62,5 +62,5 @@ const DirectedNetwork = ({
 };
 
 export default compose<DirectedNetworkProps, DirectedNetworkProps>(
-    injectData(),
+    injectData(null, null, true),
 )(DirectedNetwork);

--- a/packages/frontend-common/formats/chart/leaflet/LeafletView.tsx
+++ b/packages/frontend-common/formats/chart/leaflet/LeafletView.tsx
@@ -174,4 +174,4 @@ const LeafletView = ({
 };
 
 // @ts-expect-error TS2345
-export default compose(injectData())(LeafletView);
+export default compose(injectData(null, null, true))(LeafletView);

--- a/packages/frontend-common/formats/chart/network3D/Network3DView.tsx
+++ b/packages/frontend-common/formats/chart/network3D/Network3DView.tsx
@@ -78,4 +78,4 @@ const Network3D = ({ formatData, colorSet, field }: NetworkProps) => {
 };
 
 // @ts-expect-error TS2345
-export default compose(injectData())(Network3D);
+export default compose(injectData(null, null, true))(Network3D);

--- a/packages/frontend-common/formats/chart/streamgraph/Streamgraph.tsx
+++ b/packages/frontend-common/formats/chart/streamgraph/Streamgraph.tsx
@@ -855,4 +855,4 @@ class Streamgraph extends PureComponent<StreamgraphProps> {
     }
 }
 
-export default compose(injectData())(Streamgraph);
+export default compose(injectData(null, null, true))(Streamgraph);

--- a/packages/frontend-common/formats/chart/venn/VennView.tsx
+++ b/packages/frontend-common/formats/chart/venn/VennView.tsx
@@ -78,4 +78,4 @@ const Venn = ({ formatData, colorSet }: VennProps) => {
 };
 
 // @ts-expect-error TS2345
-export default compose(injectData())(Venn);
+export default compose(injectData(null, null, true))(Venn);

--- a/packages/frontend-common/formats/vega-lite/component/bar-chart/BarChartView.tsx
+++ b/packages/frontend-common/formats/vega-lite/component/bar-chart/BarChartView.tsx
@@ -203,5 +203,8 @@ export const BarChartAdminView = connect((_state, props) => {
     // @ts-expect-error TS2345
 })(BarChartView);
 
-// @ts-expect-error TS2345
-export default compose(injectData(), connect(mapStateToProps))(BarChartView);
+export default compose(
+    injectData(null, null, true),
+    connect(mapStateToProps),
+    // @ts-expect-error TS2345
+)(BarChartView);

--- a/packages/frontend-common/formats/vega-lite/component/bubble-plot/BubblePlotView.tsx
+++ b/packages/frontend-common/formats/vega-lite/component/bubble-plot/BubblePlotView.tsx
@@ -207,5 +207,8 @@ export const BubblePlotAdminView = connect((_state, props) => {
     // @ts-expect-error TS2345
 })(BubblePlotView);
 
-// @ts-expect-error TS2345
-export default compose(injectData(), connect(mapStateToProps))(BubblePlotView);
+export default compose(
+    injectData(null, null, true),
+    connect(mapStateToProps),
+    // @ts-expect-error TS2345
+)(BubblePlotView);

--- a/packages/frontend-common/formats/vega-lite/component/cartography/CartographyView.tsx
+++ b/packages/frontend-common/formats/vega-lite/component/cartography/CartographyView.tsx
@@ -156,5 +156,8 @@ export const CartographyAdminView = connect((_state, props) => {
     // @ts-expect-error TS2345
 })(CartographyView);
 
-// @ts-expect-error TS2345
-export default compose(injectData(), connect(mapStateToProps))(CartographyView);
+export default compose(
+    injectData(null, null, true),
+    connect(mapStateToProps),
+    // @ts-expect-error TS2345
+)(CartographyView);

--- a/packages/frontend-common/formats/vega-lite/component/heatmap/HeatMapView.tsx
+++ b/packages/frontend-common/formats/vega-lite/component/heatmap/HeatMapView.tsx
@@ -208,6 +208,6 @@ export const HeatMapAdminView = connect((_state, props) => {
 })(HeatMapView);
 
 export default compose<HeatMapViewProps, HeatMapViewProps>(
-    injectData(),
+    injectData(null, null, true),
     connect(mapStateToProps),
 )(HeatMapView);

--- a/packages/frontend-common/formats/vega-lite/component/pie-chart/PieChartView.tsx
+++ b/packages/frontend-common/formats/vega-lite/component/pie-chart/PieChartView.tsx
@@ -164,5 +164,8 @@ export const PieChartAdminView = connect((_state, props) => {
     // @ts-expect-error TS2345
 })(PieChartView);
 
-// @ts-expect-error TS2345
-export default compose(injectData(), connect(mapStateToProps))(PieChartView);
+export default compose(
+    injectData(null, null, true),
+    connect(mapStateToProps),
+    // @ts-expect-error TS2345
+)(PieChartView);

--- a/packages/frontend-common/formats/vega/component/flow-map/FlowMapView.tsx
+++ b/packages/frontend-common/formats/vega/component/flow-map/FlowMapView.tsx
@@ -143,5 +143,8 @@ export const FlowMapAdminView = connect((_state, props) => {
     };
 })(FlowMapView);
 
-// @ts-expect-error TS2345
-export default compose(injectData(), connect(mapStateToProps))(FlowMapView);
+export default compose(
+    injectData(null, null, true),
+    connect(mapStateToProps),
+    // @ts-expect-error TS2345
+)(FlowMapView);

--- a/packages/frontend-common/formats/vega/component/radar-chart/RadarChartView.tsx
+++ b/packages/frontend-common/formats/vega/component/radar-chart/RadarChartView.tsx
@@ -162,5 +162,8 @@ export const RadarChartAdminView = connect((_state, props) => {
     // @ts-expect-error TS2345
 })(RadarChartView);
 
-// @ts-expect-error TS2345
-export default compose(injectData(), connect(mapStateToProps))(RadarChartView);
+export default compose(
+    injectData(null, null, true),
+    connect(mapStateToProps),
+    // @ts-expect-error TS2345
+)(RadarChartView);

--- a/packages/frontend-common/formats/vega/component/tree-map/TreeMapView.tsx
+++ b/packages/frontend-common/formats/vega/component/tree-map/TreeMapView.tsx
@@ -180,5 +180,8 @@ export const TreeMapAdminView = connect((_state, props) => {
     // @ts-expect-error TS2345
 })(TreeMapView);
 
-// @ts-expect-error TS2345
-export default compose(injectData(), connect(mapStateToProps))(TreeMapView);
+export default compose(
+    injectData(null, null, true),
+    connect(mapStateToProps),
+    // @ts-expect-error TS2345
+)(TreeMapView);


### PR DESCRIPTION
Reverts Inist-CNRS/lodex#3564