### PR TITLE
Improve bubble chart label readability

### DIFF
--- a/packages/frontend-common/formats/chart/bubbleChart/Bubble.tsx
+++ b/packages/frontend-common/formats/chart/bubbleChart/Bubble.tsx
@@ -49,13 +49,13 @@ const styles = {
     })),
 
     leafLabel: memoize(
-    ({
-        r,
-        lineClamp,
-    }: {
-        r: number;
-        lineClamp: number;
-    }): CSSProperties => ({
+        ({
+            r,
+            lineClamp,
+        }: {
+            r: number;
+            lineClamp: number;
+        }): CSSProperties => ({
             width: '88%',
             maxWidth: '88%',
             maxHeight: '78%',
@@ -110,14 +110,7 @@ const Bubble = ({
 }: BubbleProps) => {
     const showLabel = r >= 14;
 
-    const lineClamp =
-        r < 22
-            ? 2
-            : r < 38
-              ? 3
-              : r < 65
-                ? 4
-                : 5;
+    const lineClamp = r < 22 ? 2 : r < 38 ? 3 : r < 65 ? 4 : 5;
 
     return (
         <Box

--- a/packages/frontend-common/formats/chart/bubbleChart/Bubble.tsx
+++ b/packages/frontend-common/formats/chart/bubbleChart/Bubble.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import memoize from 'lodash/memoize';
 // @ts-expect-error TS7016
 import { hsl } from 'd3-color';
@@ -11,37 +12,79 @@ const styles = {
         left: y - r,
         width: r * 2,
         height: r * 2,
+        boxSizing: 'border-box',
+
         backgroundColor: color,
         color: hsl(color).l > 0.57 ? '#222' : '#fff',
+
         alignItems: 'center',
         borderRadius: '100%',
         display: 'flex',
         justifyContent: 'center',
+        overflow: 'hidden',
+
+        /*
+         * La place de la bordure est réservée en permanence.
+         * Le texte ne change donc plus de position au survol.
+         */
+        borderWidth: '1px',
+        borderStyle: 'solid',
+        borderColor: 'transparent',
+
         ...(isSelected
             ? {
                   backgroundColor: hsl(color).darker(0.5).toString(),
-                  borderSize: '1px',
-                  borderStyle: 'solid',
                   borderColor: '#000',
               }
             : {}),
+
         ...(interactive && {
             cursor: 'pointer',
+
             '&:hover': {
                 backgroundColor: hsl(color).darker(0.5).toString(),
-                borderSize: '1px',
-                borderStyle: 'solid',
                 borderColor: '#000',
             },
         }),
     })),
-    leafLabel: memoize(({ r }) => ({
-        overflow: 'hidden',
-        padding: '10px',
-        textOverflow: 'ellipsis',
-        textAlign: 'center',
-        fontSize: r / 3,
-    })),
+
+    leafLabel: memoize(
+    ({
+        r,
+        lineClamp,
+    }: {
+        r: number;
+        lineClamp: number;
+    }): CSSProperties => ({
+            width: '88%',
+            maxWidth: '88%',
+            maxHeight: '78%',
+            boxSizing: 'border-box',
+
+            padding: r < 22 ? '1px' : '2px',
+
+            textAlign: 'center',
+            fontSize: Math.max(7, Math.min(15, r / 3)),
+            lineHeight: 1.05,
+            fontWeight: 500,
+
+            /*
+             * Les retours à la ligne se font uniquement
+             * entre les mots.
+             */
+            whiteSpace: 'normal',
+            wordBreak: 'normal',
+            overflowWrap: 'normal',
+            hyphens: 'none',
+
+            display: '-webkit-box',
+            WebkitBoxOrient: 'vertical',
+            WebkitLineClamp: lineClamp,
+
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+        }),
+    ),
 };
 
 interface BubbleProps {
@@ -65,6 +108,17 @@ const Bubble = ({
     onClick,
     isSelected,
 }: BubbleProps) => {
+    const showLabel = r >= 14;
+
+    const lineClamp =
+        r < 22
+            ? 2
+            : r < 38
+              ? 3
+              : r < 65
+                ? 4
+                : 5;
+
     return (
         <Box
             sx={styles.leaf({
@@ -80,10 +134,17 @@ const Bubble = ({
             data-iscapture="true"
             onClick={() => onClick?.(name)}
         >
-            {r > 10 && (
-                // @ts-expect-error TS7006
-                <div style={styles.leafLabel({ r, x, y }, color)}>{name}</div>
+            {showLabel && (
+                <div
+                    style={styles.leafLabel({
+                        r,
+                        lineClamp,
+                    })}
+                >
+                    {name}
+                </div>
             )}
+
             <ReactTooltip
                 id={`bubble-${name}`}
                 place="top"


### PR DESCRIPTION
prise en charge des libellés trop longs
<img width="511" height="483" alt="image" src="https://github.com/user-attachments/assets/003b6a65-1593-49fa-bac3-b65ac032ad19" />
<img width="534" height="504" alt="image" src="https://github.com/user-attachments/assets/dc149a7e-1c5a-4be0-8eb7-0c7a5eeaf265" />
