### PR TITLE
Improve Web of Science TXT loader

### DIFF
--- a/packages/workers/src/loaders/txt-wos.ini
+++ b/packages/workers/src/loaders/txt-wos.ini
@@ -37,7 +37,18 @@ value = self() \
 [ungroup]
 
 [exchange]
-value = self().omit(["_key", "_isArray"])
+value = self() \
+  .omit(["_key", "_isArray", "FN", "VR"]) \
+  .mapValues((value, key) => \
+    ["DE", "ID", "RP", "C3"].includes(key) \
+      ? _.chain(value) \
+          .castArray() \
+          .flatMap(item => _.isString(item) ? item.split(";") : item) \
+          .map(_.trim) \
+          .compact() \
+          .value() \
+      : value \
+  )
 
 # Ensures that each object contains an identification key (required by lodex)
 [swing]


### PR DESCRIPTION
Suppression de 2 clés qui contiennent des métadonnées globales du fichier, et split sur 4 colonnes qui sont des chaînes mais multivaluées