### PR TITLE
fix: prevent 0 values from being converted to 1 in aggregation

### DIFF
--- a/packages/workers/src/routines/group-and-sum-with.ini
+++ b/packages/workers/src/routines/group-and-sum-with.ini
@@ -55,7 +55,8 @@ path = id
 value = get(self.field1Name)
 
 path = value
-value = fix(_.get(self,self.field2Name), '').filter(Boolean).map(Number).shift()
+value = fix(_.get(self,self.field2Name), '').map(Number).shift()
+
 ; on regroupe par champ identique
 [aggregate]
 


### PR DESCRIPTION
l'instruction ezs aggregate mettait par défaut 1 s'il n'y a pas de valeur.

Or juste avant aggregate on a filter(boolean) qui enlève donc les 0. Or si on les supprime, ils sont trnasformé en 1 ensuite...

On enlève donc filter pour que les 0 soient bien additionnés

closes #3506 