### PR TITLE
feat(loader): add Web of Science TXT loader

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -137,6 +137,7 @@ module.exports = {
             'tsv',
             'tsv-double-quotes',
             'tsv-wos',
+            'txt-wos'
             'rdf',
             'skos',
             'json',

--- a/config/default.js
+++ b/config/default.js
@@ -137,7 +137,7 @@ module.exports = {
             'tsv',
             'tsv-double-quotes',
             'tsv-wos',
-            'txt-wos'
+            'txt-wos',
             'rdf',
             'skos',
             'json',

--- a/packages/workers/src/README.md
+++ b/packages/workers/src/README.md
@@ -33,6 +33,6 @@ On peut créer ou modifier des **workers** existants en suivant la structure exi
 Pour créer un `worker` il convient de :
 - Déposer le fichier `ini` dans le dossier adéquat.
 - Déclarer le nouveau `worker` dans le fichier (`translations`)[https://github.com/Inist-CNRS/lodex/blob/master/src/app/custom/translations.tsv] avec son nom, sa description en anglais et en français.
-- Déclarer le nouveau `worker` dans le fichier de configuration.
+- Déclarer le nouveau `worker` dans le fichier de configuration (config/default.js)[https://github.com/Inist-CNRS/lodex/blob/master/config/default.js] afin qu'il soit disponible dans l'interface d'administration..
 
 ! D'autres modifications peuvent êtres nécessaires, notament pour les `exporters`.

--- a/packages/workers/src/loaders/txt-wos.ini
+++ b/packages/workers/src/loaders/txt-wos.ini
@@ -1,0 +1,73 @@
+append = pack
+label = wos-txt
+
+# load some plugins to activate some statements
+[use]
+plugin = basics
+
+[TXTParse]
+separator = fix("\n")
+
+[group]
+size = 10000000
+
+[exchange]
+value = self() \
+  .join("\n") \
+  .split(/\nER\s*\n?/) \
+  .map(notice => notice.trim()) \
+  .filter(Boolean) \
+  .map(notice => notice.split("\n") \
+    .reduce((obj, line) => { \
+      if (/^[A-Z0-9]{2} /.test(line)) { \
+        obj._key = line.slice(0, 2); \
+        obj._isArray = /^(AU|AF|C1|C3|CR|WC|SC|EM|RI|OI|FU)$/.test(obj._key); \
+        obj[obj._key] = obj._isArray \
+          ? _.castArray(obj[obj._key] || []).concat(line.slice(3).trim()) \
+          : line.slice(3).trim(); \
+      } else if (obj._key && /^(AU|AF|C1|C3|CR|WC|SC|EM|RI|OI|FU)$/.test(obj._key)) { \
+        obj[obj._key] = _.castArray(obj[obj._key]).concat(line.trim()); \
+      } else if (obj._key) { \
+        obj[obj._key] += " " + line.trim(); \
+      } \
+      return obj; \
+    }, {}) \
+  )
+
+[ungroup]
+
+[exchange]
+value = self().omit(["_key", "_isArray"])
+
+# Ensures that each object contains an identification key (required by lodex)
+[swing]
+test = pick(['URI', 'uri']).pickBy(_.identity).isEmpty()
+[swing/identify]
+
+# Ignore objects with duplicate URI
+[dedupe]
+ignore = true
+
+# Uncomment to see each data sent to the database
+#[debug]
+
+# Add contextual metadata related to the import
+[assign]
+path = lodexStamp.importedDate
+value = fix(new Date()).thru(d => d.toDateString())
+path = lodexStamp.usedParser
+value = env('parser')
+path = lodexStamp.uploadedFilename
+value = env('source')
+path = importDateTime
+value = fix(new Date()).thru(d => \
+  new Intl.DateTimeFormat("fr-FR", { \
+    timeZone: "Europe/Paris", \
+    year: "numeric", \
+    month: "long", \
+    day: "numeric", \
+    hour: "2-digit", \
+    minute: "2-digit", \
+    second: "2-digit" \
+  }).format(d) \
+)

--- a/src/app/custom/translations.tsv
+++ b/src/app/custom/translations.tsv
@@ -567,6 +567,8 @@
 "query-openalex-comment"	"Direct loading of query results for the OpenAlex database."	"Chargement direct des résultats d'une requête d'interrogation pour la base OpenAlex."
 "query-openalex-for-model"	"TXT - OpenAlex query for Lodex model"	"TXT - requête OpenAlex pour modèle Lodex"
 "query-openalex-for-model-comment"	"Direct loading of query results from OpenAlex database for Lodex model."	"Chargement des résultats d'une requête OpenAlex permettant de récupérer les données utilisées dans le modèle Lodex associé."
+"txt-wos"	"TXT - from Web of Science"	"TXT - du Web of Science"
+"txt-wos-comment"	"Imports records exported from Web of Science in plain text (.txt) format."	"Importe des notices bibliographiques exportées depuis Web of Science au format texte brut (.txt)."
 "automatic-loader"	"AUTO - with filename extension"	"AUTO - avec l'extension du nom de fichier"
 "custom-loader"	"CUSTOM - modified loader"	"CUSTOM - Loader customisé"
 "add-custom-loader"	"Customize loader"	"Customiser le loader"


### PR DESCRIPTION
Ajout d'un loader pour les exports plain text (txt) du WoS qui transforme automatiquement en tableaux tous les champs multivalués