### PR TITLE
fix routine catalog sorting

### DIFF
--- a/packages/admin-app/src/fields/wizard/RoutineCatalogAutocomplete.tsx
+++ b/packages/admin-app/src/fields/wizard/RoutineCatalogAutocomplete.tsx
@@ -151,7 +151,9 @@ const RoutineCatalog = ({
             ignorePunctuation: true,
         });
         // @ts-expect-error TS2345
-        return formatedRoutineCatalog.sort(sorter.compare);
+        return formatedRoutineCatalog.sort((a, b) =>
+            sorter.compare(a.title, b.title),
+        );
     }, [precomputed]);
 
     useEffect(() => {

--- a/packages/admin-app/src/fields/wizard/RoutineCatalogAutocomplete.tsx
+++ b/packages/admin-app/src/fields/wizard/RoutineCatalogAutocomplete.tsx
@@ -150,7 +150,7 @@ const RoutineCatalog = ({
             numeric: true,
             ignorePunctuation: true,
         });
-        // @ts-expect-error TS2345
+
         return formatedRoutineCatalog.sort((a, b) =>
             sorter.compare(a.title, b.title),
         );


### PR DESCRIPTION
le tri se faisait sur les objets json du catalogue des routines, désormais on le fait sur le titre de la routine.
Aupravant "join" figurait entre "cross-by" et "decompose-by" par exemple